### PR TITLE
feat: server-side render main page HTML with initial data

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { stackRoutes } from "./routes/stacks";
 import { ingestRoutes } from "./routes/ingest";
 import { releaseRoutes } from "./routes/release";
 import { releasePageRoutes } from "./routes/release-page";
+import { mainPageRoutes } from "./routes/main-page";
 import { rssRoutes } from "./routes/rss";
 import { getUploadsDir, rewriteUploadsRequestPath } from "./uploads";
 
@@ -19,6 +20,9 @@ app.onError((err, c) => {
   console.error(`[api] ${c.req.method} ${c.req.path} error:`, err);
   return c.json({ error: "Internal server error" }, 500);
 });
+
+// ---------- Main page (SSR) ----------
+app.route("/", mainPageRoutes);
 
 // ---------- API routes ----------
 app.route("/api/music-items", musicItemRoutes);
@@ -58,6 +62,7 @@ if (isDev) {
   let viteHandle: ((req: unknown, res: unknown) => void) | null = null;
   const server = createHttpServer((req, res) => {
     if (
+      req.url === "/" ||
       req.url?.startsWith("/api/") ||
       req.url?.startsWith("/uploads/") ||
       req.url === "/r" ||

--- a/server/page-assets.ts
+++ b/server/page-assets.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+interface PageAssets {
+  cssHref: string;
+  scriptSrc: string;
+}
+
+let assetsCache: PageAssets | null = null;
+
+export async function getPageAssets(): Promise<PageAssets> {
+  if (process.env.NODE_ENV !== "production") {
+    return {
+      cssHref: "/src/styles/main.css",
+      scriptSrc: "/src/main.ts",
+    };
+  }
+
+  if (assetsCache) return assetsCache;
+
+  try {
+    const html = await readFile(path.resolve("dist/index.html"), "utf-8");
+    const cssMatch = html.match(/href="(\/assets\/[^"]+\.css)"/);
+    const jsMatch = html.match(/src="(\/assets\/[^"]+\.js)"/);
+    assetsCache = {
+      cssHref: cssMatch?.[1] ?? "/assets/index.css",
+      scriptSrc: jsMatch?.[1] ?? "/assets/index.js",
+    };
+  } catch {
+    assetsCache = {
+      cssHref: "/assets/index.css",
+      scriptSrc: "/assets/index.js",
+    };
+  }
+
+  return assetsCache;
+}

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -1,0 +1,350 @@
+import { Hono } from "hono";
+import { eq, inArray, count, asc, sql } from "drizzle-orm";
+import { db } from "../db/index";
+import { musicItems, musicItemStacks, stacks, musicItemOrder, stackParents } from "../db/schema";
+import { fullItemSelect, hydrateItemStacks } from "../music-item-creator";
+import { applyOrder, buildContextKey } from "../../shared/music-list-context";
+import { renderMusicList } from "../../src/ui/view/templates";
+import type { MusicItemFull, StackWithCount } from "../../src/types";
+import { getPageAssets } from "../page-assets";
+import pkg from "../../package.json";
+
+const DEFAULT_FILTER = "to-listen" as const;
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function safeJson(obj: unknown): string {
+  return JSON.stringify(obj)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+function renderStackTab(stack: StackWithCount): string {
+  return `<button class="stack-tab" data-stack-id="${stack.id}">${escapeHtml(stack.name)}</button>`;
+}
+
+async function fetchInitialStacks(): Promise<StackWithCount[]> {
+  const rows = await db
+    .select({
+      id: stacks.id,
+      name: stacks.name,
+      created_at: stacks.createdAt,
+      item_count: count(musicItemStacks.musicItemId),
+    })
+    .from(stacks)
+    .leftJoin(musicItemStacks, eq(stacks.id, musicItemStacks.stackId))
+    .groupBy(stacks.id)
+    .orderBy(asc(stacks.name));
+
+  const parentRows = await db
+    .select({
+      parent_stack_id: stackParents.parentStackId,
+      child_stack_id: stackParents.childStackId,
+    })
+    .from(stackParents);
+
+  const parentByChild = new Map(parentRows.map((r) => [r.child_stack_id, r.parent_stack_id]));
+
+  return rows.map((row) => ({
+    ...row,
+    parent_stack_id: parentByChild.get(row.id) ?? null,
+  }));
+}
+
+async function fetchInitialItems(): Promise<MusicItemFull[]> {
+  const items = await fullItemSelect()
+    .where(eq(musicItems.listenStatus, DEFAULT_FILTER))
+    .orderBy(sql`${musicItems.createdAt} DESC`);
+
+  if (items.length === 0) return [];
+
+  const stackRows = await db
+    .select({
+      musicItemId: musicItemStacks.musicItemId,
+      id: stacks.id,
+      name: stacks.name,
+    })
+    .from(musicItemStacks)
+    .innerJoin(stacks, eq(stacks.id, musicItemStacks.stackId))
+    .where(inArray(musicItemStacks.musicItemId, items.map((i) => i.id)));
+
+  const enriched = hydrateItemStacks(items, stackRows);
+
+  const contextKey = buildContextKey(DEFAULT_FILTER, null);
+  const orderRow = await db
+    .select()
+    .from(musicItemOrder)
+    .where(eq(musicItemOrder.contextKey, contextKey))
+    .get();
+
+  if (orderRow) {
+    const orderedIds = JSON.parse(orderRow.itemIds) as number[];
+    return applyOrder(enriched, orderedIds) as unknown as MusicItemFull[];
+  }
+
+  return enriched as unknown as MusicItemFull[];
+}
+
+function renderMainPage(opts: {
+  musicListHtml: string;
+  stackBarTabsHtml: string;
+  stacksJson: string;
+  cssHref: string;
+  scriptSrc: string;
+  isDev: boolean;
+  appVersion: string;
+}): string {
+  const viteClient = opts.isDev
+    ? `\n    <script type="module" src="/@vite/client"></script>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Track music you want to listen to" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>On The Beach</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="${escapeHtml(opts.cssHref)}" />
+  </head>
+  <body>
+    <div id="app">
+      <header class="header">
+        <h1>On The Beach</h1>
+        <p class="header__subtitle">Music Tracking</p>
+        <div class="header__winbuttons">
+          <button class="header__winbtn" aria-label="Minimize" tabindex="-1">_</button>
+          <button class="header__winbtn" aria-label="Maximize" tabindex="-1">□</button>
+          <button class="header__winbtn header__winbtn--close" aria-label="Close" tabindex="-1">
+            ✕
+          </button>
+        </div>
+      </header>
+
+      <main class="main">
+        <section class="add-section">
+          <form id="add-form" class="add-form" method="post">
+            <div class="add-form__row">
+              <input
+                type="text"
+                id="url-input"
+                name="url"
+                placeholder="Paste a music link..."
+                class="input"
+              />
+              <input
+                type="file"
+                id="scan-file-input"
+                class="add-form__scan-input"
+                accept="image/*"
+              />
+              <button
+                type="button"
+                id="add-form-scan-btn"
+                class="btn add-form__scan-btn"
+                aria-label="Scan album cover"
+              >
+                Scan
+              </button>
+              <button type="submit" id="add-form-submit" class="btn btn--primary" disabled>
+                Add
+              </button>
+            </div>
+
+            <details class="add-form__details">
+              <summary>More options</summary>
+              <div class="add-form__extra">
+                <input type="text" name="title" placeholder="Title" class="input" />
+                <input type="text" name="artist" placeholder="Artist" class="input" />
+                <select name="itemType" class="input">
+                  <option value="album">Album</option>
+                  <option value="ep">EP</option>
+                  <option value="single">Single</option>
+                  <option value="track">Track</option>
+                  <option value="mix">Mix</option>
+                </select>
+                <input type="text" name="label" placeholder="Label" class="input" />
+                <input
+                  type="number"
+                  name="year"
+                  placeholder="Year"
+                  min="1900"
+                  max="2099"
+                  class="input"
+                />
+                <input type="text" name="country" placeholder="Country" class="input" />
+                <input type="text" name="genre" placeholder="Genre" class="input" />
+                <input type="text" name="artworkUrl" placeholder="Artwork URL" class="input" />
+                <input
+                  type="text"
+                  name="catalogueNumber"
+                  placeholder="Catalogue number"
+                  class="input"
+                />
+                <textarea name="notes" placeholder="Notes" class="input"></textarea>
+                <div class="stack-picker" id="add-form-stacks">
+                  <div class="stack-picker__chips" id="add-form-stack-chips"></div>
+                  <button
+                    type="button"
+                    class="stack-picker__add btn btn--ghost"
+                    id="add-form-stack-btn"
+                  >
+                    + Stack
+                  </button>
+                </div>
+              </div>
+            </details>
+          </form>
+        </section>
+
+        <section class="stack-section">
+          <div id="stack-bar" class="stack-bar">
+            <button class="stack-tab active" data-stack="all">All</button>
+            ${opts.stackBarTabsHtml}
+            <button
+              class="stack-tab stack-tab--manage"
+              id="manage-stacks-btn"
+              title="Manage stacks"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <circle cx="12" cy="12" r="3"></circle>
+                <path
+                  d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
+                ></path>
+              </svg>
+            </button>
+            <button
+              class="stack-tab stack-tab--delete"
+              id="delete-stack-btn"
+              title="Delete selected stack"
+              hidden
+              aria-label="Delete selected stack"
+            >
+              🗑
+            </button>
+          </div>
+          <div id="stack-manage" class="stack-manage" hidden>
+            <div id="stack-manage-list"></div>
+            <div class="stack-manage__create">
+              <input
+                type="text"
+                id="stack-manage-input"
+                class="input"
+                placeholder="New stack name..."
+              />
+              <button type="button" id="stack-manage-create-btn" class="btn btn--primary">
+                Create
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section class="filter-section">
+          <div id="filter-bar" class="filter-bar">
+            <button class="filter-btn" data-filter="all">All</button>
+            <button class="filter-btn active" data-filter="to-listen">To Listen</button>
+            <button class="filter-btn" data-filter="listened">Listened</button>
+          </div>
+        </section>
+
+        <section class="list-section">
+          <div class="music-list-shell">
+            <div id="music-list" class="music-list">
+              ${opts.musicListHtml}
+            </div>
+            <div id="music-list-scrollbar" class="music-scrollbar">
+              <button
+                type="button"
+                class="music-scrollbar__button"
+                data-scroll-btn="up"
+                aria-label="Scroll up"
+                tabindex="-1"
+              >
+                ▲
+              </button>
+              <div id="music-list-scroll-track" class="music-scrollbar__track">
+                <div id="music-list-scroll-thumb" class="music-scrollbar__thumb"></div>
+              </div>
+              <button
+                type="button"
+                class="music-scrollbar__button"
+                data-scroll-btn="down"
+                aria-label="Scroll down"
+                tabindex="-1"
+              >
+                ▼
+              </button>
+            </div>
+          </div>
+        </section>
+      </main>
+      <footer class="footer">
+        <span id="app-version">v${escapeHtml(opts.appVersion)}</span>
+      </footer>
+    </div>
+
+    <script id="__initial_state__" type="application/json">${opts.stacksJson}</script>${viteClient}
+    <script type="module" src="${escapeHtml(opts.scriptSrc)}"></script>
+  </body>
+</html>`;
+}
+
+export function createMainPageRoutes(): Hono {
+  const routes = new Hono();
+  const isDev = process.env.NODE_ENV !== "production";
+
+  routes.get("/", async (c) => {
+    const [initialItems, initialStacks, { cssHref, scriptSrc }] = await Promise.all([
+      fetchInitialItems(),
+      fetchInitialStacks(),
+      getPageAssets(),
+    ]);
+
+    const musicListHtml = renderMusicList(initialItems, DEFAULT_FILTER);
+    const stackBarTabsHtml = initialStacks.map((s) => renderStackTab(s)).join("");
+    const stacksJson = safeJson({ stacks: initialStacks });
+
+    return c.html(
+      renderMainPage({
+        musicListHtml,
+        stackBarTabsHtml,
+        stacksJson,
+        cssHref,
+        scriptSrc,
+        isDev,
+        appVersion: pkg.version,
+      }),
+    );
+  });
+
+  return routes;
+}
+
+export const mainPageRoutes = createMainPageRoutes();

--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -1,27 +1,9 @@
 import { Hono } from "hono";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { fetchFullItem } from "../music-item-creator";
 import type { MusicItemFull } from "../../src/types";
+import { getPageAssets } from "../page-assets";
 
 export type FetchItemFn = (id: number) => Promise<MusicItemFull | null>;
-
-let cssHrefCache: string | null = null;
-
-async function getCssHref(): Promise<string> {
-  if (process.env.NODE_ENV !== "production") {
-    return "/src/styles/main.css";
-  }
-  if (cssHrefCache) return cssHrefCache;
-  try {
-    const html = await readFile(path.resolve("dist/index.html"), "utf-8");
-    const match = html.match(/href="(\/assets\/[^"]+\.css)"/);
-    cssHrefCache = match?.[1] ?? "/assets/index.css";
-  } catch {
-    cssHrefCache = "/assets/index.css";
-  }
-  return cssHrefCache;
-}
 
 function escapeHtml(str: string): string {
   return str
@@ -233,7 +215,7 @@ export function createReleasePageRoutes(fetchItem: FetchItemFn = fetchFullItem):
       return c.html(renderNotFoundPage(), 404);
     }
 
-    const cssHref = await getCssHref();
+    const { cssHref } = await getPageAssets();
     return c.html(renderReleasePage(item, cssHref));
   });
 


### PR DESCRIPTION
The main page (GET /) is now fully rendered on the server, embedding
the music list and stack bar with live data from the database. The
client receives pre-rendered HTML and skips the initial API calls for
items and stacks, doing as little work as possible on load.

- Add server/page-assets.ts: shared utility for CSS/JS asset path
  resolution (dev vs production hashed filenames)
- Add server/routes/main-page.ts: Hono route that fetches initial
  items (to-listen filter) and stacks, renders full page HTML using
  the same renderMusicList template as the client, and embeds a
  __initial_state__ JSON script tag with stack data for the client
- Update server/routes/release-page.ts: use shared getPageAssets()
  instead of local getCssHref()
- Update server/index.ts: register main page SSR route; in dev mode
  route GET / to Hono instead of Vite so the SSR path is used
- Update src/app.ts: read __initial_state__ on init; if server data
  is present load stacks from it and skip renderStackBar/renderMusicList
  API calls; only sync the scrollbar via requestAnimationFrame

https://claude.ai/code/session_01ATAoQwbku684kyfTVNaPF3