### PR TITLE
chore: log musicbrainz searches

### DIFF
--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -65,8 +65,16 @@ export async function lookupRelease(
   const query = queryParts.join(" ");
   const params = new URLSearchParams({ query, limit: "1", fmt: "json" });
   const url = `${MB_API_BASE}/release?${params}`;
+  const searchLog = {
+    artist,
+    title,
+    year: year ?? null,
+    query,
+  };
 
   try {
+    console.info("[musicbrainz] Searching releases", searchLog);
+
     const response = await fetch(url, {
       headers: {
         "User-Agent": USER_AGENT,
@@ -75,23 +83,25 @@ export async function lookupRelease(
     });
 
     if (!response.ok) {
-      console.warn(`[musicbrainz] Search returned ${response.status}`);
+      console.warn(`[musicbrainz] Search returned ${response.status}`, searchLog);
       return null;
     }
 
     const data = (await response.json()) as MbSearchResponse;
+    const releaseCount = Array.isArray(data.releases) ? data.releases.length : 0;
 
-    if (!Array.isArray(data.releases) || data.releases.length === 0) {
+    if (releaseCount === 0) {
+      console.info("[musicbrainz] Search returned no releases", searchLog);
       return null;
     }
 
-    const release = data.releases[0] as MbRelease;
+    const release = data.releases![0] as MbRelease;
     const { label, catalogueNumber } = parseLabelInfo(release["label-info"]);
     const country = typeof release.country === "string" ? release.country : null;
     const artistCredit = Array.isArray(release["artist-credit"]) ? release["artist-credit"] : [];
     const firstCredit = artistCredit[0] as MbArtistCredit | undefined;
 
-    return {
+    const result = {
       year: parseYear(release.date),
       label,
       country,
@@ -102,6 +112,14 @@ export async function lookupRelease(
           ? firstCredit.artist.id
           : null,
     };
+
+    console.info("[musicbrainz] Search result", {
+      ...searchLog,
+      releaseCount,
+      result,
+    });
+
+    return result;
   } catch (err) {
     console.error("[musicbrainz] Lookup failed:", err);
     return null;

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -12,6 +12,50 @@ describe("lookupRelease", () => {
     mock.restore();
   });
 
+  test("logs the search terms and parsed result", async () => {
+    const infoSpy = spyOn(console, "info").mockImplementation(() => {});
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbResponse([
+        {
+          id: "release-uuid-123",
+          date: "1997-05-21",
+          country: "GB",
+          "artist-credit": [{ artist: { id: "artist-uuid-456" } }],
+          "label-info": [
+            {
+              "catalog-number": "CDPUSH45",
+              label: { name: "Parlophone" },
+            },
+          ],
+        },
+      ]),
+    );
+
+    await lookupRelease("Radiohead", "OK Computer", "1997");
+
+    expect(infoSpy).toHaveBeenCalledWith("[musicbrainz] Searching releases", {
+      artist: "Radiohead",
+      title: "OK Computer",
+      year: "1997",
+      query: "artist:Radiohead AND release:OK Computer AND date:1997",
+    });
+    expect(infoSpy).toHaveBeenCalledWith("[musicbrainz] Search result", {
+      artist: "Radiohead",
+      title: "OK Computer",
+      year: "1997",
+      query: "artist:Radiohead AND release:OK Computer AND date:1997",
+      releaseCount: 1,
+      result: {
+        year: 1997,
+        label: "Parlophone",
+        country: "GB",
+        catalogueNumber: "CDPUSH45",
+        musicbrainzReleaseId: "release-uuid-123",
+        musicbrainzArtistId: "artist-uuid-456",
+      },
+    });
+  });
+
   test("returns parsed fields from the first matching release", async () => {
     spyOn(globalThis, "fetch").mockResolvedValueOnce(
       makeMbResponse([
@@ -41,10 +85,17 @@ describe("lookupRelease", () => {
   });
 
   test("returns null when releases array is empty", async () => {
+    const infoSpy = spyOn(console, "info").mockImplementation(() => {});
     spyOn(globalThis, "fetch").mockResolvedValueOnce(makeMbResponse([]));
 
     const result = await lookupRelease("Unknown", "Unknown");
     expect(result).toBeNull();
+    expect(infoSpy).toHaveBeenCalledWith("[musicbrainz] Search returned no releases", {
+      artist: "Unknown",
+      title: "Unknown",
+      year: null,
+      query: "artist:Unknown AND release:Unknown",
+    });
   });
 
   test("returns null on non-200 response", async () => {


### PR DESCRIPTION
## Summary
- log outbound MusicBrainz search terms before each lookup
- log explicit no-result responses and parsed result summaries
- add unit coverage for the new logging behavior

## Testing
- bun run test
- bun run test:e2e