### PR TITLE
Refactor App state handling and display separation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,29 +1,33 @@
 import { ApiClient } from "./services/api-client";
-import type {
-  MusicItemFull,
-  ListenStatus,
-  ItemType,
-  StackWithCount,
-  MusicItemFilters,
-} from "./types";
-
-const STATUS_LABELS: Record<Exclude<ListenStatus, "listening">, string> = {
-  "to-listen": "To Listen",
-  listened: "Listened",
-  "to-revisit": "Revisit",
-  done: "Done",
-};
+import type { ListenStatus } from "./types";
+import {
+  buildCreateMusicItemInputFromValues,
+  getCoverScanErrorMessage,
+  hasAnyNonEmptyField,
+} from "./ui/domain/add-form";
+import type { AddFormValues } from "./ui/domain/add-form";
+import { buildMusicItemFilters } from "./ui/domain/music-list";
+import { constrainDimensions } from "./ui/domain/scan";
+import { initialAddFormState, transitionAddFormState } from "./ui/state/add-form-machine";
+import { initialAppState, transitionAppState } from "./ui/state/app-machine";
+import {
+  initialRatingState,
+  resolveRatingClick,
+  transitionRatingState,
+} from "./ui/state/rating-machine";
+import {
+  renderAddFormStackChips,
+  renderMusicList,
+  renderStackDropdownContent,
+  renderStackManageList,
+  renderStackRenameEditor,
+} from "./ui/view/templates";
 
 export class App {
   private api: ApiClient;
-  private currentFilter: ListenStatus | "all" = "to-listen";
-  private currentStack: number | null = null;
-  private stacks: StackWithCount[] = [];
-  private isReady = false;
-  private addFormInitialized = false;
-  private addFormSelectedStacks: number[] = [];
-  private scanInProgress = false;
-  private ratingClearCandidate: { id: number; value: number } | null = null;
+  private appState = initialAppState;
+  private addFormState = initialAddFormState;
+  private ratingState = initialRatingState;
 
   constructor() {
     this.api = new ApiClient();
@@ -31,10 +35,13 @@ export class App {
 
   async initialize(): Promise<void> {
     this.setupAddForm();
-    this.isReady = true;
+    this.appState = transitionAppState(this.appState, { type: "APP_READY" });
     this.initializeUI();
+
     const versionEl = document.getElementById("app-version");
-    if (versionEl) versionEl.textContent = `v${__APP_VERSION__}`;
+    if (versionEl) {
+      versionEl.textContent = `v${__APP_VERSION__}`;
+    }
   }
 
   private initializeUI(): void {
@@ -42,122 +49,106 @@ export class App {
     this.setupStackBar();
     this.setupStackManagePanel();
     this.setupEventDelegation();
-    this.renderStackBar();
-    this.renderMusicList();
+    void this.renderStackBar();
+    void this.renderMusicList();
   }
 
   private setupAddForm(): void {
-    if (this.addFormInitialized) return;
+    if (this.addFormState.initialized) {
+      return;
+    }
 
-    const form = document.getElementById("add-form") as HTMLFormElement;
-    const detailsEl = form.querySelector(".add-form__details") as HTMLDetailsElement | null;
-    const titleInput = form.querySelector('input[name="title"]') as HTMLInputElement | null;
-    const artistInput = form.querySelector('input[name="artist"]') as HTMLInputElement | null;
-    const artworkInput = form.querySelector('input[name="artworkUrl"]') as HTMLInputElement | null;
-    const scanButton = document.getElementById("add-form-scan-btn") as HTMLButtonElement | null;
-    const scanInput = document.getElementById("scan-file-input") as HTMLInputElement | null;
-    const submitButton = document.getElementById("add-form-submit") as HTMLButtonElement;
-    this.addFormInitialized = true;
+    const form = document.getElementById("add-form");
+    const submitButton = document.getElementById("add-form-submit");
+    if (!(form instanceof HTMLFormElement) || !(submitButton instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    this.addFormState = transitionAddFormState(this.addFormState, { type: "INITIALIZED" });
+
+    const detailsEl = form.querySelector(".add-form__details");
+    const titleInput = form.querySelector('input[name="title"]');
+    const artistInput = form.querySelector('input[name="artist"]');
+    const artworkInput = form.querySelector('input[name="artworkUrl"]');
+    const scanButton = document.getElementById("add-form-scan-btn");
+    const scanInput = document.getElementById("scan-file-input");
 
     const updateSubmitState = (): void => {
       const fieldsToCheck = form.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
         'input[name="url"], input[name="title"], input[name="artist"], input[name="label"], input[name="year"], input[name="country"], input[name="genre"], input[name="catalogueNumber"], textarea[name="notes"]',
       );
-      const hasData = Array.from(fieldsToCheck).some((el) => el.value.trim() !== "");
-      submitButton.disabled = !hasData;
+      submitButton.disabled = !hasAnyNonEmptyField(
+        Array.from(fieldsToCheck, (field) => field.value),
+      );
     };
 
     form.addEventListener("input", updateSubmitState);
 
-    if (scanButton && scanInput) {
+    if (scanButton instanceof HTMLButtonElement && scanInput instanceof HTMLInputElement) {
       scanButton.addEventListener("click", () => {
-        if (this.scanInProgress) return;
+        if (this.addFormState.scanState === "scanning") {
+          return;
+        }
+
         scanInput.click();
       });
 
       scanInput.addEventListener("change", async () => {
         const file = scanInput.files?.[0];
-        if (!file) return;
+        if (!file) {
+          return;
+        }
 
         await this.handleCoverScan(
           file,
           scanButton,
-          detailsEl,
-          artistInput,
-          titleInput,
-          artworkInput,
+          detailsEl instanceof HTMLDetailsElement ? detailsEl : null,
+          artistInput instanceof HTMLInputElement ? artistInput : null,
+          titleInput instanceof HTMLInputElement ? titleInput : null,
+          artworkInput instanceof HTMLInputElement ? artworkInput : null,
         );
         scanInput.value = "";
       });
     }
 
-    // Stack picker button
     document.getElementById("add-form-stack-btn")?.addEventListener("click", () => {
-      this.showAddFormStackDropdown();
+      void this.showAddFormStackDropdown();
     });
 
-    // Stack chip removal
-    document.getElementById("add-form-stack-chips")?.addEventListener("click", (e) => {
-      const target = e.target as HTMLElement;
-      if (target.dataset.removeStack) {
-        this.addFormSelectedStacks = this.addFormSelectedStacks.filter(
-          (id) => id !== Number(target.dataset.removeStack),
-        );
-        this.renderAddFormStackChips();
+    document.getElementById("add-form-stack-chips")?.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (!target.dataset.removeStack) {
+        return;
       }
+
+      this.addFormState = transitionAddFormState(this.addFormState, {
+        type: "STACK_REMOVED",
+        stackId: Number(target.dataset.removeStack),
+      });
+      this.renderAddFormStackChips();
     });
 
-    form.addEventListener("submit", async (e) => {
-      e.preventDefault();
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
 
-      if (!this.isReady) {
+      if (!this.appState.isReady) {
         alert("App is still loading. Please try again in a moment.");
         return;
       }
 
       const formData = new FormData(form);
-      let url = (formData.get("url") as string).trim();
-      const title = (formData.get("title") as string) || undefined;
-      const artist = (formData.get("artist") as string) || undefined;
-      const itemType = (formData.get("itemType") as ItemType) || "album";
-      const label = (formData.get("label") as string) || undefined;
-      const yearRaw = (formData.get("year") as string).trim();
-      const year = yearRaw ? Number(yearRaw) : undefined;
-      const country = (formData.get("country") as string) || undefined;
-      const genre = (formData.get("genre") as string) || undefined;
-      const catalogueNumber = (formData.get("catalogueNumber") as string) || undefined;
-      const notes = (formData.get("notes") as string) || undefined;
-      let artworkUrl = ((formData.get("artworkUrl") as string) || "").trim() || undefined;
-
-      // Auto-prepend https:// if a URL is provided but has no protocol
-      if (url && !/^https?:\/\//i.test(url)) {
-        url = `https://${url}`;
-      }
-      if (artworkUrl && !/^https?:\/\//i.test(artworkUrl) && !artworkUrl.startsWith("/uploads/")) {
-        artworkUrl = `https://${artworkUrl}`;
-      }
+      const values = this.readAddFormValues(formData);
 
       try {
-        const item = await this.api.createMusicItem({
-          url: url || undefined,
-          title,
-          artistName: artist,
-          itemType,
-          label,
-          year,
-          country,
-          genre,
-          catalogueNumber,
-          notes,
-          artworkUrl,
-        });
-        // Assign selected stacks
-        if (this.addFormSelectedStacks.length > 0) {
-          await this.api.setItemStacks(item.id, this.addFormSelectedStacks);
-          this.addFormSelectedStacks = [];
+        const item = await this.api.createMusicItem(buildCreateMusicItemInputFromValues(values));
+
+        if (this.addFormState.selectedStackIds.length > 0) {
+          await this.api.setItemStacks(item.id, this.addFormState.selectedStackIds);
+          this.addFormState = transitionAddFormState(this.addFormState, { type: "CLEAR_STACKS" });
           this.renderAddFormStackChips();
           await this.renderStackBar();
         }
+
         form.reset();
         submitButton.disabled = true;
         await this.renderMusicList();
@@ -168,8 +159,32 @@ export class App {
     });
   }
 
+  private readAddFormValues(formData: FormData): AddFormValues {
+    return {
+      url: this.readStringField(formData, "url"),
+      title: this.readStringField(formData, "title"),
+      artist: this.readStringField(formData, "artist"),
+      itemType: this.readStringField(formData, "itemType") || "album",
+      label: this.readStringField(formData, "label"),
+      year: this.readStringField(formData, "year"),
+      country: this.readStringField(formData, "country"),
+      genre: this.readStringField(formData, "genre"),
+      catalogueNumber: this.readStringField(formData, "catalogueNumber"),
+      notes: this.readStringField(formData, "notes"),
+      artworkUrl: this.readStringField(formData, "artworkUrl"),
+    };
+  }
+
+  private readStringField(formData: FormData, name: string): string {
+    const value = formData.get(name);
+    return typeof value === "string" ? value : "";
+  }
+
   private setScanButtonState(button: HTMLButtonElement, isLoading: boolean): void {
-    this.scanInProgress = isLoading;
+    this.addFormState = transitionAddFormState(this.addFormState, {
+      type: isLoading ? "SCAN_STARTED" : "SCAN_FINISHED",
+    });
+
     button.disabled = isLoading;
     button.classList.toggle("is-loading", isLoading);
     button.textContent = isLoading ? "Scanning..." : "Scan";
@@ -188,9 +203,11 @@ export class App {
     try {
       const imageBase64 = await this.encodeScanImage(file);
       const uploadResult = await this.api.uploadReleaseImage(imageBase64);
+
       if (artworkInput) {
         artworkInput.value = uploadResult.artworkUrl;
       }
+
       if (detailsEl) {
         detailsEl.open = true;
       }
@@ -200,20 +217,13 @@ export class App {
         artistInput.value = result.artist;
         artistInput.dispatchEvent(new Event("input", { bubbles: true }));
       }
+
       if (titleInput && result.title) {
         titleInput.value = result.title;
         titleInput.dispatchEvent(new Event("input", { bubbles: true }));
       }
     } catch (error) {
-      if (error instanceof Error && error.message.includes("uploadReleaseImage")) {
-        alert("Couldn't save the image. Enter details manually.");
-        return;
-      }
-      if (error instanceof Error && error.message.includes("503")) {
-        alert("Scan unavailable. Enter details manually.");
-      } else {
-        alert("Couldn't read the cover. Enter details manually.");
-      }
+      alert(getCoverScanErrorMessage(error));
     } finally {
       this.setScanButtonState(scanButton, false);
     }
@@ -222,7 +232,7 @@ export class App {
   private async encodeScanImage(file: File): Promise<string> {
     const imageDataUrl = await this.readFileAsDataUrl(file);
     const image = await this.loadImage(imageDataUrl);
-    const { width, height } = this.constrainDimensions(image.width, image.height, 1024);
+    const { width, height } = constrainDimensions(image.width, image.height, 1024);
 
     const canvas = document.createElement("canvas");
     canvas.width = width;
@@ -246,14 +256,20 @@ export class App {
   private readFileAsDataUrl(file: Blob): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
+
       reader.onload = () => {
         if (typeof reader.result !== "string") {
           reject(new Error("Failed to read image file"));
           return;
         }
+
         resolve(reader.result);
       };
-      reader.onerror = () => reject(reader.error ?? new Error("Failed to read image file"));
+
+      reader.onerror = () => {
+        reject(reader.error ?? new Error("Failed to read image file"));
+      };
+
       reader.readAsDataURL(file);
     });
   }
@@ -267,133 +283,143 @@ export class App {
     });
   }
 
-  private constrainDimensions(
-    width: number,
-    height: number,
-    maxEdge: number,
-  ): { width: number; height: number } {
-    const largestEdge = Math.max(width, height);
-    if (largestEdge <= maxEdge) {
-      return { width, height };
-    }
-
-    const scale = maxEdge / largestEdge;
-    return {
-      width: Math.max(1, Math.round(width * scale)),
-      height: Math.max(1, Math.round(height * scale)),
-    };
-  }
-
   private setupFilterBar(): void {
     const filterBar = document.getElementById("filter-bar");
-    if (!filterBar) return;
+    if (!filterBar) {
+      return;
+    }
 
-    filterBar.addEventListener("click", (e) => {
-      const target = e.target as HTMLElement;
-      if (!target.classList.contains("filter-btn")) return;
+    filterBar.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (!target.classList.contains("filter-btn")) {
+        return;
+      }
 
-      // Update active state
-      filterBar.querySelectorAll(".filter-btn").forEach((btn) => {
-        btn.classList.remove("active");
+      this.appState = transitionAppState(this.appState, {
+        type: "FILTER_SELECTED",
+        filter: target.dataset.filter as ListenStatus | "all",
+      });
+
+      filterBar.querySelectorAll(".filter-btn").forEach((button) => {
+        button.classList.remove("active");
       });
       target.classList.add("active");
 
-      // Set filter and re-render
-      this.currentFilter = target.dataset.filter as ListenStatus | "all";
-      this.renderMusicList();
+      void this.renderMusicList();
     });
   }
 
   private async renderStackBar(): Promise<void> {
-    this.stacks = await this.api.listStacks();
-    const bar = document.getElementById("stack-bar")!;
-    const allBtn = bar.querySelector('[data-stack="all"]')!;
-    const manageBtn = document.getElementById("manage-stacks-btn")!;
+    const stacks = await this.api.listStacks();
+    this.appState = transitionAppState(this.appState, {
+      type: "STACKS_LOADED",
+      stacks,
+    });
 
-    // Remove old dynamic tabs
-    bar.querySelectorAll(".stack-tab[data-stack-id]").forEach((el) => el.remove());
-
-    // Insert stack tabs before the manage button
-    for (const stack of this.stacks) {
-      const btn = document.createElement("button");
-      btn.className = `stack-tab${this.currentStack === stack.id ? " active" : ""}`;
-      btn.dataset.stackId = String(stack.id);
-      btn.textContent = stack.name;
-      bar.insertBefore(btn, manageBtn);
+    const bar = document.getElementById("stack-bar");
+    const manageBtn = document.getElementById("manage-stacks-btn");
+    if (!bar || !manageBtn) {
+      return;
     }
 
-    // Update active state on All button
-    allBtn.className = `stack-tab${this.currentStack === null ? " active" : ""}`;
+    const allBtn = bar.querySelector('[data-stack="all"]');
+
+    bar.querySelectorAll(".stack-tab[data-stack-id]").forEach((element) => {
+      element.remove();
+    });
+
+    for (const stack of this.appState.stacks) {
+      const button = document.createElement("button");
+      button.className = `stack-tab${this.appState.currentStack === stack.id ? " active" : ""}`;
+      button.dataset.stackId = String(stack.id);
+      button.textContent = stack.name;
+      bar.insertBefore(button, manageBtn);
+    }
+
+    if (allBtn) {
+      allBtn.className = `stack-tab${this.appState.currentStack === null ? " active" : ""}`;
+    }
   }
 
   private setupStackBar(): void {
     const bar = document.getElementById("stack-bar");
-    if (!bar) return;
+    if (!bar) {
+      return;
+    }
 
-    bar.addEventListener("click", (e) => {
-      const target = e.target as HTMLElement;
+    bar.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
       const tab = target.closest(".stack-tab") as HTMLElement | null;
-      if (!tab || tab.id === "manage-stacks-btn") return;
-
-      if (tab.dataset.stack === "all") {
-        this.currentStack = null;
-      } else if (tab.dataset.stackId) {
-        this.currentStack = Number(tab.dataset.stackId);
+      if (!tab || tab.id === "manage-stacks-btn") {
+        return;
       }
 
-      this.renderStackBar();
-      this.renderMusicList();
+      if (tab.dataset.stack === "all") {
+        this.appState = transitionAppState(this.appState, { type: "STACK_SELECTED_ALL" });
+      } else if (tab.dataset.stackId) {
+        this.appState = transitionAppState(this.appState, {
+          type: "STACK_SELECTED",
+          stackId: Number(tab.dataset.stackId),
+        });
+      }
+
+      void this.renderStackBar();
+      void this.renderMusicList();
     });
   }
 
   private setupEventDelegation(): void {
     const list = document.getElementById("music-list");
-    if (!list) return;
+    if (!list) {
+      return;
+    }
 
-    list.addEventListener("click", async (e) => {
-      const target = e.target as HTMLElement;
+    list.addEventListener("click", async (event) => {
+      const target = event.target as HTMLElement;
 
-      // Stack dropdown
       if (target.dataset.action === "stack" || target.closest('[data-action="stack"]')) {
-        const card = target.closest("[data-item-id]") as HTMLElement;
+        const card = target.closest("[data-item-id]") as HTMLElement | null;
         const id = Number(card?.dataset.itemId);
-        if (id) {
+        if (id && card) {
           await this.renderStackDropdown(card, id);
         }
         return;
       }
 
-      // Delete button
       const deleteBtn = target.closest('[data-action="delete"]');
-      if (deleteBtn) {
-        const card = deleteBtn.closest("[data-item-id]") as HTMLElement;
-        const id = Number(card?.dataset.itemId);
-        if (id && confirm("Delete this item?")) {
-          card.remove();
-          await this.api.deleteMusicItem(id);
-        }
+      if (!deleteBtn) {
+        return;
       }
+
+      const card = deleteBtn.closest("[data-item-id]") as HTMLElement | null;
+      const id = Number(card?.dataset.itemId);
+      if (!id || !card || !confirm("Delete this item?")) {
+        return;
+      }
+
+      card.remove();
+      await this.api.deleteMusicItem(id);
     });
 
-    list.addEventListener("change", async (e) => {
-      const target = e.target as HTMLSelectElement;
+    list.addEventListener("change", async (event) => {
+      const target = event.target as HTMLSelectElement;
 
-      // Status select
       if (target.classList.contains("status-select")) {
-        const card = target.closest("[data-item-id]") as HTMLElement;
+        const card = target.closest("[data-item-id]") as HTMLElement | null;
         const id = Number(card?.dataset.itemId);
         const status = target.value as ListenStatus;
+
         if (id) {
           await this.api.updateListenStatus(id, status);
           await this.renderMusicList();
         }
       }
 
-      // Rating radio
-      const radioTarget = e.target as HTMLInputElement;
+      const radioTarget = event.target as HTMLInputElement;
       if (radioTarget.type === "radio" && radioTarget.name.startsWith("rating-")) {
         const card = radioTarget.closest("[data-item-id]") as HTMLElement | null;
         const id = Number(card?.dataset.itemId);
+
         if (id) {
           await this.api.updateMusicItem(id, { rating: Number(radioTarget.value) });
           await this.renderMusicList();
@@ -401,422 +427,349 @@ export class App {
       }
     });
 
-    const resolveRatingInput = (target: HTMLElement): HTMLInputElement | null => {
-      if (target instanceof HTMLLabelElement && target.htmlFor) {
-        return document.getElementById(target.htmlFor) as HTMLInputElement | null;
+    list.addEventListener("mousedown", (event) => {
+      const input = this.resolveRatingInput(event.target as HTMLElement);
+      if (!input || input.type !== "radio" || !input.name.startsWith("rating-")) {
+        return;
       }
-      return target.closest('input[type="radio"]') as HTMLInputElement | null;
-    };
 
-    list.addEventListener("mousedown", (e) => {
-      const input = resolveRatingInput(e.target as HTMLElement);
-      if (!input || input.type !== "radio" || !input.name.startsWith("rating-")) return;
-
-      if (input.checked) {
-        const card = input.closest("[data-item-id]") as HTMLElement | null;
-        const id = Number(card?.dataset.itemId);
-        if (!id) {
-          this.ratingClearCandidate = null;
-          return;
-        }
-        this.ratingClearCandidate = { id, value: Number(input.value) };
-      } else {
-        this.ratingClearCandidate = null;
+      if (!input.checked) {
+        this.ratingState = transitionRatingState(this.ratingState, { type: "RESET" });
+        return;
       }
+
+      const card = input.closest("[data-item-id]") as HTMLElement | null;
+      const itemId = Number(card?.dataset.itemId);
+      if (!itemId) {
+        this.ratingState = transitionRatingState(this.ratingState, { type: "RESET" });
+        return;
+      }
+
+      this.ratingState = transitionRatingState(this.ratingState, {
+        type: "POINTER_DOWN_ON_CHECKED",
+        itemId,
+        value: Number(input.value),
+      });
     });
 
-    list.addEventListener("click", async (e) => {
-      const input = resolveRatingInput(e.target as HTMLElement);
-      if (!input || input.type !== "radio" || !input.name.startsWith("rating-")) return;
-
-      if (this.ratingClearCandidate) {
-        const card = input.closest("[data-item-id]") as HTMLElement | null;
-        const id = Number(card?.dataset.itemId);
-        if (!id) {
-          this.ratingClearCandidate = null;
-          return;
-        }
-        if (
-          id === this.ratingClearCandidate.id &&
-          Number(input.value) === this.ratingClearCandidate.value
-        ) {
-          this.ratingClearCandidate = null;
-          await this.api.updateMusicItem(id, { rating: null });
-          await this.renderMusicList();
-          return;
-        }
+    list.addEventListener("click", async (event) => {
+      const input = this.resolveRatingInput(event.target as HTMLElement);
+      if (!input || input.type !== "radio" || !input.name.startsWith("rating-")) {
+        return;
       }
-      this.ratingClearCandidate = null;
+
+      const card = input.closest("[data-item-id]") as HTMLElement | null;
+      const itemId = Number(card?.dataset.itemId);
+      if (!itemId) {
+        this.ratingState = transitionRatingState(this.ratingState, { type: "RESET" });
+        return;
+      }
+
+      const clickResult = resolveRatingClick(this.ratingState, itemId, Number(input.value));
+      this.ratingState = clickResult.state;
+
+      if (clickResult.shouldClear) {
+        await this.api.updateMusicItem(itemId, { rating: null });
+        await this.renderMusicList();
+      }
     });
+  }
+
+  private resolveRatingInput(target: HTMLElement): HTMLInputElement | null {
+    if (target instanceof HTMLLabelElement && target.htmlFor) {
+      return document.getElementById(target.htmlFor) as HTMLInputElement | null;
+    }
+
+    return target.closest('input[type="radio"]') as HTMLInputElement | null;
   }
 
   private async renderMusicList(): Promise<void> {
-    const container = document.getElementById("music-list")!;
-
-    const filters: MusicItemFilters = {};
-    if (this.currentFilter !== "all") {
-      filters.listenStatus = this.currentFilter;
-    }
-    if (this.currentStack !== null) {
-      filters.stackId = this.currentStack;
-    }
-    const hasFilters = Object.keys(filters).length > 0;
-    const result = await this.api.listMusicItems(hasFilters ? filters : undefined);
-
-    if (result.items.length === 0) {
-      const message =
-        this.currentFilter === "all"
-          ? "No music tracked yet. Paste a link above to get started!"
-          : `No items with status "${STATUS_LABELS[this.currentFilter as keyof typeof STATUS_LABELS]}"`;
-      container.innerHTML = `
-        <div class="empty-state">
-          <p>${message}</p>
-        </div>
-      `;
+    const container = document.getElementById("music-list");
+    if (!container) {
       return;
     }
 
-    container.innerHTML = result.items.map((item) => this.renderMusicCard(item)).join("");
-  }
-  private renderStarRating(itemId: number, rating: number | null): string {
-    const stars = [5, 4, 3, 2, 1]
-      .map(
-        (n) => `
-          <input type="radio" id="star-${itemId}-${n}" name="rating-${itemId}" value="${n}" ${rating === n ? "checked" : ""}>
-          <label for="star-${itemId}-${n}" title="${n} star${n > 1 ? "s" : ""}">&#9733;</label>`,
-      )
-      .join("");
-    return `
-      <fieldset class="star-rating">
-        <legend class="visually-hidden">Rating</legend>
-        ${stars}
-      </fieldset>`;
-  }
+    const filters = buildMusicItemFilters(this.appState.currentFilter, this.appState.currentStack);
+    const result = await this.api.listMusicItems(filters);
 
-  private renderMusicCard(item: MusicItemFull): string {
-    const statusOptions = Object.entries(STATUS_LABELS)
-      .map(
-        ([value, label]) =>
-          `<option value="${value}" ${item.listen_status === value ? "selected" : ""}>${label}</option>`,
-      )
-      .join("");
-
-    return `
-      <article class="music-card" data-item-id="${item.id}">
-        ${
-          item.artwork_url
-            ? `<img class="music-card__artwork" src="${this.escapeHtml(item.artwork_url)}" alt="Artwork for ${this.escapeHtml(item.title)}">`
-            : ""
-        }
-        <div class="music-card__content">
-          <div class="music-card__title">${this.escapeHtml(item.title)}</div>
-          ${item.artist_name ? `<div class="music-card__artist">${this.escapeHtml(item.artist_name)}</div>` : ""}
-          ${
-            item.stacks.length > 0
-              ? `<div class="music-card__stacks">${item.stacks.map((s) => `<span class="music-card__stack-chip">${this.escapeHtml(s.name)}</span>`).join("")}</div>`
-              : ""
-          }
-          <div class="music-card__meta">
-            <select class="status-select">${statusOptions}</select>
-            ${["listened", "to-revisit"].includes(item.listen_status) ? this.renderStarRating(item.id, item.rating) : ""}
-            ${
-              item.primary_source
-                ? item.primary_url
-                  ? `<a href="${this.escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer" class="badge badge--source">${this.escapeHtml(item.primary_source)}</a>`
-                  : `<span class="badge badge--source">${this.escapeHtml(item.primary_source)}</span>`
-                : ""
-            }
-          </div>
-        </div>
-        <div class="music-card__actions">
-          ${
-            item.primary_url
-              ? `
-            <a href="${this.escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer" class="btn btn--ghost" title="Open link">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                <polyline points="15 3 21 3 21 9"></polyline>
-                <line x1="10" y1="14" x2="21" y2="3"></line>
-              </svg>
-            </a>
-          `
-              : ""
-          }
-          <button class="btn btn--ghost" data-action="stack" title="Manage stacks">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="12" y1="5" x2="12" y2="19"></line>
-              <line x1="5" y1="12" x2="19" y2="12"></line>
-            </svg>
-          </button>
-          <button type="button" class="btn btn--ghost btn--danger" data-action="delete" title="Delete">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="3 6 5 6 21 6"></polyline>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-            </svg>
-          </button>
-        </div>
-      </article>
-    `;
+    container.innerHTML = renderMusicList(result.items, this.appState.currentFilter);
   }
 
   private async renderStackManagePanel(): Promise<void> {
     const stacks = await this.api.listStacks();
-    const list = document.getElementById("stack-manage-list")!;
-    list.innerHTML = stacks
-      .map(
-        (s) => `
-      <div class="stack-manage__item" data-manage-stack-id="${s.id}">
-        <span class="stack-manage__name">${this.escapeHtml(s.name)}</span>
-        <span class="stack-manage__count">${s.item_count} items</span>
-        <button class="stack-manage__rename-btn">rename</button>
-        <button class="stack-manage__delete-btn">delete</button>
-      </div>
-    `,
-      )
-      .join("");
+    const list = document.getElementById("stack-manage-list");
+    if (!list) {
+      return;
+    }
+
+    list.innerHTML = renderStackManageList(stacks);
   }
 
   private setupStackManagePanel(): void {
-    const panel = document.getElementById("stack-manage")!;
-    const manageBtn = document.getElementById("manage-stacks-btn")!;
+    const panel = document.getElementById("stack-manage");
+    const manageButton = document.getElementById("manage-stacks-btn");
+    if (!panel || !manageButton) {
+      return;
+    }
 
-    manageBtn.addEventListener("click", () => {
-      const isHidden = panel.hidden;
-      panel.hidden = !isHidden;
+    manageButton.addEventListener("click", () => {
+      this.appState = transitionAppState(this.appState, { type: "STACK_MANAGE_TOGGLED" });
+      panel.hidden = !this.appState.stackManageOpen;
+
       if (!panel.hidden) {
-        this.renderStackManagePanel();
+        void this.renderStackManagePanel();
       }
     });
 
     document.getElementById("stack-manage-create-btn")?.addEventListener("click", async () => {
-      const input = document.getElementById("stack-manage-input") as HTMLInputElement;
+      const input = document.getElementById("stack-manage-input");
+      if (!(input instanceof HTMLInputElement)) {
+        return;
+      }
+
       const name = input.value.trim();
-      if (!name) return;
+      if (!name) {
+        return;
+      }
+
       await this.api.createStack(name);
       input.value = "";
       await this.renderStackBar();
       await this.renderStackManagePanel();
     });
 
-    document.getElementById("stack-manage-list")?.addEventListener("click", async (e) => {
-      const target = e.target as HTMLElement;
-      const item = target.closest("[data-manage-stack-id]") as HTMLElement;
-      if (!item) return;
+    document.getElementById("stack-manage-list")?.addEventListener("click", async (event) => {
+      const target = event.target as HTMLElement;
+      const item = target.closest("[data-manage-stack-id]") as HTMLElement | null;
+      if (!item) {
+        return;
+      }
+
       const stackId = Number(item.dataset.manageStackId);
 
       if (target.classList.contains("stack-manage__rename-btn")) {
-        const nameEl = item.querySelector(".stack-manage__name")!;
-        const currentName = nameEl.textContent!.trim();
-        item.innerHTML = `
-          <input type="text" class="stack-manage__rename-input input" value="${this.escapeHtml(currentName)}">
-          <button class="stack-manage__rename-confirm">save</button>
-        `;
-        const renameInput = item.querySelector(".stack-manage__rename-input") as HTMLInputElement;
-        renameInput.focus();
-        renameInput.select();
+        const nameEl = item.querySelector(".stack-manage__name");
+        const currentName = nameEl?.textContent?.trim() ?? "";
+        item.innerHTML = renderStackRenameEditor(currentName);
+
+        const renameInput = item.querySelector(".stack-manage__rename-input");
+        if (renameInput instanceof HTMLInputElement) {
+          renameInput.focus();
+          renameInput.select();
+        }
       }
 
       if (target.classList.contains("stack-manage__rename-confirm")) {
-        const renameInput = item.querySelector(".stack-manage__rename-input") as HTMLInputElement;
-        const newName = renameInput.value.trim();
-        if (newName) {
-          await this.api.renameStack(stackId, newName);
-          await this.renderStackBar();
-          await this.renderStackManagePanel();
+        const renameInput = item.querySelector(".stack-manage__rename-input");
+        if (!(renameInput instanceof HTMLInputElement)) {
+          return;
         }
+
+        const newName = renameInput.value.trim();
+        if (!newName) {
+          return;
+        }
+
+        await this.api.renameStack(stackId, newName);
+        await this.renderStackBar();
+        await this.renderStackManagePanel();
       }
 
       if (target.classList.contains("stack-manage__delete-btn")) {
-        const stack = this.stacks.find((s) => s.id === stackId);
-        if (confirm(`Delete "${stack?.name}"? Links won't be deleted, just untagged.`)) {
-          await this.api.deleteStack(stackId);
-          if (this.currentStack === stackId) {
-            this.currentStack = null;
-          }
-          await this.renderStackBar();
-          await this.renderStackManagePanel();
-          await this.renderMusicList();
+        const stack = this.appState.stacks.find((candidate) => candidate.id === stackId);
+        if (!confirm(`Delete "${stack?.name}"? Links won't be deleted, just untagged.`)) {
+          return;
         }
+
+        await this.api.deleteStack(stackId);
+        this.appState = transitionAppState(this.appState, {
+          type: "STACK_DELETED",
+          stackId,
+        });
+        await this.renderStackBar();
+        await this.renderStackManagePanel();
+        await this.renderMusicList();
       }
     });
   }
 
   private renderAddFormStackChips(): void {
     const container = document.getElementById("add-form-stack-chips");
-    if (!container) return;
-    container.innerHTML = this.addFormSelectedStacks
-      .map((id) => {
-        const stack = this.stacks.find((s) => s.id === id);
-        if (!stack) return "";
-        return `<span class="stack-chip">
-          ${this.escapeHtml(stack.name)}
-          <button type="button" class="stack-chip__remove" data-remove-stack="${id}">&times;</button>
-        </span>`;
-      })
-      .join("");
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = renderAddFormStackChips(
+      this.addFormState.selectedStackIds,
+      this.appState.stacks,
+    );
   }
 
   private async showAddFormStackDropdown(): Promise<void> {
-    document.querySelectorAll(".stack-dropdown").forEach((el) => el.remove());
+    document.querySelectorAll(".stack-dropdown").forEach((dropdown) => {
+      dropdown.remove();
+    });
 
     const stacks = await this.api.listStacks();
-    const selectedSet = new Set(this.addFormSelectedStacks);
+    const selectedStackIds = new Set(this.addFormState.selectedStackIds);
 
     const dropdown = document.createElement("div");
     dropdown.className = "stack-dropdown";
-    dropdown.innerHTML = `
-      ${stacks
-        .map(
-          (s) => `
-        <label class="stack-dropdown__item">
-          <input type="checkbox" class="stack-dropdown__checkbox"
-                 data-stack-id="${s.id}" ${selectedSet.has(s.id) ? "checked" : ""}>
-          ${this.escapeHtml(s.name)}
-        </label>
-      `,
-        )
-        .join("")}
-      <div class="stack-dropdown__new">
-        <input type="text" class="stack-dropdown__new-input input"
-               placeholder="New stack...">
-      </div>
-    `;
+    dropdown.innerHTML = renderStackDropdownContent(stacks, selectedStackIds);
 
-    const picker = document.getElementById("add-form-stacks")!;
+    const picker = document.getElementById("add-form-stacks");
+    if (!picker) {
+      return;
+    }
+
     picker.appendChild(dropdown);
 
-    dropdown.addEventListener("change", async (e) => {
-      const target = e.target as HTMLInputElement;
-      if (!target.classList.contains("stack-dropdown__checkbox")) return;
-      const stackId = Number(target.dataset.stackId);
-      if (target.checked) {
-        if (!this.addFormSelectedStacks.includes(stackId)) {
-          this.addFormSelectedStacks.push(stackId);
+    dropdown.addEventListener("change", (event) => {
+      const target = event.target as HTMLInputElement;
+      if (!target.classList.contains("stack-dropdown__checkbox")) {
+        return;
+      }
+
+      this.addFormState = transitionAddFormState(this.addFormState, {
+        type: "STACK_TOGGLED",
+        stackId: Number(target.dataset.stackId),
+        checked: target.checked,
+      });
+      this.renderAddFormStackChips();
+    });
+
+    const newInput = dropdown.querySelector(".stack-dropdown__new-input");
+    if (newInput instanceof HTMLInputElement) {
+      newInput.addEventListener("keydown", async (event) => {
+        if (event.key !== "Enter") {
+          return;
         }
-      } else {
-        this.addFormSelectedStacks = this.addFormSelectedStacks.filter((id) => id !== stackId);
-      }
-      this.renderAddFormStackChips();
-    });
 
-    const newInput = dropdown.querySelector(".stack-dropdown__new-input") as HTMLInputElement;
-    newInput.addEventListener("keydown", async (e) => {
-      if (e.key !== "Enter") return;
-      e.preventDefault();
-      const name = newInput.value.trim();
-      if (!name) return;
-      const stack = await this.api.createStack(name);
-      this.addFormSelectedStacks.push(stack.id);
-      await this.renderStackBar();
-      this.renderAddFormStackChips();
-      await this.showAddFormStackDropdown();
-    });
+        event.preventDefault();
+        const name = newInput.value.trim();
+        if (!name) {
+          return;
+        }
 
-    const closeOnEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        dropdown.remove();
-        document.removeEventListener("keydown", closeOnEscape);
+        const stack = await this.api.createStack(name);
+        this.addFormState = transitionAddFormState(this.addFormState, {
+          type: "STACK_ADDED",
+          stackId: stack.id,
+        });
+        await this.renderStackBar();
+        this.renderAddFormStackChips();
+        await this.showAddFormStackDropdown();
+      });
+    }
+
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") {
+        return;
       }
+
+      dropdown.remove();
+      document.removeEventListener("keydown", closeOnEscape);
     };
+
     document.addEventListener("keydown", closeOnEscape);
 
     setTimeout(() => {
-      const clickOutside = (e: MouseEvent) => {
-        if (
-          !dropdown.contains(e.target as Node) &&
-          !(e.target as HTMLElement).closest("#add-form-stack-btn")
-        ) {
-          dropdown.remove();
-          document.removeEventListener("click", clickOutside);
+      const clickOutside = (event: MouseEvent): void => {
+        const target = event.target as HTMLElement;
+        if (dropdown.contains(target) || target.closest("#add-form-stack-btn")) {
+          return;
         }
+
+        dropdown.remove();
+        document.removeEventListener("click", clickOutside);
       };
+
       document.addEventListener("click", clickOutside);
     }, 0);
   }
 
   private async renderStackDropdown(cardEl: HTMLElement, itemId: number): Promise<void> {
-    // Remove any existing dropdown
-    document.querySelectorAll(".stack-dropdown").forEach((el) => el.remove());
+    document.querySelectorAll(".stack-dropdown").forEach((dropdown) => {
+      dropdown.remove();
+    });
 
-    const stacks = await this.api.listStacks();
-    const itemStacks = await this.api.getStacksForItem(itemId);
-    const itemStackIds = new Set(itemStacks.map((s) => s.id));
+    const [stacks, itemStacks] = await Promise.all([
+      this.api.listStacks(),
+      this.api.getStacksForItem(itemId),
+    ]);
+    const selectedStackIds = new Set(itemStacks.map((stack) => stack.id));
 
     const dropdown = document.createElement("div");
     dropdown.className = "stack-dropdown";
-    dropdown.innerHTML = `
-      ${stacks
-        .map(
-          (s) => `
-        <label class="stack-dropdown__item">
-          <input type="checkbox" class="stack-dropdown__checkbox"
-                 data-stack-id="${s.id}" ${itemStackIds.has(s.id) ? "checked" : ""}>
-          ${this.escapeHtml(s.name)}
-        </label>
-      `,
-        )
-        .join("")}
-      <div class="stack-dropdown__new">
-        <input type="text" class="stack-dropdown__new-input input"
-               placeholder="New stack...">
-      </div>
-    `;
+    dropdown.innerHTML = renderStackDropdownContent(stacks, selectedStackIds);
 
-    const actionsEl = cardEl.querySelector(".music-card__actions")!;
-    (actionsEl as HTMLElement).style.position = "relative";
+    const actionsEl = cardEl.querySelector(".music-card__actions");
+    if (!(actionsEl instanceof HTMLElement)) {
+      return;
+    }
+
+    actionsEl.style.position = "relative";
     actionsEl.appendChild(dropdown);
 
-    // Handle checkbox toggles
-    dropdown.addEventListener("change", async (e) => {
-      const target = e.target as HTMLInputElement;
-      if (!target.classList.contains("stack-dropdown__checkbox")) return;
+    dropdown.addEventListener("change", async (event) => {
+      const target = event.target as HTMLInputElement;
+      if (!target.classList.contains("stack-dropdown__checkbox")) {
+        return;
+      }
+
       const stackId = Number(target.dataset.stackId);
       if (target.checked) {
         await this.api.addItemToStack(itemId, stackId);
       } else {
         await this.api.removeItemFromStack(itemId, stackId);
       }
+
       await this.renderStackBar();
     });
 
-    // Handle new stack creation
-    const newInput = dropdown.querySelector(".stack-dropdown__new-input") as HTMLInputElement;
-    newInput.addEventListener("keydown", async (e) => {
-      if (e.key !== "Enter") return;
-      const name = newInput.value.trim();
-      if (!name) return;
-      const stack = await this.api.createStack(name);
-      await this.api.addItemToStack(itemId, stack.id);
-      await this.renderStackBar();
-      await this.renderStackDropdown(cardEl, itemId);
-    });
+    const newInput = dropdown.querySelector(".stack-dropdown__new-input");
+    if (newInput instanceof HTMLInputElement) {
+      newInput.addEventListener("keydown", async (event) => {
+        if (event.key !== "Enter") {
+          return;
+        }
 
-    // Close on Escape
-    const closeOnEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        dropdown.remove();
-        document.removeEventListener("keydown", closeOnEscape);
-        this.renderMusicList();
+        const name = newInput.value.trim();
+        if (!name) {
+          return;
+        }
+
+        const stack = await this.api.createStack(name);
+        await this.api.addItemToStack(itemId, stack.id);
+        await this.renderStackBar();
+        await this.renderStackDropdown(cardEl, itemId);
+      });
+    }
+
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") {
+        return;
       }
+
+      dropdown.remove();
+      document.removeEventListener("keydown", closeOnEscape);
+      void this.renderMusicList();
     };
+
     document.addEventListener("keydown", closeOnEscape);
 
-    // Close on outside click (setTimeout to avoid same click closing it)
     setTimeout(() => {
-      const clickOutside = (e: MouseEvent) => {
-        if (!dropdown.contains(e.target as Node)) {
-          dropdown.remove();
-          document.removeEventListener("click", clickOutside);
-          this.renderMusicList();
+      const clickOutside = (event: MouseEvent): void => {
+        if (dropdown.contains(event.target as Node)) {
+          return;
         }
+
+        dropdown.remove();
+        document.removeEventListener("click", clickOutside);
+        void this.renderMusicList();
       };
+
       document.addEventListener("click", clickOutside);
     }, 0);
-  }
-
-  private escapeHtml(text: string): string {
-    const div = document.createElement("div");
-    div.textContent = text;
-    return div.innerHTML;
   }
 }

--- a/src/ui/domain/add-form.ts
+++ b/src/ui/domain/add-form.ts
@@ -1,0 +1,79 @@
+import type { CreateMusicItemInput, ItemType } from "../../types";
+
+export interface AddFormValues {
+  url: string;
+  title: string;
+  artist: string;
+  itemType: string;
+  label: string;
+  year: string;
+  country: string;
+  genre: string;
+  catalogueNumber: string;
+  notes: string;
+  artworkUrl: string;
+}
+
+export function hasAnyNonEmptyField(values: readonly string[]): boolean {
+  return values.some((value) => value.trim() !== "");
+}
+
+export function buildCreateMusicItemInputFromValues(values: AddFormValues): CreateMusicItemInput {
+  const yearRaw = values.year.trim();
+
+  return {
+    url: normalizeUrlWithProtocol(values.url),
+    title: toOptionalString(values.title),
+    artistName: toOptionalString(values.artist),
+    itemType: (toOptionalString(values.itemType) as ItemType | undefined) ?? "album",
+    label: toOptionalString(values.label),
+    year: yearRaw ? Number(yearRaw) : undefined,
+    country: toOptionalString(values.country),
+    genre: toOptionalString(values.genre),
+    catalogueNumber: toOptionalString(values.catalogueNumber),
+    notes: toOptionalString(values.notes),
+    artworkUrl: normalizeArtworkUrl(values.artworkUrl),
+  };
+}
+
+export function getCoverScanErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.includes("uploadReleaseImage")) {
+    return "Couldn't save the image. Enter details manually.";
+  }
+
+  if (error instanceof Error && error.message.includes("503")) {
+    return "Scan unavailable. Enter details manually.";
+  }
+
+  return "Couldn't read the cover. Enter details manually.";
+}
+
+function toOptionalString(value: string): string | undefined {
+  return value || undefined;
+}
+
+function normalizeUrlWithProtocol(value: string): string | undefined {
+  const url = value.trim();
+  if (!url) {
+    return undefined;
+  }
+
+  if (!/^https?:\/\//i.test(url)) {
+    return `https://${url}`;
+  }
+
+  return url;
+}
+
+function normalizeArtworkUrl(value: string): string | undefined {
+  const artworkUrl = value.trim();
+  if (!artworkUrl) {
+    return undefined;
+  }
+
+  if (!/^https?:\/\//i.test(artworkUrl) && !artworkUrl.startsWith("/uploads/")) {
+    return `https://${artworkUrl}`;
+  }
+
+  return artworkUrl;
+}

--- a/src/ui/domain/music-list.ts
+++ b/src/ui/domain/music-list.ts
@@ -1,0 +1,31 @@
+import type { ListenStatus, MusicItemFilters } from "../../types";
+import { STATUS_LABELS } from "./status";
+
+export type FilterSelection = ListenStatus | "all";
+
+export function buildMusicItemFilters(
+  currentFilter: FilterSelection,
+  currentStack: number | null,
+): MusicItemFilters | undefined {
+  const filters: MusicItemFilters = {};
+
+  if (currentFilter !== "all") {
+    filters.listenStatus = currentFilter;
+  }
+
+  if (currentStack !== null) {
+    filters.stackId = currentStack;
+  }
+
+  return Object.keys(filters).length > 0 ? filters : undefined;
+}
+
+export function getEmptyStateMessage(currentFilter: FilterSelection): string {
+  if (currentFilter === "all") {
+    return "No music tracked yet. Paste a link above to get started!";
+  }
+
+  const labels = STATUS_LABELS as Partial<Record<ListenStatus, string>>;
+  const label = labels[currentFilter] ?? currentFilter;
+  return `No items with status "${label}"`;
+}

--- a/src/ui/domain/scan.ts
+++ b/src/ui/domain/scan.ts
@@ -1,0 +1,17 @@
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+export function constrainDimensions(width: number, height: number, maxEdge: number): Dimensions {
+  const largestEdge = Math.max(width, height);
+  if (largestEdge <= maxEdge) {
+    return { width, height };
+  }
+
+  const scale = maxEdge / largestEdge;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}

--- a/src/ui/domain/status.ts
+++ b/src/ui/domain/status.ts
@@ -1,0 +1,10 @@
+import type { ListenStatus } from "../../types";
+
+export type DisplayListenStatus = Exclude<ListenStatus, "listening">;
+
+export const STATUS_LABELS: Record<DisplayListenStatus, string> = {
+  "to-listen": "To Listen",
+  listened: "Listened",
+  "to-revisit": "Revisit",
+  done: "Done",
+};

--- a/src/ui/state/add-form-machine.ts
+++ b/src/ui/state/add-form-machine.ts
@@ -1,0 +1,79 @@
+export interface AddFormState {
+  initialized: boolean;
+  selectedStackIds: number[];
+  scanState: "idle" | "scanning";
+}
+
+export type AddFormEvent =
+  | { type: "INITIALIZED" }
+  | { type: "STACK_TOGGLED"; stackId: number; checked: boolean }
+  | { type: "STACK_ADDED"; stackId: number }
+  | { type: "STACK_REMOVED"; stackId: number }
+  | { type: "CLEAR_STACKS" }
+  | { type: "SCAN_STARTED" }
+  | { type: "SCAN_FINISHED" };
+
+export const initialAddFormState: AddFormState = {
+  initialized: false,
+  selectedStackIds: [],
+  scanState: "idle",
+};
+
+export function transitionAddFormState(state: AddFormState, event: AddFormEvent): AddFormState {
+  switch (event.type) {
+    case "INITIALIZED":
+      return {
+        ...state,
+        initialized: true,
+      };
+    case "STACK_TOGGLED": {
+      const exists = state.selectedStackIds.includes(event.stackId);
+      if (event.checked && !exists) {
+        return {
+          ...state,
+          selectedStackIds: [...state.selectedStackIds, event.stackId],
+        };
+      }
+
+      if (!event.checked && exists) {
+        return {
+          ...state,
+          selectedStackIds: state.selectedStackIds.filter((id) => id !== event.stackId),
+        };
+      }
+
+      return state;
+    }
+    case "STACK_ADDED":
+      if (state.selectedStackIds.includes(event.stackId)) {
+        return state;
+      }
+
+      return {
+        ...state,
+        selectedStackIds: [...state.selectedStackIds, event.stackId],
+      };
+    case "STACK_REMOVED":
+      return {
+        ...state,
+        selectedStackIds: state.selectedStackIds.filter((id) => id !== event.stackId),
+      };
+    case "CLEAR_STACKS":
+      return {
+        ...state,
+        selectedStackIds: [],
+      };
+    case "SCAN_STARTED":
+      return {
+        ...state,
+        scanState: "scanning",
+      };
+    case "SCAN_FINISHED":
+      return {
+        ...state,
+        scanState: "idle",
+      };
+    default:
+      return state;
+  }
+}

--- a/src/ui/state/app-machine.ts
+++ b/src/ui/state/app-machine.ts
@@ -1,0 +1,69 @@
+import type { ListenStatus, StackWithCount } from "../../types";
+
+export interface AppState {
+  currentFilter: ListenStatus | "all";
+  currentStack: number | null;
+  stacks: StackWithCount[];
+  isReady: boolean;
+  stackManageOpen: boolean;
+}
+
+export type AppEvent =
+  | { type: "APP_READY" }
+  | { type: "FILTER_SELECTED"; filter: ListenStatus | "all" }
+  | { type: "STACK_SELECTED"; stackId: number }
+  | { type: "STACK_SELECTED_ALL" }
+  | { type: "STACKS_LOADED"; stacks: StackWithCount[] }
+  | { type: "STACK_MANAGE_TOGGLED" }
+  | { type: "STACK_DELETED"; stackId: number };
+
+export const initialAppState: AppState = {
+  currentFilter: "to-listen",
+  currentStack: null,
+  stacks: [],
+  isReady: false,
+  stackManageOpen: false,
+};
+
+export function transitionAppState(state: AppState, event: AppEvent): AppState {
+  switch (event.type) {
+    case "APP_READY":
+      return {
+        ...state,
+        isReady: true,
+      };
+    case "FILTER_SELECTED":
+      return {
+        ...state,
+        currentFilter: event.filter,
+      };
+    case "STACK_SELECTED":
+      return {
+        ...state,
+        currentStack: event.stackId,
+      };
+    case "STACK_SELECTED_ALL":
+      return {
+        ...state,
+        currentStack: null,
+      };
+    case "STACKS_LOADED":
+      return {
+        ...state,
+        stacks: event.stacks,
+      };
+    case "STACK_MANAGE_TOGGLED":
+      return {
+        ...state,
+        stackManageOpen: !state.stackManageOpen,
+      };
+    case "STACK_DELETED":
+      return {
+        ...state,
+        currentStack: state.currentStack === event.stackId ? null : state.currentStack,
+        stacks: state.stacks.filter((stack) => stack.id !== event.stackId),
+      };
+    default:
+      return state;
+  }
+}

--- a/src/ui/state/rating-machine.ts
+++ b/src/ui/state/rating-machine.ts
@@ -1,0 +1,55 @@
+export interface RatingClearCandidate {
+  id: number;
+  value: number;
+}
+
+export interface RatingState {
+  clearCandidate: RatingClearCandidate | null;
+}
+
+export type RatingEvent =
+  | { type: "POINTER_DOWN_ON_CHECKED"; itemId: number; value: number }
+  | { type: "RESET" };
+
+export interface RatingClickResult {
+  shouldClear: boolean;
+  state: RatingState;
+}
+
+export const initialRatingState: RatingState = {
+  clearCandidate: null,
+};
+
+export function transitionRatingState(state: RatingState, event: RatingEvent): RatingState {
+  switch (event.type) {
+    case "POINTER_DOWN_ON_CHECKED":
+      return {
+        ...state,
+        clearCandidate: {
+          id: event.itemId,
+          value: event.value,
+        },
+      };
+    case "RESET":
+      return {
+        ...state,
+        clearCandidate: null,
+      };
+    default:
+      return state;
+  }
+}
+
+export function resolveRatingClick(
+  state: RatingState,
+  itemId: number,
+  value: number,
+): RatingClickResult {
+  const candidate = state.clearCandidate;
+  const shouldClear = candidate !== null && candidate.id === itemId && candidate.value === value;
+
+  return {
+    shouldClear,
+    state: transitionRatingState(state, { type: "RESET" }),
+  };
+}

--- a/src/ui/view/templates.ts
+++ b/src/ui/view/templates.ts
@@ -1,0 +1,177 @@
+import type { MusicItemFull, StackWithCount } from "../../types";
+import type { FilterSelection } from "../domain/music-list";
+import { getEmptyStateMessage } from "../domain/music-list";
+import { STATUS_LABELS } from "../domain/status";
+
+export function renderMusicList(items: MusicItemFull[], currentFilter: FilterSelection): string {
+  if (items.length === 0) {
+    const message = getEmptyStateMessage(currentFilter);
+    return `
+      <div class="empty-state">
+        <p>${message}</p>
+      </div>
+    `;
+  }
+
+  return items.map((item) => renderMusicCard(item)).join("");
+}
+
+export function renderMusicCard(item: MusicItemFull): string {
+  const statusOptions = Object.entries(STATUS_LABELS)
+    .map(
+      ([value, label]) =>
+        `<option value="${value}" ${item.listen_status === value ? "selected" : ""}>${label}</option>`,
+    )
+    .join("");
+
+  return `
+    <article class="music-card" data-item-id="${item.id}">
+      ${
+        item.artwork_url
+          ? `<img class="music-card__artwork" src="${escapeHtml(item.artwork_url)}" alt="Artwork for ${escapeHtml(item.title)}">`
+          : ""
+      }
+      <div class="music-card__content">
+        <div class="music-card__title">${escapeHtml(item.title)}</div>
+        ${item.artist_name ? `<div class="music-card__artist">${escapeHtml(item.artist_name)}</div>` : ""}
+        ${
+          item.stacks.length > 0
+            ? `<div class="music-card__stacks">${item.stacks
+                .map(
+                  (stack) =>
+                    `<span class="music-card__stack-chip">${escapeHtml(stack.name)}</span>`,
+                )
+                .join("")}</div>`
+            : ""
+        }
+        <div class="music-card__meta">
+          <select class="status-select">${statusOptions}</select>
+          ${["listened", "to-revisit"].includes(item.listen_status) ? renderStarRating(item.id, item.rating) : ""}
+          ${
+            item.primary_source
+              ? item.primary_url
+                ? `<a href="${escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer" class="badge badge--source">${escapeHtml(item.primary_source)}</a>`
+                : `<span class="badge badge--source">${escapeHtml(item.primary_source)}</span>`
+              : ""
+          }
+        </div>
+      </div>
+      <div class="music-card__actions">
+        ${
+          item.primary_url
+            ? `
+          <a href="${escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer" class="btn btn--ghost" title="Open link">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+              <polyline points="15 3 21 3 21 9"></polyline>
+              <line x1="10" y1="14" x2="21" y2="3"></line>
+            </svg>
+          </a>
+        `
+            : ""
+        }
+        <button class="btn btn--ghost" data-action="stack" title="Manage stacks">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
+        <button type="button" class="btn btn--ghost btn--danger" data-action="delete" title="Delete">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+      </div>
+    </article>
+  `;
+}
+
+export function renderStackManageList(stacks: StackWithCount[]): string {
+  return stacks
+    .map(
+      (stack) => `
+      <div class="stack-manage__item" data-manage-stack-id="${stack.id}">
+        <span class="stack-manage__name">${escapeHtml(stack.name)}</span>
+        <span class="stack-manage__count">${stack.item_count} items</span>
+        <button class="stack-manage__rename-btn">rename</button>
+        <button class="stack-manage__delete-btn">delete</button>
+      </div>
+    `,
+    )
+    .join("");
+}
+
+export function renderStackRenameEditor(currentName: string): string {
+  return `
+    <input type="text" class="stack-manage__rename-input input" value="${escapeHtml(currentName)}">
+    <button class="stack-manage__rename-confirm">save</button>
+  `;
+}
+
+export function renderAddFormStackChips(
+  selectedStackIds: number[],
+  stacks: StackWithCount[],
+): string {
+  return selectedStackIds
+    .map((stackId) => {
+      const stack = stacks.find((candidate) => candidate.id === stackId);
+      if (!stack) {
+        return "";
+      }
+
+      return `<span class="stack-chip">
+        ${escapeHtml(stack.name)}
+        <button type="button" class="stack-chip__remove" data-remove-stack="${stackId}">&times;</button>
+      </span>`;
+    })
+    .join("");
+}
+
+export function renderStackDropdownContent(
+  stacks: StackWithCount[],
+  selectedStackIds: Set<number>,
+): string {
+  return `
+    ${stacks
+      .map(
+        (stack) => `
+      <label class="stack-dropdown__item">
+        <input type="checkbox" class="stack-dropdown__checkbox"
+               data-stack-id="${stack.id}" ${selectedStackIds.has(stack.id) ? "checked" : ""}>
+        ${escapeHtml(stack.name)}
+      </label>
+    `,
+      )
+      .join("")}
+    <div class="stack-dropdown__new">
+      <input type="text" class="stack-dropdown__new-input input"
+             placeholder="New stack...">
+    </div>
+  `;
+}
+
+function renderStarRating(itemId: number, rating: number | null): string {
+  const stars = [5, 4, 3, 2, 1]
+    .map(
+      (value) => `
+        <input type="radio" id="star-${itemId}-${value}" name="rating-${itemId}" value="${value}" ${rating === value ? "checked" : ""}>
+        <label for="star-${itemId}-${value}" title="${value} star${value > 1 ? "s" : ""}">&#9733;</label>`,
+    )
+    .join("");
+
+  return `
+    <fieldset class="star-rating">
+      <legend class="visually-hidden">Rating</legend>
+      ${stars}
+    </fieldset>`;
+}
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/tests/unit/app-domain.test.ts
+++ b/tests/unit/app-domain.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildCreateMusicItemInputFromValues,
+  getCoverScanErrorMessage,
+  hasAnyNonEmptyField,
+} from "../../src/ui/domain/add-form";
+import { buildMusicItemFilters, getEmptyStateMessage } from "../../src/ui/domain/music-list";
+import { constrainDimensions } from "../../src/ui/domain/scan";
+
+describe("app domain helpers", () => {
+  it("detects whether add form has any user input", () => {
+    expect(hasAnyNonEmptyField(["", "   "])).toBe(false);
+    expect(hasAnyNonEmptyField(["", " title "])).toBe(true);
+  });
+
+  it("builds a create payload and normalizes URL fields", () => {
+    const payload = buildCreateMusicItemInputFromValues({
+      url: "example.com/release",
+      title: "Title",
+      artist: "Artist",
+      itemType: "album",
+      label: "Label",
+      year: "2024",
+      country: "UK",
+      genre: "Dub",
+      catalogueNumber: "CAT-1",
+      notes: "Notes",
+      artworkUrl: "cdn.example.com/art.jpg",
+    });
+
+    expect(payload).toEqual({
+      url: "https://example.com/release",
+      title: "Title",
+      artistName: "Artist",
+      itemType: "album",
+      label: "Label",
+      year: 2024,
+      country: "UK",
+      genre: "Dub",
+      catalogueNumber: "CAT-1",
+      notes: "Notes",
+      artworkUrl: "https://cdn.example.com/art.jpg",
+    });
+  });
+
+  it("preserves upload artwork paths without protocol", () => {
+    const payload = buildCreateMusicItemInputFromValues({
+      url: "",
+      title: "",
+      artist: "",
+      itemType: "album",
+      label: "",
+      year: "",
+      country: "",
+      genre: "",
+      catalogueNumber: "",
+      notes: "",
+      artworkUrl: "/uploads/test.jpg",
+    });
+
+    expect(payload.artworkUrl).toBe("/uploads/test.jpg");
+  });
+
+  it("returns API filter object only when needed", () => {
+    expect(buildMusicItemFilters("all", null)).toBeUndefined();
+    expect(buildMusicItemFilters("listened", null)).toEqual({ listenStatus: "listened" });
+    expect(buildMusicItemFilters("all", 7)).toEqual({ stackId: 7 });
+  });
+
+  it("builds the same empty-state messages used by the UI", () => {
+    expect(getEmptyStateMessage("all")).toContain("No music tracked yet");
+    expect(getEmptyStateMessage("to-revisit")).toBe('No items with status "Revisit"');
+  });
+
+  it("returns scan alert messages for known error types", () => {
+    expect(getCoverScanErrorMessage(new Error("uploadReleaseImage failed: 500"))).toContain(
+      "Couldn't save the image",
+    );
+    expect(getCoverScanErrorMessage(new Error("scanCover failed: 503"))).toContain(
+      "Scan unavailable",
+    );
+    expect(getCoverScanErrorMessage(new Error("other"))).toContain("Couldn't read the cover");
+  });
+
+  it("constrains image dimensions while preserving aspect ratio", () => {
+    expect(constrainDimensions(500, 300, 1024)).toEqual({ width: 500, height: 300 });
+    expect(constrainDimensions(2000, 1000, 1000)).toEqual({ width: 1000, height: 500 });
+  });
+});

--- a/tests/unit/app-state-machines.test.ts
+++ b/tests/unit/app-state-machines.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+
+import { initialAddFormState, transitionAddFormState } from "../../src/ui/state/add-form-machine";
+import { initialAppState, transitionAppState } from "../../src/ui/state/app-machine";
+import {
+  initialRatingState,
+  resolveRatingClick,
+  transitionRatingState,
+} from "../../src/ui/state/rating-machine";
+
+describe("app state machine", () => {
+  it("tracks filter and stack selection", () => {
+    let state = transitionAppState(initialAppState, { type: "APP_READY" });
+    state = transitionAppState(state, { type: "FILTER_SELECTED", filter: "listened" });
+    state = transitionAppState(state, { type: "STACK_SELECTED", stackId: 4 });
+
+    expect(state.isReady).toBe(true);
+    expect(state.currentFilter).toBe("listened");
+    expect(state.currentStack).toBe(4);
+
+    state = transitionAppState(state, { type: "STACK_SELECTED_ALL" });
+    expect(state.currentStack).toBeNull();
+  });
+
+  it("resets active stack when deleted", () => {
+    let state = transitionAppState(initialAppState, { type: "STACK_SELECTED", stackId: 2 });
+    state = transitionAppState(state, {
+      type: "STACKS_LOADED",
+      stacks: [
+        { id: 2, name: "Dub", created_at: "", item_count: 1 },
+        { id: 3, name: "House", created_at: "", item_count: 1 },
+      ],
+    });
+
+    state = transitionAppState(state, { type: "STACK_DELETED", stackId: 2 });
+    expect(state.currentStack).toBeNull();
+    expect(state.stacks.map((stack) => stack.id)).toEqual([3]);
+  });
+});
+
+describe("add form state machine", () => {
+  it("adds, toggles, and clears selected stacks", () => {
+    let state = transitionAddFormState(initialAddFormState, { type: "INITIALIZED" });
+    state = transitionAddFormState(state, { type: "STACK_ADDED", stackId: 5 });
+    state = transitionAddFormState(state, { type: "STACK_ADDED", stackId: 5 });
+    state = transitionAddFormState(state, { type: "STACK_TOGGLED", stackId: 7, checked: true });
+    state = transitionAddFormState(state, { type: "STACK_REMOVED", stackId: 5 });
+
+    expect(state.initialized).toBe(true);
+    expect(state.selectedStackIds).toEqual([7]);
+
+    state = transitionAddFormState(state, { type: "CLEAR_STACKS" });
+    expect(state.selectedStackIds).toEqual([]);
+  });
+
+  it("tracks scan idle/scanning states", () => {
+    let state = transitionAddFormState(initialAddFormState, { type: "SCAN_STARTED" });
+    expect(state.scanState).toBe("scanning");
+
+    state = transitionAddFormState(state, { type: "SCAN_FINISHED" });
+    expect(state.scanState).toBe("idle");
+  });
+});
+
+describe("rating state machine", () => {
+  it("marks a checked star as clearable when clicked again", () => {
+    const state = transitionRatingState(initialRatingState, {
+      type: "POINTER_DOWN_ON_CHECKED",
+      itemId: 9,
+      value: 3,
+    });
+
+    const clearResult = resolveRatingClick(state, 9, 3);
+    expect(clearResult.shouldClear).toBe(true);
+    expect(clearResult.state.clearCandidate).toBeNull();
+  });
+
+  it("does not clear when rating click does not match candidate", () => {
+    const state = transitionRatingState(initialRatingState, {
+      type: "POINTER_DOWN_ON_CHECKED",
+      itemId: 9,
+      value: 3,
+    });
+
+    const clearResult = resolveRatingClick(state, 9, 4);
+    expect(clearResult.shouldClear).toBe(false);
+    expect(clearResult.state.clearCandidate).toBeNull();
+  });
+});


### PR DESCRIPTION
Summary
- split `src/app.ts` into clearer UI, logic, and binding modules with focused responsibilities
- introduce state-machine-driven business logic so application behavior can be unit tested independently
- keep DOM binding layer lightweight while reusing the same state transitions as before

Testing
- Not run (not requested)