### PR TITLE
test: stabilize Percy MusicBrainz lookup fixture

### DIFF
--- a/playwright/ui-percy.spec.ts
+++ b/playwright/ui-percy.spec.ts
@@ -121,6 +121,33 @@ async function mockCoverScanRoutes(
   fixturePath: string,
   uploadedArtworkUrl: string,
 ): Promise<void> {
+  await page.route("**/api/release/lookup", async (route) => {
+    const request = route.request();
+    const body = request.postDataJSON();
+    const isSallyOldfieldLookup =
+      body &&
+      typeof body === "object" &&
+      body.artist === "Sally Oldfield" &&
+      body.title === "Water Bearer";
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        isSallyOldfieldLookup
+          ? {
+              year: 1978,
+              label: "Bronze",
+              country: "GB",
+              catalogueNumber: "BRON 511",
+              musicbrainzReleaseId: "b4ff2378-f836-4d22-be42-35b6bf168784",
+              musicbrainzArtistId: "d0b8d24f-a6c6-4428-b7b8-f131561d1a91",
+            }
+          : {},
+      ),
+    });
+  });
+
   await page.route("**/api/release/image", async (route) => {
     await route.fulfill({
       status: 201,


### PR DESCRIPTION
## Summary
- stub `/api/release/lookup` in the Percy fixture so the Sally Oldfield scan flow no longer depends on live MusicBrainz search results
- keep the stub selective so the Sally Oldfield fixture gets deterministic metadata while other manual adds remain unchanged
- remove the external source of Percy visual diffs for issue #84

## Testing
- `bun run test:unit`
- `PLAYWRIGHT_SERVER_BASE_PORT=47100 bunx playwright test playwright/ui-percy.spec.ts --project=ui-chrome-desktop --workers=1`
- `PLAYWRIGHT_SERVER_BASE_PORT=47200 bun run test:e2e` (UI Percy projects passed; unrelated chromium failures remained in `playwright/add-link.spec.ts`, `playwright/bandcamp-link.spec.ts`, and `playwright/stacks.spec.ts`)

Closes #84