### PR TITLE
fix: preserve apostrophes in OG metadata parsing

### DIFF
--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -24,18 +24,18 @@ export function parseOgTags(html: string): OgData {
 
   // Match <meta> tags with property/name and content in either order
   const metaRegex =
-    /<meta\s+(?:[^>]*?)(?:property|name)\s*=\s*["']([^"']+)["'][^>]*?content\s*=\s*["']([^"']*?)["'][^>]*?\/?>/gi;
+    /<meta\s+(?:[^>]*?)(?:property|name)\s*=\s*(["'])([^"']+)\1[^>]*?content\s*=\s*(["'])([\s\S]*?)\3[^>]*?\/?>/gi;
   const metaRegexReversed =
-    /<meta\s+(?:[^>]*?)content\s*=\s*["']([^"']*?)["'][^>]*?(?:property|name)\s*=\s*["']([^"']+)["'][^>]*?\/?>/gi;
+    /<meta\s+(?:[^>]*?)content\s*=\s*(["'])([\s\S]*?)\1[^>]*?(?:property|name)\s*=\s*(["'])([^"']+)\3[^>]*?\/?>/gi;
 
   const tags = new Map<string, string>();
 
   let match: RegExpExecArray | null;
   while ((match = metaRegex.exec(html)) !== null) {
-    tags.set(match[1].toLowerCase(), decodeHtmlEntities(match[2]));
+    tags.set(match[2].toLowerCase(), decodeHtmlEntities(match[4]));
   }
   while ((match = metaRegexReversed.exec(html)) !== null) {
-    tags.set(match[2].toLowerCase(), decodeHtmlEntities(match[1]));
+    tags.set(match[4].toLowerCase(), decodeHtmlEntities(match[2]));
   }
 
   data.ogTitle = tags.get("og:title");
@@ -61,9 +61,16 @@ export function decodeHtmlEntities(text: string): string {
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
     .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#(\d+);/g, (_, num) => String.fromCharCode(Number(num)));
+    .replace(/&#x([0-9a-f]+);/gi, (raw, hex) => {
+      const codePoint = Number.parseInt(hex, 16);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : raw;
+    })
+    .replace(/&#(\d+);/g, (raw, num) => {
+      const codePoint = Number.parseInt(num, 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : raw;
+    });
 }
 
 export function parseBandcampOg(og: OgData): ScrapedMetadata {

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -16,12 +16,14 @@ describe("decodeHtmlEntities", () => {
     expect(decodeHtmlEntities("Rock &amp; Roll")).toBe("Rock & Roll");
     expect(decodeHtmlEntities("&lt;b&gt;bold&lt;/b&gt;")).toBe("<b>bold</b>");
     expect(decodeHtmlEntities("&quot;quoted&quot;")).toBe('"quoted"');
+    expect(decodeHtmlEntities("it&apos;s")).toBe("it's");
     expect(decodeHtmlEntities("it&#39;s")).toBe("it's");
     expect(decodeHtmlEntities("it&#x27;s")).toBe("it's");
   });
 
   test("decodes numeric entities", () => {
     expect(decodeHtmlEntities("&#8211;")).toBe("\u2013");
+    expect(decodeHtmlEntities("it&#x2019;s")).toBe("it\u2019s");
   });
 });
 
@@ -69,6 +71,16 @@ describe("parseOgTags", () => {
     `;
     const result = parseOgTags(html);
     expect(result.ogTitle).toBe("Rock & Roll");
+  });
+
+  test("preserves apostrophes in quoted meta content values", () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="It's a Beautiful Place" />
+      </head></html>
+    `;
+    const result = parseOgTags(html);
+    expect(result.ogTitle).toBe("It's a Beautiful Place");
   });
 
   test("extracts og:site_name", () => {


### PR DESCRIPTION
## Summary
- fix OG meta parsing so apostrophes in quoted content values are not truncated
- improve entity decoding for apostrophe variants (`&apos;`, `&#x2019;`, and numeric entities)
- add regression tests for Apple Music apostrophe cases

## Testing
- bun test tests/unit/scraper.test.ts
- bun test tests/unit

Closes #48
