### PR TITLE
Add bottom padding to music list on mobile devices

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -758,6 +758,10 @@ select.input {
 }
 
 @media (max-width: 520px) {
+  .music-list {
+    padding-bottom: 150px;
+  }
+
   .music-card {
     padding: 8px 6px;
     min-height: 74px;


### PR DESCRIPTION
## Summary
Added bottom padding to the `.music-list` element on mobile devices (max-width: 520px) to improve spacing and prevent content from being hidden behind fixed UI elements.

## Changes
- Added `padding-bottom: 150px` to `.music-list` within the mobile media query (max-width: 520px)

## Details
This change ensures that the music list has adequate bottom spacing on mobile viewports, likely to prevent the last items from being obscured by a fixed footer or player control element that is 150px in height.

https://claude.ai/code/session_01S2vRRWtaaAvnJLeQLXAGb9