### PR TITLE
test: stabilize release list ordering for Percy

### DIFF
--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, inArray, count, asc, sql } from "drizzle-orm";
+import { eq, inArray, count, asc, desc } from "drizzle-orm";
 import { db } from "../db/index";
 import { musicItems, musicItemStacks, stacks, musicItemOrder, stackParents } from "../db/schema";
 import { fullItemSelect, hydrateItemStacks } from "../music-item-creator";
@@ -62,7 +62,7 @@ async function fetchInitialStacks(): Promise<StackWithCount[]> {
 async function fetchInitialItems(): Promise<MusicItemFull[]> {
   const items = await fullItemSelect()
     .where(eq(musicItems.listenStatus, DEFAULT_FILTER))
-    .orderBy(sql`${musicItems.createdAt} DESC`);
+    .orderBy(desc(musicItems.createdAt), desc(musicItems.id));
 
   if (items.length === 0) return [];
 

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, inArray, sql } from "drizzle-orm";
+import { eq, and, inArray, sql, desc } from "drizzle-orm";
 import { db } from "../db/index";
 import {
   musicItems,
@@ -207,7 +207,8 @@ musicItemRoutes.get("/", async (c) => {
     query = query.where(and(...conditions));
   }
 
-  query = query.orderBy(sql`${musicItems.createdAt} DESC`);
+  // created_at is only second-resolution in SQLite, so break ties by id.
+  query = query.orderBy(desc(musicItems.createdAt), desc(musicItems.id));
 
   const items = await query;
 


### PR DESCRIPTION
## Summary
- add a deterministic secondary sort for music item lists when created_at ties
- apply the same ordering to the initial server-rendered list and the /api/music-items API
- keep user-saved custom reorderings unchanged because applyOrder still overrides the default sort

## Testing
- bun run test:unit
- bun run typecheck
- bun run test:e2e