### PR TITLE
fix: keep mobile stack bar scrollable

### DIFF
--- a/playwright/stacks.spec.ts
+++ b/playwright/stacks.spec.ts
@@ -164,4 +164,51 @@ test.describe("Stacks", () => {
       page.locator(".music-card").first().locator(".music-card__stack-chip"),
     ).toContainText("Drum and Bass");
   });
+
+  test("keeps the stack bar to two rows and scrolls on mobile when many stacks exist", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    await expect(page.getByPlaceholder("Paste a music link...")).toBeVisible();
+
+    await page.locator("#manage-stacks-btn").click();
+    await expect(page.locator(".stack-manage")).toBeVisible();
+
+    for (let index = 1; index <= 12; index += 1) {
+      await page.locator("#stack-manage-input").fill(`Long Stack ${index}`);
+      await page.locator("#stack-manage-create-btn").click();
+    }
+
+    await expect(page.locator(".stack-tab", { hasText: "Long Stack 12" })).toBeVisible();
+
+    const stackBarMetrics = await page.locator("#stack-bar").evaluate((element) => {
+      const tabs = Array.from(element.querySelectorAll(".stack-tab")).filter((tab) => {
+        const htmlTab = tab as HTMLElement;
+        return !htmlTab.hidden;
+      });
+
+      const topPositions = tabs.map((tab) => Math.round((tab as HTMLElement).getBoundingClientRect().top));
+      const rowPositions: number[] = [];
+      const rowTolerance = 4;
+
+      for (const top of topPositions.sort((left, right) => left - right)) {
+        const matchesExistingRow = rowPositions.some(
+          (rowTop) => Math.abs(rowTop - top) <= rowTolerance,
+        );
+
+        if (!matchesExistingRow) {
+          rowPositions.push(top);
+        }
+      }
+
+      return {
+        rowCount: rowPositions.length,
+        scrollsHorizontally: element.scrollWidth > element.clientWidth,
+      };
+    });
+
+    expect(stackBarMetrics.rowCount).toBeLessThanOrEqual(2);
+    expect(stackBarMetrics.scrollsHorizontally).toBe(true);
+  });
 });

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -967,6 +967,25 @@ select.input {
 }
 
 @media (max-width: 520px) {
+  .stack-bar {
+    display: grid;
+    grid-template-rows: repeat(2, auto);
+    grid-auto-flow: column;
+    grid-auto-columns: max-content;
+    align-items: end;
+    align-content: end;
+    justify-content: start;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .stack-tab--manage {
+    margin-left: 0;
+  }
+
   .add-form__primary {
     grid-template-columns: 1fr 1fr;
   }
@@ -1122,6 +1141,8 @@ select.input {
   .stack-tab {
     padding: 4px 12px 5px;
     font-size: 12px;
+    top: 0;
+    white-space: nowrap;
   }
 
   .btn {


### PR DESCRIPTION
## Summary
- keep the mobile stack bar to two rows and scroll overflow horizontally
- remove the mobile auto-push spacing on the manage button so it stays in the scrollable tab strip
- add a Playwright regression that verifies the stack bar stays within two rows and scrolls on mobile

## Testing
- bun test tests/unit
- bunx playwright test playwright/stacks.spec.ts
- full Playwright suite not completed locally in this run; pushing per user request