### PR TITLE
fix: switch production deployment from static site to Bun server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.worktrees
+.git
+*.md
+docs
+playwright
+tests
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1-alpine
+WORKDIR /app
+
+# Install dependencies
+COPY package.json bun.lock bun.lockb* ./
+RUN bun install --frozen-lockfile
+
+# Copy source and build frontend
+COPY . .
+RUN bun run build
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["bun", "server/index.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 services:
   app:
-    image: node:24-alpine
+    build: .
     container_name: on-the-beach-app
     restart: unless-stopped
-    working_dir: /app
     ports:
       - "3000:3000"
     environment:
       DATABASE_PATH: /app/data/on_the_beach.db
       NODE_ENV: production
     volumes:
-      - .:/app
-      - /app/node_modules
-    command: ["node", "dist-server/index.js"]
+      - app-data:/app/data
+
+volumes:
+  app-data:

--- a/docs/deployment/coolify-alpha.md
+++ b/docs/deployment/coolify-alpha.md
@@ -24,12 +24,24 @@ dig enlaplaya.example.com +short
 Create a new Coolify application from `richpjames/on-the-beach`:
 
 - `Branch`: `main`
-- `Build Pack`: `Nixpacks`
-- `Static Site`: enabled
+- `Build Pack`: `Dockerfile`
 - `Base Directory`: `/`
-- `Publish Directory`: `/dist`
+- `Port`: `3000`
 - `Domain`: `https://enlaplaya.example.com`
 - `Force HTTPS`: enabled
+
+> **Important**: Do NOT use Static Site mode. The app requires a running backend server
+> (Hono + SQLite) to handle `/api/*` routes. The Dockerfile builds the frontend and
+> starts the Bun server in a single container.
+
+Add an environment variable in Coolify:
+
+- `DATABASE_PATH`: `/app/data/on_the_beach.db`
+
+Add a persistent volume in Coolify:
+
+- Source: a named volume (e.g. `on-the-beach-data`)
+- Destination: `/app/data`
 
 Run one manual deploy to confirm baseline.
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import * as schema from "./schema";
 
 const dbPath = process.env.DATABASE_PATH ?? "on_the_beach.db";
@@ -7,3 +8,6 @@ const sqlite = new Database(dbPath);
 sqlite.exec("PRAGMA journal_mode = WAL");
 sqlite.exec("PRAGMA foreign_keys = ON");
 export const db = drizzle(sqlite, { schema });
+
+// Apply any pending migrations on startup (idempotent)
+migrate(db, { migrationsFolder: `${import.meta.dir}/../../drizzle` });


### PR DESCRIPTION
## Summary

- Production was deployed as a Coolify static site (nginx only) — all `/api/*` routes returned 404 from nginx because no backend server was running
- Adds a `Dockerfile` using `oven/bun:1-alpine` that builds the Vite frontend and runs the Hono backend in a single container
- Fixes `docker-compose.yml` to use the Dockerfile, dropping the broken `node:24-alpine` + non-existent `dist-server/index.js` approach (server requires Bun-only APIs: `bun:sqlite`, `Bun.serve()`)
- Adds auto-migration in `server/db/index.ts` so the SQLite schema initialises on first boot without needing `drizzle-kit` at runtime
- Updates deployment docs: switch Coolify from **Static Site** to **Dockerfile** build pack, expose port 3000, add a persistent volume at `/app/data`

## Test Plan

- [ ] Merge and trigger a Coolify deploy
- [ ] In Coolify, change Build Pack to **Dockerfile**, set Port to **3000**, add env var `DATABASE_PATH=/app/data/on_the_beach.db`, add persistent volume at `/app/data`
- [ ] Confirm `/api/music-items` returns `200` (not nginx 404)
- [ ] Add a Bandcamp URL in the UI and confirm it saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)