### PR TITLE
refactor: standardize release wording

### DIFF
--- a/eval/submit.ts
+++ b/eval/submit.ts
@@ -10,7 +10,7 @@ const RESULTS_DIR = resolve(EVAL_DIR, "results");
 
 const SCAN_PROMPT =
   "You are reading a photo of a CD or vinyl cover. Respond with JSON only using keys artist and title of the release." +
-  " If the release has no separate album title, use the artist name as the title." +
+  " If the release has no separate release title, use the artist name as the title." +
   'If uncertain, use null values. Example: {"artist":"Radiohead","title":"OK Computer"}';
 
 const OCR_SCHEMA = {

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
               type="button"
               id="add-form-scan-btn"
               class="btn add-form__scan-btn"
-              aria-label="Scan album cover"
+              aria-label="Scan release cover"
             >
               Scan
             </button>
@@ -58,9 +58,9 @@
 
           <div class="add-form__secondary" hidden>
             <input type="text" name="artist" placeholder="Artist" class="input" />
-            <input type="text" name="title" placeholder="Album" class="input" />
+            <input type="text" name="title" placeholder="Release" class="input" />
             <select name="itemType" class="input">
-              <option value="album">Album</option>
+              <option value="album">Release</option>
               <option value="ep">EP</option>
               <option value="single">Single</option>
               <option value="track">Track</option>

--- a/playwright/manual-add.spec.ts
+++ b/playwright/manual-add.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ request }) => {
   await request.post("/api/__test__/reset");
 });
 
-test("initial form shows link input first, artist and album revealed after clicking Add", async ({
+test("initial form shows link input first, artist and release revealed after clicking Add", async ({
   page,
 }) => {
   await page.goto("/");
@@ -26,7 +26,7 @@ test("can manually add a release without link or artwork", async ({ page }) => {
 
   const addButton = page.getByRole("button", { name: "Add" });
   await expect(addButton).toBeEnabled();
-  await addButton.click(); // reveals artist/album fields
+  await addButton.click(); // reveals artist/release fields
   await addButton.click(); // submits with empty fields
 
   const card = page.locator(".music-card").first();

--- a/playwright/rating.spec.ts
+++ b/playwright/rating.spec.ts
@@ -8,8 +8,8 @@ test("star rating appears on to-listen items and persists", async ({ page }) => 
   await page.goto("/");
 
   // Add an item manually via the title field (no URL)
-  await page.getByRole("button", { name: "Add" }).click(); // reveals artist/album fields
-  await page.locator('input[name="title"]').fill("Test Album");
+  await page.getByRole("button", { name: "Add" }).click(); // reveals artist/release fields
+  await page.locator('input[name="title"]').fill("Test Release");
   await page.getByRole("button", { name: "Add" }).click(); // submits
   const card = page.locator(".music-card").first();
   await expect(card).toBeVisible({ timeout: 10_000 });

--- a/playwright/scan-cover.spec.ts
+++ b/playwright/scan-cover.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page, request }) => {
   await page.locator(".add-form__details summary").click(); // opens scan controls
 });
 
-test("scan prefill opens details and fills artist/title", async ({ page }) => {
+test("scan prefill opens details and fills artist/release title", async ({ page }) => {
   await page.route("**/api/release/image", async (route) => {
     await route.fulfill({
       status: 201,
@@ -32,7 +32,7 @@ test("scan prefill opens details and fills artist/title", async ({ page }) => {
 
   const fixturePath = path.join(process.cwd(), "playwright/fixtures/cover-sample.png");
 
-  await page.getByRole("button", { name: "Scan album cover" }).click();
+  await page.getByRole("button", { name: "Scan release cover" }).click();
   await page.locator("#scan-file-input").setInputFiles(fixturePath);
 
   await expect(page.locator(".add-form__details")).toHaveAttribute("open", "");

--- a/playwright/ui-percy.spec.ts
+++ b/playwright/ui-percy.spec.ts
@@ -170,7 +170,7 @@ async function addItemViaCoverScan(
     await expect(details).toHaveAttribute("open", "");
   }
 
-  await page.getByRole("button", { name: "Scan album cover" }).click();
+  await page.getByRole("button", { name: "Scan release cover" }).click();
   await page.locator("#scan-file-input").setInputFiles(fixturePath);
 
   await expect(page.locator(".add-form__details")).toHaveAttribute("open", "");

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -163,7 +163,7 @@ function renderMainPage(opts: {
                 type="button"
                 id="add-form-scan-btn"
                 class="btn add-form__scan-btn"
-                aria-label="Scan album cover"
+                aria-label="Scan release cover"
               >
                 Scan
               </button>
@@ -172,9 +172,9 @@ function renderMainPage(opts: {
 
             <div class="add-form__secondary" hidden>
               <input type="text" name="artist" placeholder="Artist" class="input" />
-              <input type="text" name="title" placeholder="Album" class="input" />
+              <input type="text" name="title" placeholder="Release" class="input" />
               <select name="itemType" class="input">
-                <option value="album">Album</option>
+                <option value="album">Release</option>
                 <option value="ep">EP</option>
                 <option value="single">Single</option>
                 <option value="track">Track</option>

--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { extractAlbumInfo } from "../vision";
+import { extractReleaseInfo } from "../vision";
 import { lookupRelease } from "../musicbrainz";
 import { createScanEnricher } from "../scan-enricher";
 import type { ScanResult } from "../../src/types";
@@ -37,7 +37,7 @@ function validateImageBase64(
   return { ok: true, value: trimmed };
 }
 
-export type ExtractAlbumInfoFn = (base64Image: string) => Promise<ScanResult | null>;
+export type ExtractReleaseInfoFn = (base64Image: string) => Promise<ScanResult | null>;
 export type SaveReleaseImageFn = (base64Image: string) => Promise<string>;
 
 async function saveReleaseImage(base64Image: string): Promise<string> {
@@ -53,7 +53,7 @@ async function saveReleaseImage(base64Image: string): Promise<string> {
 }
 
 export function createReleaseRoutes(
-  scanReleaseCover: ExtractAlbumInfoFn = createScanEnricher(extractAlbumInfo, lookupRelease),
+  scanReleaseCover: ExtractReleaseInfoFn = createScanEnricher(extractReleaseInfo, lookupRelease),
   saveImage: SaveReleaseImageFn = saveReleaseImage,
 ): Hono {
   const routes = new Hono();

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -75,7 +75,7 @@ export function decodeHtmlEntities(text: string): string {
 
 export function parseBandcampOg(og: OgData): ScrapedMetadata {
   const title = og.ogTitle || og.title || "";
-  // Bandcamp format: "Album Title, by Artist Name"
+  // Bandcamp format: "Release Title, by Artist Name"
   const byMatch = title.match(/^(.+?),\s*by\s+(.+)$/i);
   if (byMatch) {
     return {
@@ -115,7 +115,7 @@ export function parseAppleMusicOg(og: OgData): ScrapedMetadata {
     }
   }
 
-  // og:description is often "Artist · YEAR · N Songs", but may also be "Album · ...".
+  // og:description is often "Artist · YEAR · N Songs", but may also be "Release · ...".
   if (!result.potentialArtist && og.ogDescription) {
     const artistMatch = og.ogDescription.match(/^(.+?)\s+[·-]\s+/i);
     const candidateArtist = artistMatch?.[1]?.trim();

--- a/server/vision.ts
+++ b/server/vision.ts
@@ -145,7 +145,7 @@ async function extractWithOcr(
   return parseOcrResponse(response);
 }
 
-export async function extractAlbumInfo(base64Image: string): Promise<ScanResult | null> {
+export async function extractReleaseInfo(base64Image: string): Promise<ScanResult | null> {
   const apiKey = process.env.MISTRAL_API_KEY;
   if (!apiKey) {
     return null;

--- a/tests/unit/email-parser.test.ts
+++ b/tests/unit/email-parser.test.ts
@@ -25,7 +25,7 @@ describe("extractMusicUrls", () => {
   });
 
   it("extracts spotify URLs from HTML", () => {
-    const html = `<a href="https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy">Album</a>`;
+    const html = `<a href="https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy">Release</a>`;
     expect(extractMusicUrls({ html })).toEqual([
       "https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy",
     ]);

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -106,7 +106,7 @@ describe("POST /api/ingest/email", () => {
     mockCreate.mockResolvedValue({
       item: {
         id: 1,
-        title: "Cool Album",
+        title: "Cool Release",
         primary_url: "https://artist.bandcamp.com/album/cool-album",
       } as any,
       created: true,
@@ -120,7 +120,7 @@ describe("POST /api/ingest/email", () => {
     expect(body.received).toBe(true);
     expect(body.items_created).toBe(1);
     expect(body.items_skipped).toBe(0);
-    expect(body.items[0].title).toBe("Cool Album");
+    expect(body.items[0].title).toBe("Cool Release");
     expect(mockCreate).toHaveBeenCalledWith("https://artist.bandcamp.com/album/cool-album", {
       notes: "Via email from noreply@bandcamp.com",
     });
@@ -166,7 +166,7 @@ describe("POST /api/ingest/email", () => {
     mockCreate.mockResolvedValue({
       item: {
         id: 2,
-        title: "SG Album",
+        title: "SG Release",
         primary_url: "https://artist.bandcamp.com/album/sg-test",
       } as any,
       created: true,

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -65,14 +65,14 @@ describe("lookupRelease", () => {
     spyOn(globalThis, "fetch").mockResolvedValueOnce(
       makeMbResponse([
         {
-          title: "Some Album",
+          title: "Some Release",
           date: "2010",
           country: "US",
         },
       ]),
     );
 
-    const result = await lookupRelease("Some Artist", "Some Album");
+    const result = await lookupRelease("Some Artist", "Some Release");
     expect(result).toEqual({
       year: 2010,
       label: null,

--- a/tests/unit/parse-url.test.ts
+++ b/tests/unit/parse-url.test.ts
@@ -25,7 +25,7 @@ describe("parseUrl - youtube", () => {
 });
 
 describe("parseUrl - apple music", () => {
-  test("identifies apple music album link and extracts title", () => {
+  test("identifies apple music release link and extracts title", () => {
     const result = parseUrl("https://music.apple.com/es/album/el-poder-verde/1810282984?l=en-GB");
 
     expect(result.source).toBe("apple_music");

--- a/tests/unit/release-route.test.ts
+++ b/tests/unit/release-route.test.ts
@@ -2,18 +2,18 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import { createReleaseRoutes } from "../../server/routes/release";
 
-const mockExtractAlbumInfo = mock();
+const mockExtractReleaseInfo = mock();
 const mockSaveImage = mock();
 
 function makeApp(): Hono {
   const app = new Hono();
-  app.route("/api/release", createReleaseRoutes(mockExtractAlbumInfo, mockSaveImage));
+  app.route("/api/release", createReleaseRoutes(mockExtractReleaseInfo, mockSaveImage));
   return app;
 }
 
 describe("POST /api/release/scan", () => {
   beforeEach(() => {
-    mockExtractAlbumInfo.mockReset();
+    mockExtractReleaseInfo.mockReset();
     mockSaveImage.mockReset();
     mockSaveImage.mockResolvedValue("/uploads/mock.jpg");
   });
@@ -30,7 +30,7 @@ describe("POST /api/release/scan", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain("imageBase64");
-    expect(mockExtractAlbumInfo).not.toHaveBeenCalled();
+    expect(mockExtractReleaseInfo).not.toHaveBeenCalled();
   });
 
   test("returns 400 for invalid JSON body", async () => {
@@ -45,11 +45,11 @@ describe("POST /api/release/scan", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe("Invalid JSON payload");
-    expect(mockExtractAlbumInfo).not.toHaveBeenCalled();
+    expect(mockExtractReleaseInfo).not.toHaveBeenCalled();
   });
 
   test("returns 200 with parsed fields on success", async () => {
-    mockExtractAlbumInfo.mockResolvedValueOnce({
+    mockExtractReleaseInfo.mockResolvedValueOnce({
       artist: "Boards of Canada",
       title: "Geogaddi",
     });
@@ -68,11 +68,11 @@ describe("POST /api/release/scan", () => {
       artist: "Boards of Canada",
       title: "Geogaddi",
     });
-    expect(mockExtractAlbumInfo).toHaveBeenCalledWith("YWJjZA==");
+    expect(mockExtractReleaseInfo).toHaveBeenCalledWith("YWJjZA==");
   });
 
   test("returns enriched fields when scan function returns them", async () => {
-    mockExtractAlbumInfo.mockResolvedValueOnce({
+    mockExtractReleaseInfo.mockResolvedValueOnce({
       artist: "Radiohead",
       title: "OK Computer",
       year: 1997,
@@ -102,7 +102,7 @@ describe("POST /api/release/scan", () => {
   });
 
   test("returns 503 when vision extraction fails", async () => {
-    mockExtractAlbumInfo.mockResolvedValueOnce(null);
+    mockExtractReleaseInfo.mockResolvedValueOnce(null);
 
     const app = makeApp();
 
@@ -120,7 +120,7 @@ describe("POST /api/release/scan", () => {
 
 describe("POST /api/release/image", () => {
   beforeEach(() => {
-    mockExtractAlbumInfo.mockReset();
+    mockExtractReleaseInfo.mockReset();
     mockSaveImage.mockReset();
     mockSaveImage.mockResolvedValue("/uploads/mock.jpg");
   });

--- a/tests/unit/rss-route.test.ts
+++ b/tests/unit/rss-route.test.ts
@@ -124,7 +124,7 @@ describe("GET /feed/stacks/:stackId.rss", () => {
     expect(body).toContain("Brian Eno");
   });
 
-  test("item title combines artist and album name", async () => {
+  test("item title combines artist and release name", async () => {
     const fetchStack = mock(async (_id: number) => ({ id: 1, name: "Ambient" }));
     const fetchItems = mock(async (_id: number) => [
       makeItem({ title: "Geogaddi", artist_name: "Boards of Canada" }),
@@ -137,7 +137,7 @@ describe("GET /feed/stacks/:stackId.rss", () => {
     expect(body).toContain("<title>Boards of Canada — Geogaddi</title>");
   });
 
-  test("item title uses only album name when artist is unknown", async () => {
+  test("item title uses only release name when artist is unknown", async () => {
     const fetchStack = mock(async (_id: number) => ({ id: 1, name: "Ambient" }));
     const fetchItems = mock(async (_id: number) => [
       makeItem({ title: "Untitled Mix", artist_name: null }),

--- a/tests/unit/smtp-ingest.test.ts
+++ b/tests/unit/smtp-ingest.test.ts
@@ -56,7 +56,7 @@ describe("SMTP ingest server", () => {
     mockCreate.mockResolvedValue({
       item: {
         id: 1,
-        title: "Test Album",
+        title: "Test Release",
         primary_url: "https://artist.bandcamp.com/album/test",
       } as any,
       created: true,
@@ -99,7 +99,7 @@ describe("SMTP ingest server", () => {
     process.env.SMTP_ALLOWED_FROM = "noreply@bandcamp.com";
 
     mockCreate.mockResolvedValue({
-      item: { id: 1, title: "Album" } as any,
+      item: { id: 1, title: "Release" } as any,
       created: true,
     });
 
@@ -123,7 +123,7 @@ describe("SMTP ingest server", () => {
     process.env.SMTP_ALLOWED_FROM = "noreply@bandcamp.com,alerts@spotify.com";
 
     mockCreate.mockResolvedValue({
-      item: { id: 2, title: "Allowed Album" } as any,
+      item: { id: 2, title: "Allowed Release" } as any,
       created: true,
     });
 

--- a/tests/unit/vision.test.ts
+++ b/tests/unit/vision.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { extractAlbumInfo } from "../../server/vision";
+import { extractReleaseInfo } from "../../server/vision";
 
 function mockChatCompletionResponse(
   content: string | Array<{ type: string; text: string }>,
@@ -61,7 +61,7 @@ function mockOcrResponse(payload: {
   );
 }
 
-describe("extractAlbumInfo", () => {
+describe("extractReleaseInfo", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
@@ -81,7 +81,7 @@ describe("extractAlbumInfo", () => {
       }),
     );
 
-    const result = await extractAlbumInfo("base64-image-data");
+    const result = await extractReleaseInfo("base64-image-data");
     expect(result).toEqual({ artist: "Radiohead", title: "OK Computer" });
   });
 
@@ -92,7 +92,7 @@ describe("extractAlbumInfo", () => {
       }),
     );
 
-    const result = await extractAlbumInfo("base64-image-data");
+    const result = await extractReleaseInfo("base64-image-data");
     expect(result).toEqual({ artist: "Bonobo", title: "Migration" });
   });
 
@@ -103,7 +103,7 @@ describe("extractAlbumInfo", () => {
       mockChatCompletionResponse('{"artist":"Massive Attack","title":"Mezzanine"}'),
     );
 
-    const result = await extractAlbumInfo("base64-image-data");
+    const result = await extractReleaseInfo("base64-image-data");
     expect(result).toEqual({ artist: "Massive Attack", title: "Mezzanine" });
   });
 
@@ -114,14 +114,14 @@ describe("extractAlbumInfo", () => {
       mockChatCompletionResponse("I can't identify this cover confidently."),
     );
 
-    const result = await extractAlbumInfo("base64-image-data");
+    const result = await extractReleaseInfo("base64-image-data");
     expect(result).toBeNull();
   });
 
   test("returns null when provider request fails", async () => {
     spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network down"));
 
-    const result = await extractAlbumInfo("base64-image-data");
+    const result = await extractReleaseInfo("base64-image-data");
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- replace user-facing "Album" wording with "Release" in the add flow and related UI copy
- rename the vision scan helper from extractAlbumInfo to extractReleaseInfo for consistency
- update unit and Playwright tests to match the new wording

## Testing
- bun test tests/unit
- bun run typecheck
- bun run test:e2e
Fixes #60