### PR TITLE
fix: prefer Apple Music artwork thumbnails

### DIFF
--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -144,6 +144,24 @@ function hasScrapedMetadata(
   return Boolean(metadata?.potentialArtist || metadata?.potentialTitle || metadata?.imageUrl);
 }
 
+function hasCompleteAppleMusicMetadata(
+  metadata: ScrapedMetadata | null | undefined,
+): metadata is ScrapedMetadata {
+  return Boolean(metadata?.potentialArtist && metadata?.potentialTitle && metadata?.imageUrl);
+}
+
+function mergeScrapedMetadata(
+  ...entries: Array<ScrapedMetadata | null | undefined>
+): ScrapedMetadata | null {
+  const merged: ScrapedMetadata = {
+    potentialArtist: firstDefined(...entries.map((entry) => entry?.potentialArtist)),
+    potentialTitle: firstDefined(...entries.map((entry) => entry?.potentialTitle)),
+    imageUrl: firstDefined(...entries.map((entry) => entry?.imageUrl)),
+  };
+
+  return hasScrapedMetadata(merged) ? merged : null;
+}
+
 function normalizeMixcloudImageUrl(url: string | undefined): string | undefined {
   const trimmed = url?.trim();
   if (!trimmed) return undefined;
@@ -452,6 +470,55 @@ async function scrapeYouTubeOEmbed(
   }
 }
 
+async function scrapeAppleMusicOEmbed(
+  url: string,
+  timeoutMs: number,
+): Promise<ScrapedMetadata | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const oembedUrl = `https://music.apple.com/api/oembed?url=${encodeURIComponent(url)}`;
+
+    const response = await fetch(oembedUrl, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as unknown;
+    if (!isRecord(data)) {
+      return null;
+    }
+
+    const potentialTitle = firstDefined(getString(data.title), getString(data.name));
+    const potentialArtist = firstDefined(
+      getString(data.author_name),
+      getString(data.author),
+      getString(data.uploader),
+    );
+    const imageUrl = normalizeAppleMusicImageUrl(
+      firstDefined(getString(data.thumbnail_url), getString(data.thumbnail), getString(data.image)),
+    );
+
+    if (!potentialTitle && !potentialArtist && !imageUrl) {
+      return null;
+    }
+
+    return {
+      potentialTitle,
+      potentialArtist,
+      imageUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function extractAppleMusicLookupId(url: string): string | undefined {
   try {
     const parsed = new URL(url);
@@ -563,14 +630,26 @@ export async function scrapeUrl(
   timeoutMs = 5000,
 ): Promise<ScrapedMetadata | null> {
   let mixcloudOEmbed: ScrapedMetadata | null = null;
+  let appleMusicOEmbed: ScrapedMetadata | null = null;
   let appleMusicLookup: ScrapedMetadata | null = null;
+  let appleMusicMetadata: ScrapedMetadata | null = null;
 
   if (source === "mixcloud") {
     mixcloudOEmbed = await scrapeMixcloudOEmbed(url, timeoutMs);
   }
 
   if (source === "apple_music") {
+    appleMusicOEmbed = await scrapeAppleMusicOEmbed(url, timeoutMs);
+    appleMusicMetadata = mergeScrapedMetadata(appleMusicOEmbed);
+    if (hasCompleteAppleMusicMetadata(appleMusicMetadata)) {
+      return appleMusicMetadata;
+    }
+
     appleMusicLookup = await scrapeAppleMusicLookup(url, timeoutMs);
+    appleMusicMetadata = mergeScrapedMetadata(appleMusicOEmbed, appleMusicLookup);
+    if (hasCompleteAppleMusicMetadata(appleMusicMetadata)) {
+      return appleMusicMetadata;
+    }
   }
 
   try {
@@ -586,8 +665,8 @@ export async function scrapeUrl(
       return mixcloudOEmbed;
     }
 
-    if (source === "apple_music" && hasScrapedMetadata(appleMusicLookup)) {
-      return appleMusicLookup;
+    if (source === "apple_music" && hasScrapedMetadata(appleMusicMetadata)) {
+      return appleMusicMetadata;
     }
 
     const controller = new AbortController();
@@ -605,7 +684,7 @@ export async function scrapeUrl(
 
     const contentType = response.headers.get("content-type") || "";
     const fallback =
-      source === "mixcloud" ? mixcloudOEmbed : source === "apple_music" ? appleMusicLookup : null;
+      source === "mixcloud" ? mixcloudOEmbed : source === "apple_music" ? appleMusicMetadata : null;
 
     if (!contentType.includes("text/html")) {
       return hasScrapedMetadata(fallback) ? fallback : null;
@@ -653,23 +732,14 @@ export async function scrapeUrl(
 
     if (source === "apple_music") {
       const appleMusicOg = parseAppleMusicOg(og);
-      const merged: ScrapedMetadata = {
-        potentialArtist: firstDefined(
-          appleMusicLookup?.potentialArtist,
-          appleMusicOg.potentialArtist,
-        ),
-        potentialTitle: firstDefined(appleMusicLookup?.potentialTitle, appleMusicOg.potentialTitle),
-        imageUrl: firstDefined(appleMusicLookup?.imageUrl, appleMusicOg.imageUrl),
-      };
-
-      return hasScrapedMetadata(merged) ? merged : null;
+      return mergeScrapedMetadata(appleMusicOEmbed, appleMusicLookup, appleMusicOg);
     }
 
     const parser = SOURCE_PARSERS[source] || parseDefaultOg;
     return parser(og);
   } catch {
     const fallback =
-      source === "mixcloud" ? mixcloudOEmbed : source === "apple_music" ? appleMusicLookup : null;
+      source === "mixcloud" ? mixcloudOEmbed : source === "apple_music" ? appleMusicMetadata : null;
     return hasScrapedMetadata(fallback) ? fallback : null;
   }
 }

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -475,8 +475,42 @@ describe("scrapeUrl", () => {
     mock.restore();
   });
 
-  test("uses Apple lookup metadata without scraping the full page", async () => {
+  test("prefers Apple oEmbed metadata for square artwork without scraping the full page", async () => {
     const fetchSpy = spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          title: "It's a Beautiful Place",
+          author_name: "Water From Your Eyes",
+          thumbnail_url:
+            "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/example/300x300bb.jpg",
+        }),
+        {
+          headers: { "content-type": "application/json; charset=utf-8" },
+        },
+      ),
+    );
+
+    const result = await scrapeUrl(
+      "https://music.apple.com/es/album/its-a-beautiful-place/1811583108?l=en-GB",
+      "apple_music",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.potentialTitle).toBe("It's a Beautiful Place");
+    expect(result!.potentialArtist).toBe("Water From Your Eyes");
+    expect(result!.imageUrl).toBe(
+      "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/example/1200x1200bb.jpg",
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://music.apple.com/api/oembed?url=https%3A%2F%2Fmusic.apple.com%2Fes%2Falbum%2Fits-a-beautiful-place%2F1811583108%3Fl%3Den-GB",
+    );
+    mock.restore();
+  });
+
+  test("falls back to Apple lookup metadata when oEmbed is unavailable", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }));
     fetchSpy.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -500,14 +534,15 @@ describe("scrapeUrl", () => {
       "https://music.apple.com/es/album/its-a-beautiful-place/1811583108?l=en-GB",
       "apple_music",
     );
+
     expect(result).not.toBeNull();
     expect(result!.potentialTitle).toBe("It's a Beautiful Place");
     expect(result!.potentialArtist).toBe("Water From Your Eyes");
     expect(result!.imageUrl).toBe(
       "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/example/1200x1200bb.jpg",
     );
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://itunes.apple.com/lookup?id=1811583108");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1]?.[0]).toBe("https://itunes.apple.com/lookup?id=1811583108");
     mock.restore();
   });
 });


### PR DESCRIPTION
## Summary
- prefer Apple Music oEmbed metadata for artwork so Apple Music links use the square cover image instead of the bordered social card
- keep the existing iTunes lookup as a fallback when oEmbed is unavailable
- add scraper regression tests for the oEmbed-first and lookup-fallback paths

Closes #49.

## Verification
- bun test tests/unit/scraper.test.ts
- bun run typecheck
- bun run test *(fails in this environment on existing SMTP socket permission and SQLite file access issues)*