### PR TITLE
feat: improve unsupported link ingestion

### DIFF
--- a/server/link-extractor.ts
+++ b/server/link-extractor.ts
@@ -1,5 +1,5 @@
 import { Mistral } from "@mistralai/mistralai";
-import type { ItemType } from "../src/types";
+import type { ItemType, LinkReleaseCandidate } from "../src/types";
 
 const DEFAULT_LINK_MODEL = "mistral-small-latest";
 const MAX_AI_TEXT_CHARS = 20_000;
@@ -7,8 +7,10 @@ const MAX_AI_TEXT_CHARS = 20_000;
 const WEB_RELEASE_PROMPT =
   "You are extracting music release data from a web page snippet. " +
   "Respond with JSON only using this shape: " +
-  '{"releases":[{"artist":"string|null","title":"string|null","itemType":"album|ep|single|track|mix|compilation|null"}]}. ' +
+  '{"releases":[{"artist":"string|null","title":"string|null","itemType":"album|ep|single|track|mix|compilation|null","confidence":"number|null","evidence":"string|null","isPrimary":"boolean|null"}]}. ' +
   "Return every distinct music release clearly described in the snippet. " +
+  "Mark isPrimary true only when the page is mainly about that one release, such as a product page or dedicated release page. " +
+  "Use evidence for a short reason like 'product title', 'headline', or 'release section'. " +
   "If a release is self-titled or has no distinct title, use the artist name as the title. " +
   "Do not invent releases. Return an empty releases array when the snippet is music-related but no concrete release can be extracted.";
 
@@ -18,9 +20,27 @@ interface TextChunkLike {
 }
 
 export interface ExtractedReleaseCandidate {
+  candidateId: string;
   artist?: string;
   title?: string;
   itemType?: ItemType;
+  confidence?: number;
+  evidence?: string;
+  isPrimary?: boolean;
+}
+
+function slugifySegment(value: string | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+}
+
+function buildCandidateId(artist: string | undefined, title: string, index: number): string {
+  const artistPart = slugifySegment(artist) || "unknown-artist";
+  const titlePart = slugifySegment(title) || "unknown-title";
+  return `cand-${index + 1}-${artistPart}-${titlePart}`;
 }
 
 function contentToText(content: unknown): string | null {
@@ -85,7 +105,15 @@ function normalizeItemType(value: unknown): ItemType | undefined {
   }
 }
 
-function parseReleaseCandidate(value: unknown): ExtractedReleaseCandidate | null {
+function normalizeConfidence(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function parseReleaseCandidate(value: unknown, index: number): ExtractedReleaseCandidate | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -94,15 +122,22 @@ function parseReleaseCandidate(value: unknown): ExtractedReleaseCandidate | null
   const artist = normalizeNullableString(candidate.artist);
   const title = normalizeNullableString(candidate.title) ?? artist;
   const itemType = normalizeItemType(candidate.itemType);
+  const evidence = normalizeNullableString(candidate.evidence);
+  const confidence = normalizeConfidence(candidate.confidence);
+  const isPrimary = typeof candidate.isPrimary === "boolean" ? candidate.isPrimary : undefined;
 
   if (!title) {
     return null;
   }
 
   return {
-    artist,
+    candidateId: buildCandidateId(artist, title, index),
+    ...(artist ? { artist } : {}),
     title,
-    itemType,
+    ...(itemType ? { itemType } : {}),
+    ...(confidence !== undefined ? { confidence } : {}),
+    ...(evidence ? { evidence } : {}),
+    ...(isPrimary !== undefined ? { isPrimary } : {}),
   };
 }
 
@@ -126,8 +161,8 @@ export function parseReleaseCandidatesJson(rawContent: string): ExtractedRelease
     const seen = new Set<string>();
     const normalized: ExtractedReleaseCandidate[] = [];
 
-    for (const release of releases) {
-      const candidate = parseReleaseCandidate(release);
+    for (const [index, release] of releases.entries()) {
+      const candidate = parseReleaseCandidate(release, index);
       if (!candidate) {
         continue;
       }
@@ -145,6 +180,79 @@ export function parseReleaseCandidatesJson(rawContent: string): ExtractedRelease
   } catch {
     return [];
   }
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function scoreUrlMatch(urlText: string, candidate: LinkReleaseCandidate): number {
+  let score = 0;
+  const title = normalizeSearchText(candidate.title);
+  const artist = normalizeSearchText(candidate.artist ?? "");
+
+  if (title && urlText.includes(title)) {
+    score += 2.5;
+  }
+
+  if (artist && urlText.includes(artist)) {
+    score += 1.5;
+  }
+
+  const titleWords = title.split(" ").filter((word) => word.length >= 4);
+  const matchingTitleWords = titleWords.filter((word) => urlText.includes(word));
+  score += Math.min(matchingTitleWords.length * 0.35, 1.4);
+
+  return score;
+}
+
+export function pickPrimaryReleaseCandidate(
+  url: string,
+  candidates: LinkReleaseCandidate[],
+): LinkReleaseCandidate | null {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  let urlText = "";
+  try {
+    const parsed = new URL(url);
+    urlText = normalizeSearchText(`${parsed.hostname} ${parsed.pathname}`);
+  } catch {
+    urlText = normalizeSearchText(url);
+  }
+
+  const scored = candidates
+    .map((candidate) => {
+      let score = scoreUrlMatch(urlText, candidate);
+      if (candidate.isPrimary) {
+        score += 3;
+      }
+      if (candidate.confidence !== undefined) {
+        score += candidate.confidence;
+      }
+      return { candidate, score };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const best = scored[0];
+  const second = scored[1];
+  if (!best) {
+    return null;
+  }
+
+  const scoreGap = second ? best.score - second.score : best.score;
+  const hasStrongUrlSignal = scoreUrlMatch(urlText, best.candidate) >= 2.5;
+  const hasExplicitPrimarySignal = best.candidate.isPrimary === true;
+
+  if ((hasStrongUrlSignal || hasExplicitPrimarySignal) && scoreGap >= 1.25) {
+    return best.candidate;
+  }
+
+  return null;
 }
 
 export async function extractReleaseCandidatesFromWebText(

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -2,8 +2,15 @@ import { eq, and } from "drizzle-orm";
 import { db } from "./db/index";
 import { musicItems, artists, musicLinks, sources, musicItemStacks, stacks } from "./db/schema";
 import { parseUrl, isValidUrl, normalize, capitalize } from "./utils";
-import { scrapeUrl } from "./scraper";
-import type { CreateMusicItemInput, MusicItemFull } from "../src/types";
+import { scrapeUrl, UnsupportedMusicLinkError } from "./scraper";
+import { pickPrimaryReleaseCandidate } from "./link-extractor";
+import type {
+  AmbiguousLinkPayload,
+  CreateMusicItemInput,
+  ItemType,
+  LinkReleaseCandidate,
+  MusicItemFull,
+} from "../src/types";
 
 // ---------------------------------------------------------------------------
 // Helpers (moved from routes/music-items.ts for shared use)
@@ -115,6 +122,239 @@ export interface CreateResult {
   created: boolean;
 }
 
+interface ReleaseCandidateInput {
+  candidateId?: string;
+  title: string;
+  artistName?: string;
+  itemType: ItemType;
+  artworkUrl?: string | null;
+  confidence?: number;
+  evidence?: string;
+  isPrimary?: boolean;
+}
+
+export class AmbiguousLinkSelectionError extends Error {
+  payload: AmbiguousLinkPayload;
+
+  constructor(payload: AmbiguousLinkPayload) {
+    super(payload.message);
+    this.name = "AmbiguousLinkSelectionError";
+    this.payload = payload;
+  }
+}
+
+function toReleaseCandidate(input: ReleaseCandidateInput): LinkReleaseCandidate {
+  return {
+    candidateId: input.candidateId ?? `${normalize(input.title)}`,
+    artist: input.artistName,
+    title: input.title,
+    itemType: input.itemType,
+    confidence: input.confidence,
+    evidence: input.evidence,
+    isPrimary: input.isPrimary,
+  };
+}
+
+function matchExistingItem(
+  items: MusicItemFull[],
+  candidate: ReleaseCandidateInput,
+): MusicItemFull | null {
+  const normalizedTitle = normalize(candidate.title);
+  const normalizedArtist = candidate.artistName ? normalize(candidate.artistName) : null;
+
+  for (const item of items) {
+    if (item.normalized_title !== normalizedTitle) {
+      continue;
+    }
+
+    const itemArtist = item.artist_name ? normalize(item.artist_name) : null;
+    if (normalizedArtist !== itemArtist) {
+      continue;
+    }
+
+    return item;
+  }
+
+  return null;
+}
+
+async function fetchItemsByUrl(url: string): Promise<MusicItemFull[]> {
+  const rows = await db
+    .select({ musicItemId: musicLinks.musicItemId })
+    .from(musicLinks)
+    .where(eq(musicLinks.url, url));
+
+  const items = await Promise.all(rows.map((row) => fetchFullItem(row.musicItemId)));
+  return items.filter((item): item is MusicItemFull => item !== null);
+}
+
+async function insertMusicItemWithLink(
+  normalizedUrl: string,
+  sourceName: string,
+  candidate: ReleaseCandidateInput,
+  overrides?: Partial<CreateMusicItemInput>,
+): Promise<MusicItemFull> {
+  let artistId: number | null = null;
+  if (candidate.artistName) {
+    artistId = await getOrCreateArtist(candidate.artistName);
+  }
+
+  const sourceId = await getSourceId(sourceName);
+
+  const [inserted] = await db
+    .insert(musicItems)
+    .values({
+      title: capitalize(candidate.title),
+      normalizedTitle: normalize(candidate.title),
+      itemType: candidate.itemType,
+      artistId,
+      listenStatus: overrides?.listenStatus ?? "to-listen",
+      purchaseIntent: overrides?.purchaseIntent ?? "no",
+      notes: overrides?.notes ?? null,
+      artworkUrl: overrides?.artworkUrl ?? candidate.artworkUrl ?? null,
+      label: overrides?.label ?? null,
+      year: overrides?.year ?? null,
+      country: overrides?.country ?? null,
+      genre: overrides?.genre ?? null,
+      catalogueNumber: overrides?.catalogueNumber ?? null,
+      musicbrainzReleaseId: overrides?.musicbrainzReleaseId ?? null,
+      musicbrainzArtistId: overrides?.musicbrainzArtistId ?? null,
+    })
+    .returning({ id: musicItems.id });
+
+  await db.insert(musicLinks).values({
+    musicItemId: inserted.id,
+    sourceId,
+    url: normalizedUrl,
+    isPrimary: true,
+  });
+
+  const item = await fetchFullItem(inserted.id);
+  if (!item) {
+    throw new Error("Failed to fetch created item");
+  }
+
+  return item;
+}
+
+function resolveSelectedCandidate(
+  candidates: ReleaseCandidateInput[],
+  selectedCandidateId: string | undefined,
+): ReleaseCandidateInput | null {
+  if (!selectedCandidateId) {
+    return null;
+  }
+
+  return candidates.find((candidate) => candidate.candidateId === selectedCandidateId) ?? null;
+}
+
+async function resolveReleaseCandidates(
+  normalizedUrl: string,
+  overrides?: Partial<CreateMusicItemInput>,
+): Promise<{
+  normalizedUrl: string;
+  source: ReturnType<typeof parseUrl>["source"];
+  candidates: ReleaseCandidateInput[];
+}> {
+  const parsed = parseUrl(normalizedUrl);
+  const scraped = await scrapeUrl(parsed.normalizedUrl, parsed.source);
+
+  if (parsed.source !== "unknown") {
+    const title =
+      overrides?.title || scraped?.potentialTitle || parsed.potentialTitle || "Untitled";
+    const artistName = overrides?.artistName || scraped?.potentialArtist || parsed.potentialArtist;
+
+    return {
+      normalizedUrl: parsed.normalizedUrl,
+      source: parsed.source,
+      candidates: [
+        {
+          title,
+          artistName,
+          itemType: overrides?.itemType ?? scraped?.itemType ?? "album",
+          artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
+        },
+      ],
+    };
+  }
+
+  const extractedCandidates =
+    scraped?.releases?.map((release) => ({
+      candidateId: release.candidateId,
+      title: release.title || "Untitled",
+      artistName: release.artist,
+      itemType: release.itemType ?? "album",
+      artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
+      confidence: release.confidence,
+      evidence: release.evidence,
+      isPrimary: release.isPrimary,
+    })) ?? [];
+
+  if (extractedCandidates.length === 0) {
+    throw new UnsupportedMusicLinkError("Couldn't extract a release from this link");
+  }
+
+  const selectedCandidate = resolveSelectedCandidate(
+    extractedCandidates,
+    overrides?.selectedCandidateId,
+  );
+
+  if (selectedCandidate) {
+    return {
+      normalizedUrl: parsed.normalizedUrl,
+      source: parsed.source,
+      candidates: [
+        {
+          ...selectedCandidate,
+          title: overrides?.title || selectedCandidate.title,
+          artistName: overrides?.artistName || selectedCandidate.artistName,
+          itemType: overrides?.itemType ?? selectedCandidate.itemType,
+        },
+      ],
+    };
+  }
+
+  if (overrides?.title?.trim()) {
+    return {
+      normalizedUrl: parsed.normalizedUrl,
+      source: parsed.source,
+      candidates: [
+        {
+          title: overrides.title.trim(),
+          artistName: overrides.artistName?.trim() || undefined,
+          itemType: overrides.itemType ?? "album",
+          artworkUrl: overrides.artworkUrl ?? scraped?.imageUrl ?? null,
+        },
+      ],
+    };
+  }
+
+  const primaryCandidate = pickPrimaryReleaseCandidate(
+    parsed.normalizedUrl,
+    extractedCandidates.map(toReleaseCandidate),
+  );
+
+  if (primaryCandidate) {
+    const chosen = extractedCandidates.find(
+      (candidate) => candidate.candidateId === primaryCandidate.candidateId,
+    );
+    if (chosen) {
+      return {
+        normalizedUrl: parsed.normalizedUrl,
+        source: parsed.source,
+        candidates: [chosen],
+      };
+    }
+  }
+
+  throw new AmbiguousLinkSelectionError({
+    kind: "ambiguous_link",
+    url: parsed.normalizedUrl,
+    message: "This link mentions several releases. Pick one to add.",
+    candidates: extractedCandidates.map(toReleaseCandidate),
+  });
+}
+
 /**
  * Create a music item from a URL. Handles URL parsing, OG scraping,
  * artist resolution, and duplicate detection.
@@ -125,88 +365,54 @@ export async function createMusicItemFromUrl(
   url: string,
   overrides?: Partial<CreateMusicItemInput>,
 ): Promise<CreateResult> {
-  if (!isValidUrl(url)) {
-    throw new Error("Invalid URL");
+  const results = await createMusicItemsFromUrl(url, overrides);
+  const preferred = results.find((result) => result.created) ?? results[0];
+  if (!preferred) {
+    throw new Error("Failed to create music item");
   }
 
-  const parsed = parseUrl(url);
-
-  // Check for duplicate URL
-  const existing = await db
-    .select({ musicItemId: musicLinks.musicItemId })
-    .from(musicLinks)
-    .where(eq(musicLinks.url, parsed.normalizedUrl))
-    .limit(1);
-
-  if (existing[0]) {
-    const item = await fetchFullItem(existing[0].musicItemId);
-    if (item) {
-      return { item, created: false };
-    }
-  }
-
-  // Scrape OG metadata
-  const scraped = await scrapeUrl(parsed.normalizedUrl, parsed.source);
-
-  // Merge: overrides > scraped > regex-extracted > defaults
-  const title = overrides?.title || scraped?.potentialTitle || parsed.potentialTitle || "Untitled";
-  const artistName = overrides?.artistName || scraped?.potentialArtist || parsed.potentialArtist;
-
-  // Get or create artist
-  let artistId: number | null = null;
-  if (artistName) {
-    artistId = await getOrCreateArtist(artistName);
-  }
-
-  // Resolve source
-  const sourceId = await getSourceId(parsed.source);
-
-  // Insert music item
-  const [inserted] = await db
-    .insert(musicItems)
-    .values({
-      title: capitalize(title),
-      normalizedTitle: normalize(title),
-      itemType: overrides?.itemType ?? "album",
-      artistId,
-      listenStatus: overrides?.listenStatus ?? "to-listen",
-      purchaseIntent: overrides?.purchaseIntent ?? "no",
-      notes: overrides?.notes ?? null,
-      artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
-      label: overrides?.label ?? null,
-      year: overrides?.year ?? null,
-      country: overrides?.country ?? null,
-      genre: overrides?.genre ?? null,
-      catalogueNumber: overrides?.catalogueNumber ?? null,
-    })
-    .returning({ id: musicItems.id });
-
-  // Insert primary link
-  await db.insert(musicLinks).values({
-    musicItemId: inserted.id,
-    sourceId,
-    url: parsed.normalizedUrl,
-    isPrimary: true,
-  });
-
-  const item = await fetchFullItem(inserted.id);
-  if (!item) {
-    throw new Error("Failed to fetch created item");
-  }
-
-  return { item, created: true };
+  return preferred;
 }
 
 /**
  * Create music items from a URL, returning results as an array.
- * Wraps createMusicItemFromUrl for callers that expect multiple results.
  */
 export async function createMusicItemsFromUrl(
   url: string,
   overrides?: Partial<CreateMusicItemInput>,
 ): Promise<CreateResult[]> {
-  const result = await createMusicItemFromUrl(url, overrides);
-  return [result];
+  if (!isValidUrl(url)) {
+    throw new Error("Invalid URL");
+  }
+
+  const parsed = parseUrl(url);
+  const resolved = await resolveReleaseCandidates(parsed.normalizedUrl, overrides);
+  const existingItems = await fetchItemsByUrl(resolved.normalizedUrl);
+
+  if (resolved.source !== "unknown" && existingItems[0]) {
+    return [{ item: existingItems[0], created: false }];
+  }
+
+  const results: CreateResult[] = [];
+
+  for (const candidate of resolved.candidates) {
+    const existing = matchExistingItem(existingItems, candidate);
+    if (existing) {
+      results.push({ item: existing, created: false });
+      continue;
+    }
+
+    const item = await insertMusicItemWithLink(
+      resolved.normalizedUrl,
+      resolved.source,
+      candidate,
+      overrides,
+    );
+    existingItems.push(item);
+    results.push({ item, created: true });
+  }
+
+  return results;
 }
 
 /**
@@ -240,6 +446,8 @@ export async function createMusicItemDirect(
       country: overrides.country ?? null,
       genre: overrides.genre ?? null,
       catalogueNumber: overrides.catalogueNumber ?? null,
+      musicbrainzReleaseId: overrides.musicbrainzReleaseId ?? null,
+      musicbrainzArtistId: overrides.musicbrainzArtistId ?? null,
     })
     .returning({ id: musicItems.id });
 

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -307,6 +307,33 @@ function renderMainPage(opts: {
           </div>
         </section>
       </main>
+      <div id="link-picker-modal" class="link-picker" hidden>
+        <div class="link-picker__backdrop" data-link-picker-close="true"></div>
+        <div
+          class="link-picker__dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="link-picker-title"
+        >
+          <div class="link-picker__header">
+            <h2 id="link-picker-title">Pick a release</h2>
+            <p id="link-picker-message">
+              This link mentions several releases. Choose one to add.
+            </p>
+            <p id="link-picker-url" class="link-picker__url"></p>
+          </div>
+          <div id="link-picker-list" class="link-picker__list"></div>
+          <div class="link-picker__actions">
+            <button type="button" id="link-picker-cancel" class="btn btn--ghost">Cancel</button>
+            <button type="button" id="link-picker-manual" class="btn btn--ghost">
+              Enter manually
+            </button>
+            <button type="button" id="link-picker-submit" class="btn btn--primary" disabled>
+              Add selected
+            </button>
+          </div>
+        </div>
+      </div>
       <footer class="footer">
         <span id="app-version">v${escapeHtml(opts.appVersion)}</span>
       </footer>

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -12,6 +12,7 @@ import {
 import { isValidUrl, normalize } from "../utils";
 import { applyOrder, buildContextKey } from "../../shared/music-list-context";
 import {
+  AmbiguousLinkSelectionError,
   fullItemSelect,
   fetchFullItem,
   getOrCreateArtist,
@@ -276,6 +277,10 @@ musicItemRoutes.post("/", async (c) => {
     }
     return c.json(result.item, 201);
   } catch (err) {
+    if (err instanceof AmbiguousLinkSelectionError) {
+      return c.json(err.payload, 409);
+    }
+
     if (err instanceof UnsupportedMusicLinkError) {
       return c.json({ error: err.message }, 400);
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,16 @@
-import { ApiClient } from "./services/api-client";
+import { AmbiguousLinkApiError, ApiClient } from "./services/api-client";
 import Sortable from "sortablejs";
-import type { ListenStatus, StackWithCount } from "./types";
+import type { AddFormValues as AddFormValuesInput } from "./ui/domain/add-form";
+import type {
+  AmbiguousLinkPayload,
+  LinkReleaseCandidate,
+  ListenStatus,
+  StackWithCount,
+} from "./types";
 import {
   buildCreateMusicItemInputFromValues,
   getCoverScanErrorMessage,
 } from "./ui/domain/add-form";
-import type { AddFormValues } from "./ui/domain/add-form";
 import { buildContextKey, buildMusicItemFilters } from "./ui/domain/music-list";
 import { constrainDimensions } from "./ui/domain/scan";
 import {
@@ -20,6 +25,7 @@ import { initialAddFormState, transitionAddFormState } from "./ui/state/add-form
 import { initialAppState, transitionAppState } from "./ui/state/app-machine";
 import {
   renderAddFormStackChips,
+  renderAmbiguousLinkCandidates,
   renderMusicList,
   renderStackDropdownContent,
   renderStackManageList,
@@ -40,6 +46,14 @@ interface StackDropdownOptions {
   shouldIgnoreOutsideClick?: (target: HTMLElement) => boolean;
 }
 
+interface LinkPickerState {
+  url: string;
+  message: string;
+  values: AddFormValuesInput;
+  candidates: LinkReleaseCandidate[];
+  selectedCandidateId: string | null;
+}
+
 export class App {
   private api: ApiClient;
   private appState = initialAppState;
@@ -54,6 +68,7 @@ export class App {
   private activeStackDropdownCleanup: ((skipOnClose?: boolean) => void) | null = null;
   private musicListSortable: Sortable | null = null;
   private isReordering = false;
+  private linkPickerState: LinkPickerState | null = null;
 
   constructor() {
     this.api = new ApiClient();
@@ -94,6 +109,7 @@ export class App {
     this.setupStackBar();
     this.setupStackManagePanel();
     this.setupStackParentLinker();
+    this.setupLinkPicker();
     this.setupEventDelegation();
     this.setupMusicListReorder();
     this.setupCustomListScrollbar();
@@ -197,66 +213,8 @@ export class App {
         return;
       }
 
-      const formData = new FormData(form);
-      const values = this.readAddFormValues(formData);
-      let mbReleaseId: string | undefined;
-      let mbArtistId: string | undefined;
-
-      if (values.artist.trim() && values.title.trim()) {
-        try {
-          const enrichment = await this.api.lookupRelease(
-            values.artist.trim(),
-            values.title.trim(),
-            values.year.trim() || undefined,
-          );
-
-          if (enrichment.year != null && !values.year.trim()) {
-            values.year = String(enrichment.year);
-          }
-          if (enrichment.label && !values.label.trim()) {
-            values.label = enrichment.label;
-          }
-          if (enrichment.country && !values.country.trim()) {
-            values.country = enrichment.country;
-          }
-          if (enrichment.catalogueNumber && !values.catalogueNumber.trim()) {
-            values.catalogueNumber = enrichment.catalogueNumber;
-          }
-          if (enrichment.artworkUrl && !values.artworkUrl.trim()) {
-            values.artworkUrl = enrichment.artworkUrl;
-          }
-          if (enrichment.musicbrainzReleaseId) {
-            mbReleaseId = enrichment.musicbrainzReleaseId;
-          }
-          if (enrichment.musicbrainzArtistId) {
-            mbArtistId = enrichment.musicbrainzArtistId;
-          }
-        } catch {
-          // non-fatal: enrichment failure does not block saving
-        }
-      }
-
       try {
-        const item = await this.api.createMusicItem({
-          ...buildCreateMusicItemInputFromValues(values),
-          listenStatus: "to-listen",
-          musicbrainzReleaseId: mbReleaseId,
-          musicbrainzArtistId: mbArtistId,
-        });
-
-        if (this.addFormState.selectedStackIds.length > 0) {
-          await this.api.setItemStacks(item.id, this.addFormState.selectedStackIds);
-          this.addFormState = transitionAddFormState(this.addFormState, { type: "CLEAR_STACKS" });
-          this.renderAddFormStackChips();
-          await this.renderStackBar();
-        }
-
-        form.reset();
-        const secondary = form.querySelector<HTMLElement>(".add-form__secondary");
-        if (secondary) secondary.hidden = true;
-        if (this.shouldRefreshListAfterAdd()) {
-          await this.renderMusicList();
-        }
+        await this.createItemFromValues(this.readAddFormValues(new FormData(form)), form);
       } catch (error) {
         console.error("Failed to add item:", error);
         alert("Failed to add item. Please try again.");
@@ -264,7 +222,7 @@ export class App {
     });
   }
 
-  private readAddFormValues(formData: FormData): AddFormValues {
+  private readAddFormValues(formData: FormData): AddFormValuesInput {
     return {
       url: this.readStringField(formData, "url"),
       title: this.readStringField(formData, "title"),
@@ -283,6 +241,293 @@ export class App {
   private readStringField(formData: FormData, name: string): string {
     const value = formData.get(name);
     return typeof value === "string" ? value : "";
+  }
+
+  private async enrichValuesWithMusicBrainz(values: AddFormValuesInput): Promise<{
+    values: AddFormValuesInput;
+    musicbrainzReleaseId?: string;
+    musicbrainzArtistId?: string;
+  }> {
+    let mbReleaseId: string | undefined;
+    let mbArtistId: string | undefined;
+
+    if (values.artist.trim() && values.title.trim()) {
+      try {
+        const enrichment = await this.api.lookupRelease(
+          values.artist.trim(),
+          values.title.trim(),
+          values.year.trim() || undefined,
+        );
+
+        if (enrichment.year != null && !values.year.trim()) {
+          values.year = String(enrichment.year);
+        }
+        if (enrichment.label && !values.label.trim()) {
+          values.label = enrichment.label;
+        }
+        if (enrichment.country && !values.country.trim()) {
+          values.country = enrichment.country;
+        }
+        if (enrichment.catalogueNumber && !values.catalogueNumber.trim()) {
+          values.catalogueNumber = enrichment.catalogueNumber;
+        }
+        if (enrichment.artworkUrl && !values.artworkUrl.trim()) {
+          values.artworkUrl = enrichment.artworkUrl;
+        }
+        if (enrichment.musicbrainzReleaseId) {
+          mbReleaseId = enrichment.musicbrainzReleaseId;
+        }
+        if (enrichment.musicbrainzArtistId) {
+          mbArtistId = enrichment.musicbrainzArtistId;
+        }
+      } catch {
+        // non-fatal: enrichment failure does not block saving
+      }
+    }
+
+    return {
+      values,
+      musicbrainzReleaseId: mbReleaseId,
+      musicbrainzArtistId: mbArtistId,
+    };
+  }
+
+  private async createItemFromValues(
+    rawValues: AddFormValuesInput,
+    form: HTMLFormElement,
+    options?: { selectedCandidateId?: string },
+  ): Promise<void> {
+    const values = { ...rawValues };
+    const enriched = await this.enrichValuesWithMusicBrainz(values);
+
+    try {
+      const item = await this.api.createMusicItem({
+        ...buildCreateMusicItemInputFromValues(enriched.values),
+        listenStatus: "to-listen",
+        musicbrainzReleaseId: enriched.musicbrainzReleaseId,
+        musicbrainzArtistId: enriched.musicbrainzArtistId,
+        selectedCandidateId: options?.selectedCandidateId,
+      });
+
+      await this.handleCreatedItem(item.id, form);
+      this.closeLinkPicker();
+    } catch (error) {
+      if (error instanceof AmbiguousLinkApiError) {
+        this.openLinkPicker(error.payload, rawValues);
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private async handleCreatedItem(itemId: number, form: HTMLFormElement): Promise<void> {
+    if (this.addFormState.selectedStackIds.length > 0) {
+      await this.api.setItemStacks(itemId, this.addFormState.selectedStackIds);
+      this.addFormState = transitionAddFormState(this.addFormState, { type: "CLEAR_STACKS" });
+      this.renderAddFormStackChips();
+      await this.renderStackBar();
+    }
+
+    form.reset();
+    const secondary = form.querySelector<HTMLElement>(".add-form__secondary");
+    if (secondary) secondary.hidden = true;
+    if (this.shouldRefreshListAfterAdd()) {
+      await this.renderMusicList();
+    }
+  }
+
+  private setupLinkPicker(): void {
+    const modal = document.getElementById("link-picker-modal");
+    const list = document.getElementById("link-picker-list");
+    const submit = document.getElementById("link-picker-submit");
+    const manual = document.getElementById("link-picker-manual");
+    const cancel = document.getElementById("link-picker-cancel");
+
+    if (
+      !(modal instanceof HTMLElement) ||
+      !(list instanceof HTMLElement) ||
+      !(submit instanceof HTMLButtonElement) ||
+      !(manual instanceof HTMLButtonElement) ||
+      !(cancel instanceof HTMLButtonElement)
+    ) {
+      return;
+    }
+
+    list.addEventListener("click", (event) => {
+      const target = (event.target as HTMLElement).closest(
+        "[data-candidate-id]",
+      ) as HTMLElement | null;
+      if (!target || !this.linkPickerState) {
+        return;
+      }
+
+      this.linkPickerState = {
+        ...this.linkPickerState,
+        selectedCandidateId: target.dataset.candidateId ?? null,
+      };
+      this.renderLinkPicker();
+    });
+
+    submit.addEventListener("click", () => {
+      void this.submitSelectedLinkCandidate();
+    });
+
+    manual.addEventListener("click", () => {
+      this.enterSelectedCandidateManually();
+    });
+
+    cancel.addEventListener("click", () => {
+      this.closeLinkPicker();
+    });
+
+    modal.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (target.dataset.linkPickerClose === "true") {
+        this.closeLinkPicker();
+      }
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && this.linkPickerState) {
+        this.closeLinkPicker();
+      }
+    });
+  }
+
+  private openLinkPicker(payload: AmbiguousLinkPayload, values: AddFormValuesInput): void {
+    this.linkPickerState = {
+      url: payload.url,
+      message: payload.message,
+      values: { ...values },
+      candidates: payload.candidates,
+      selectedCandidateId: null,
+    };
+    this.renderLinkPicker();
+  }
+
+  private closeLinkPicker(): void {
+    this.linkPickerState = null;
+    const modal = document.getElementById("link-picker-modal");
+    if (modal instanceof HTMLElement) {
+      modal.hidden = true;
+    }
+  }
+
+  private renderLinkPicker(): void {
+    const modal = document.getElementById("link-picker-modal");
+    const list = document.getElementById("link-picker-list");
+    const url = document.getElementById("link-picker-url");
+    const message = document.getElementById("link-picker-message");
+    const submit = document.getElementById("link-picker-submit");
+
+    if (
+      !(modal instanceof HTMLElement) ||
+      !(list instanceof HTMLElement) ||
+      !(url instanceof HTMLElement) ||
+      !(message instanceof HTMLElement) ||
+      !(submit instanceof HTMLButtonElement)
+    ) {
+      return;
+    }
+
+    if (!this.linkPickerState) {
+      modal.hidden = true;
+      return;
+    }
+
+    modal.hidden = false;
+    url.textContent = this.linkPickerState.url;
+    message.textContent = this.linkPickerState.message;
+    list.innerHTML = renderAmbiguousLinkCandidates(
+      this.linkPickerState.candidates,
+      this.linkPickerState.selectedCandidateId,
+    );
+    submit.disabled = !this.linkPickerState.selectedCandidateId;
+  }
+
+  private findSelectedLinkCandidate(): LinkReleaseCandidate | null {
+    if (!this.linkPickerState?.selectedCandidateId) {
+      return null;
+    }
+
+    return (
+      this.linkPickerState.candidates.find(
+        (candidate) => candidate.candidateId === this.linkPickerState?.selectedCandidateId,
+      ) ?? null
+    );
+  }
+
+  private buildValuesForSelectedCandidate(
+    values: AddFormValuesInput,
+    candidate: LinkReleaseCandidate,
+  ): AddFormValuesInput {
+    return {
+      ...values,
+      artist: candidate.artist ?? values.artist,
+      title: candidate.title || values.title,
+      itemType: candidate.itemType ?? values.itemType,
+    };
+  }
+
+  private enterSelectedCandidateManually(): void {
+    const form = document.getElementById("add-form");
+    if (!(form instanceof HTMLFormElement) || !this.linkPickerState) {
+      return;
+    }
+
+    const selectedCandidate = this.findSelectedLinkCandidate();
+    if (selectedCandidate) {
+      this.populateAddFormFromCandidate(selectedCandidate);
+    }
+
+    const secondary = form.querySelector<HTMLElement>(".add-form__secondary");
+    if (secondary) {
+      secondary.hidden = false;
+    }
+
+    this.closeLinkPicker();
+    form.querySelector<HTMLInputElement>('input[name="artist"]')?.focus();
+  }
+
+  private populateAddFormFromCandidate(candidate: LinkReleaseCandidate): void {
+    const artistInput = document.querySelector<HTMLInputElement>('#add-form input[name="artist"]');
+    const titleInput = document.querySelector<HTMLInputElement>('#add-form input[name="title"]');
+    const itemTypeInput = document.querySelector<HTMLSelectElement>(
+      '#add-form select[name="itemType"]',
+    );
+
+    if (artistInput && candidate.artist) {
+      artistInput.value = candidate.artist;
+    }
+
+    if (titleInput) {
+      titleInput.value = candidate.title;
+    }
+
+    if (itemTypeInput && candidate.itemType) {
+      itemTypeInput.value = candidate.itemType;
+    }
+  }
+
+  private async submitSelectedLinkCandidate(): Promise<void> {
+    const form = document.getElementById("add-form");
+    if (!(form instanceof HTMLFormElement) || !this.linkPickerState?.selectedCandidateId) {
+      return;
+    }
+
+    const selectedCandidate = this.findSelectedLinkCandidate();
+    if (!selectedCandidate) {
+      return;
+    }
+
+    const values = this.buildValuesForSelectedCandidate(
+      this.linkPickerState.values,
+      selectedCandidate,
+    );
+    await this.createItemFromValues(values, form, {
+      selectedCandidateId: selectedCandidate.candidateId,
+    });
   }
 
   private shouldRefreshListAfterAdd(): boolean {

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -1,4 +1,5 @@
 import type {
+  AmbiguousLinkPayload,
   CreateMusicItemInput,
   UpdateMusicItemInput,
   MusicItemFull,
@@ -11,6 +12,16 @@ import type {
   UploadImageResult,
   LookupReleaseResult,
 } from "../types";
+
+export class AmbiguousLinkApiError extends Error {
+  payload: AmbiguousLinkPayload;
+
+  constructor(payload: AmbiguousLinkPayload) {
+    super(payload.message);
+    this.name = "AmbiguousLinkApiError";
+    this.payload = payload;
+  }
+}
 
 export class ApiClient {
   constructor(private baseUrl: string = "") {}
@@ -66,11 +77,26 @@ export class ApiClient {
   // ── Music Items ──────────────────────────────────────────────
 
   async createMusicItem(input: CreateMusicItemInput): Promise<MusicItemFull> {
-    return this.requestJson<MusicItemFull>(
-      "/api/music-items",
-      "createMusicItem",
+    const response = await fetch(
+      this.buildUrl("/api/music-items"),
       this.jsonRequest("POST", input),
     );
+    if (response.status === 409) {
+      const body = (await response.json()) as Partial<AmbiguousLinkPayload>;
+      if (
+        body.kind === "ambiguous_link" &&
+        typeof body.url === "string" &&
+        Array.isArray(body.candidates)
+      ) {
+        throw new AmbiguousLinkApiError(body as AmbiguousLinkPayload);
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(`createMusicItem failed: ${response.status}`);
+    }
+
+    return (await response.json()) as MusicItemFull;
   }
 
   async getMusicItem(id: number): Promise<MusicItemFull | null> {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1491,6 +1491,124 @@ a:hover {
     font-size: 11px;
 }
 
+.link-picker {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+}
+
+.link-picker[hidden] {
+    display: none;
+}
+
+.link-picker__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgb(4 8 20 / 48%);
+}
+
+.link-picker__dialog {
+    position: relative;
+    z-index: 1;
+    width: min(640px, calc(100vw - 24px));
+    max-height: min(78vh, 720px);
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 12px;
+    background: var(--chrome);
+    border-width: 2px;
+    border-style: solid;
+    border-color: var(--chrome-white) var(--chrome-darker) var(--chrome-darker)
+        var(--chrome-white);
+    box-shadow: 6px 6px 0 rgb(0 0 0 / 25%);
+}
+
+.link-picker__header {
+    display: grid;
+    gap: 6px;
+}
+
+.link-picker__header h2 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.link-picker__header p {
+    margin: 0;
+    font-size: 11px;
+}
+
+.link-picker__url {
+    overflow-wrap: anywhere;
+    color: var(--chrome-darker);
+}
+
+.link-picker__list {
+    display: grid;
+    gap: 8px;
+    overflow: auto;
+    padding-right: 4px;
+}
+
+.link-picker__candidate {
+    width: 100%;
+    display: grid;
+    gap: 6px;
+    justify-items: start;
+    padding: 10px;
+    text-align: left;
+    background: #ffffff;
+    border-width: 2px;
+    border-style: solid;
+    border-color: var(--chrome-dark) var(--chrome-white) var(--chrome-white)
+        var(--chrome-dark);
+}
+
+.link-picker__candidate:hover {
+    background: #f6f7fc;
+}
+
+.link-picker__candidate.is-selected {
+    background: #dfe8ff;
+    border-color: #123a7a #6e99d8 #6e99d8 #123a7a;
+}
+
+.link-picker__candidate-main {
+    display: grid;
+    gap: 2px;
+}
+
+.link-picker__candidate-title {
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.link-picker__candidate-artist {
+    font-size: 11px;
+}
+
+.link-picker__candidate-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.link-picker__candidate-evidence {
+    font-size: 10px;
+    color: var(--chrome-darker);
+}
+
+.link-picker__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
 /* ═══════════════════════════════════════════════════
    FOOTER — Status bar (inside window)
 ═══════════════════════════════════════════════════ */
@@ -1583,6 +1701,9 @@ body::after {
 /* Widen the app window on the release page so artwork can be large */
 .release-page-body {
     max-width: 650px;
+    height: auto;
+    max-height: none;
+    overflow: visible;
 }
 
 @media (min-width: 1180px) {
@@ -1596,6 +1717,10 @@ body::after {
 .release-page-body .main {
     position: relative;
     z-index: 1;
+}
+
+.release-page-body .main {
+    flex: 0 0 auto;
 }
 
 .release-page {
@@ -1625,8 +1750,11 @@ body::after {
 
 .release-page__artwork {
     display: block;
-    width: 100%;
+    width: auto;
+    max-width: min(100%, clamp(250px, calc(100vh - 335px), 480px));
+    max-height: clamp(250px, calc(100vh - 335px), 480px);
     height: auto;
+    margin: 0 auto;
     border: 2px solid var(--chrome-dark);
     border-color: var(--chrome-dark) var(--chrome-white) var(--chrome-white)
         var(--chrome-dark);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,7 @@ export interface CreateMusicItemInput {
   catalogueNumber?: string;
   musicbrainzReleaseId?: string;
   musicbrainzArtistId?: string;
+  selectedCandidateId?: string;
 }
 
 export interface UpdateMusicItemInput {
@@ -153,6 +154,23 @@ export interface LookupReleaseResult {
   musicbrainzReleaseId?: string | null;
   musicbrainzArtistId?: string | null;
   artworkUrl?: string;
+}
+
+export interface LinkReleaseCandidate {
+  candidateId: string;
+  artist?: string;
+  title: string;
+  itemType?: ItemType;
+  confidence?: number;
+  evidence?: string;
+  isPrimary?: boolean;
+}
+
+export interface AmbiguousLinkPayload {
+  kind: "ambiguous_link";
+  url: string;
+  message: string;
+  candidates: LinkReleaseCandidate[];
 }
 
 // Stacks

--- a/src/ui/view/templates.ts
+++ b/src/ui/view/templates.ts
@@ -1,4 +1,4 @@
-import type { MusicItemFull, StackWithCount } from "../../types";
+import type { LinkReleaseCandidate, MusicItemFull, StackWithCount } from "../../types";
 import { renderStarRatingControl } from "../components/star-rating";
 import type { FilterSelection } from "../domain/music-list";
 import { getEmptyStateMessage } from "../domain/music-list";
@@ -198,6 +198,47 @@ export function renderStackDropdownContent(
              placeholder="New stack...">
     </div>
   `;
+}
+
+export function renderAmbiguousLinkCandidates(
+  candidates: LinkReleaseCandidate[],
+  selectedCandidateId: string | null,
+): string {
+  return candidates
+    .map((candidate) => {
+      const isSelected = candidate.candidateId === selectedCandidateId;
+      return `
+        <button
+          type="button"
+          class="link-picker__candidate${isSelected ? " is-selected" : ""}"
+          data-candidate-id="${escapeHtml(candidate.candidateId)}"
+          aria-pressed="${isSelected ? "true" : "false"}"
+        >
+          <span class="link-picker__candidate-main">
+            <span class="link-picker__candidate-title">${escapeHtml(candidate.title)}</span>
+            ${
+              candidate.artist
+                ? `<span class="link-picker__candidate-artist">${escapeHtml(candidate.artist)}</span>`
+                : ""
+            }
+          </span>
+          <span class="link-picker__candidate-meta">
+            ${
+              candidate.itemType
+                ? `<span class="badge badge--source">${escapeHtml(candidate.itemType)}</span>`
+                : ""
+            }
+            ${candidate.isPrimary ? `<span class="badge badge--source">primary</span>` : ""}
+          </span>
+          ${
+            candidate.evidence
+              ? `<span class="link-picker__candidate-evidence">${escapeHtml(candidate.evidence)}</span>`
+              : ""
+          }
+        </button>
+      `;
+    })
+    .join("");
 }
 
 export function renderStarRating(itemId: number, rating: number | null, cssClass?: string): string {

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { AmbiguousLinkApiError, ApiClient } from "../../src/services/api-client";
+
+describe("ApiClient.createMusicItem", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("throws AmbiguousLinkApiError when the server returns ambiguous link candidates", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          kind: "ambiguous_link",
+          url: "https://example.com/newsletter",
+          message: "This link mentions several releases. Pick one to add.",
+          candidates: [
+            {
+              candidateId: "cand-1",
+              artist: "Artist One",
+              title: "Release One",
+              itemType: "album",
+            },
+          ],
+        }),
+        {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const client = new ApiClient();
+
+    let thrown: unknown;
+    try {
+      await client.createMusicItem({ url: "https://example.com/newsletter" });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AmbiguousLinkApiError);
+    expect((thrown as AmbiguousLinkApiError).payload).toEqual({
+      kind: "ambiguous_link",
+      url: "https://example.com/newsletter",
+      message: "This link mentions several releases. Pick one to add.",
+      candidates: [
+        {
+          candidateId: "cand-1",
+          artist: "Artist One",
+          title: "Release One",
+          itemType: "album",
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/link-extractor.test.ts
+++ b/tests/unit/link-extractor.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { parseReleaseCandidatesJson } from "../../server/link-extractor";
+import {
+  parseReleaseCandidatesJson,
+  pickPrimaryReleaseCandidate,
+} from "../../server/link-extractor";
 
 describe("parseReleaseCandidatesJson", () => {
   test("parses multiple releases from JSON", () => {
@@ -13,8 +16,18 @@ describe("parseReleaseCandidatesJson", () => {
     `);
 
     expect(result).toEqual([
-      { artist: "Artist One", title: "First Album", itemType: "album" },
-      { artist: "Artist Two", title: "Second EP", itemType: "ep" },
+      {
+        candidateId: "cand-1-artist-one-first-album",
+        artist: "Artist One",
+        title: "First Album",
+        itemType: "album",
+      },
+      {
+        candidateId: "cand-2-artist-two-second-ep",
+        artist: "Artist Two",
+        title: "Second EP",
+        itemType: "ep",
+      },
     ]);
   });
 
@@ -27,7 +40,14 @@ describe("parseReleaseCandidatesJson", () => {
       }
     `);
 
-    expect(result).toEqual([{ artist: "Burial", title: "Burial", itemType: "album" }]);
+    expect(result).toEqual([
+      {
+        candidateId: "cand-1-burial-burial",
+        artist: "Burial",
+        title: "Burial",
+        itemType: "album",
+      },
+    ]);
   });
 
   test("deduplicates repeated releases and ignores invalid entries", () => {
@@ -41,6 +61,63 @@ describe("parseReleaseCandidatesJson", () => {
       }
     `);
 
-    expect(result).toEqual([{ artist: "Theo Parrish", title: "In Motion", itemType: "album" }]);
+    expect(result).toEqual([
+      {
+        candidateId: "cand-1-theo-parrish-in-motion",
+        artist: "Theo Parrish",
+        title: "In Motion",
+        itemType: "album",
+      },
+    ]);
+  });
+});
+
+describe("pickPrimaryReleaseCandidate", () => {
+  test("picks the obvious product-page release when url slug matches it strongly", () => {
+    const result = pickPrimaryReleaseCandidate(
+      "https://ripgrooves.com/products/katie-webster-the-swamp-boogie-queen-cd-mint-m",
+      [
+        {
+          candidateId: "cand-1",
+          artist: "Katie Webster",
+          title: "The Swamp Boogie Queen",
+          itemType: "album",
+          confidence: 0.84,
+        },
+        {
+          candidateId: "cand-2",
+          artist: "B.B. King",
+          title: "Live in Cook County Jail",
+          itemType: "album",
+          confidence: 0.41,
+        },
+      ],
+    );
+
+    expect(result?.candidateId).toBe("cand-1");
+  });
+
+  test("returns null when several releases are peer candidates", () => {
+    const result = pickPrimaryReleaseCandidate(
+      "https://mailchi.mp/27f45c3c5d8f/the-meditationsnewsletter-17475884",
+      [
+        {
+          candidateId: "cand-1",
+          artist: "Artist One",
+          title: "Release One",
+          itemType: "album",
+          confidence: 0.56,
+        },
+        {
+          candidateId: "cand-2",
+          artist: "Artist Two",
+          title: "Release Two",
+          itemType: "album",
+          confidence: 0.54,
+        },
+      ],
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -440,7 +440,12 @@ describe("scrapeUrl", () => {
     expect(result!.potentialArtist).toBe("Theo Parrish");
     expect(result!.itemType).toBe("album");
     expect(result!.releases).toEqual([
-      { artist: "Theo Parrish", title: "In Motion", itemType: "album" },
+      {
+        candidateId: "cand-1-theo-parrish-in-motion",
+        artist: "Theo Parrish",
+        title: "In Motion",
+        itemType: "album",
+      },
     ]);
     mock.restore();
     process.env = { ...originalEnv };
@@ -671,8 +676,18 @@ describe("scrapeUrl", () => {
     const result = await scrapeUrl("https://obscuremusic.example/releases", "unknown");
     expect(result).not.toBeNull();
     expect(result!.releases).toEqual([
-      { artist: "Artist One", title: "First Album", itemType: "album" },
-      { artist: "Artist Two", title: "Second EP", itemType: "ep" },
+      {
+        candidateId: "cand-1-artist-one-first-album",
+        artist: "Artist One",
+        title: "First Album",
+        itemType: "album",
+      },
+      {
+        candidateId: "cand-2-artist-two-second-ep",
+        artist: "Artist Two",
+        title: "Second EP",
+        itemType: "ep",
+      },
     ]);
     expect(result!.potentialTitle).toBe("First Album");
     expect(result!.potentialArtist).toBe("Artist One");


### PR DESCRIPTION
## Summary
- add unsupported-link extraction for unrecognized services with multi-candidate release detection
- auto-pick obvious product-page releases while surfacing ambiguous roundup pages for user choice
- add a modal picker in the add-link flow so users can select a release or switch to manual entry

## Testing
- bun run typecheck
- bun run test:unit