### PR TITLE
Fix mobile stack reordering on touch

### DIFF
--- a/playwright/reorder.spec.ts
+++ b/playwright/reorder.spec.ts
@@ -74,15 +74,17 @@ test.describe("Reorder (touch)", () => {
     expect(initialTitles).toHaveLength(3);
     const expectedTitles = [initialTitles[1], initialTitles[2], initialTitles[0]];
 
-    await dragCardByIndexWithTouch(page, 2, 1, "before");
+    await expect(page.locator(".music-card__reorder-handle")).toHaveCount(3);
+
+    await dragCardByIndexWithTouchHandle(page, 2, 1, "before");
     await expect
       .poll(() => getCardTitles(page))
       .toEqual([initialTitles[0], initialTitles[2], initialTitles[1]]);
 
-    await dragCardByIndexWithTouch(page, 2, 1, "before");
+    await dragCardByIndexWithTouchHandle(page, 2, 1, "before");
     await expect.poll(() => getCardTitles(page)).toEqual(initialTitles);
 
-    await dragCardByIndexWithTouch(page, 0, 2, "after");
+    await dragCardByIndexWithTouchHandle(page, 0, 2, "after");
     await expect.poll(() => getCardTitles(page)).toEqual(expectedTitles);
 
     await page.reload();
@@ -122,11 +124,29 @@ async function dragCardByIndexWithMouse(
   });
 }
 
-async function dragCardByIndexWithTouch(
+async function dragCardByIndexWithTouchHandle(
   page: Page,
   fromIndex: number,
   toIndex: number,
   position: "before" | "after",
 ): Promise<void> {
-  await dragCardByIndexWithMouse(page, fromIndex, toIndex, position);
+  const cards = page.locator(".music-card");
+  const sourceHandle = cards.nth(fromIndex).locator(".music-card__reorder-handle");
+  const targetCard = cards.nth(toIndex);
+
+  const sourceBox = await sourceHandle.boundingBox();
+  const targetBox = await targetCard.boundingBox();
+  if (!sourceBox || !targetBox) {
+    throw new Error("Missing drag source handle or target bounding box");
+  }
+
+  const startX = sourceBox.width / 2;
+  const startY = sourceBox.height / 2;
+  const targetY = position === "before" ? 4 : Math.max(4, targetBox.height - 4);
+
+  await sourceHandle.hover({ position: { x: startX, y: startY } });
+  await sourceHandle.dragTo(targetCard, {
+    sourcePosition: { x: startX, y: startY },
+    targetPosition: { x: 12, y: targetY },
+  });
 }

--- a/playwright/stacks.spec.ts
+++ b/playwright/stacks.spec.ts
@@ -178,9 +178,10 @@ test.describe("Stacks", () => {
     for (let index = 1; index <= 12; index += 1) {
       await page.locator("#stack-manage-input").fill(`Long Stack ${index}`);
       await page.locator("#stack-manage-create-btn").click();
+      await expect(
+        page.locator(".stack-manage__item", { hasText: `Long Stack ${index}` }),
+      ).toBeVisible();
     }
-
-    await expect(page.locator(".stack-tab", { hasText: "Long Stack 12" })).toBeVisible();
 
     const stackBarMetrics = await page.locator("#stack-bar").evaluate((element) => {
       const tabs = Array.from(element.querySelectorAll(".stack-tab")).filter((tab) => {
@@ -188,7 +189,9 @@ test.describe("Stacks", () => {
         return !htmlTab.hidden;
       });
 
-      const topPositions = tabs.map((tab) => Math.round((tab as HTMLElement).getBoundingClientRect().top));
+      const topPositions = tabs.map((tab) =>
+        Math.round((tab as HTMLElement).getBoundingClientRect().top),
+      );
       const rowPositions: number[] = [];
       const rowTolerance = 4;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,8 +69,12 @@ export class App {
   private activeItemActionMenuCleanup: (() => void) | null = null;
   private activeStackDropdownCleanup: ((skipOnClose?: boolean) => void) | null = null;
   private musicListSortable: Sortable | null = null;
+  private musicListReorderMediaQuery: MediaQueryList | null = null;
   private isReordering = false;
   private linkPickerState: LinkPickerState | null = null;
+  private readonly handleMusicListReorderMediaChange = (): void => {
+    this.syncMusicListReorderMode();
+  };
 
   constructor() {
     this.api = new ApiClient();
@@ -1064,7 +1068,8 @@ export class App {
       invertSwap: true,
       swapThreshold: 0.35,
       // Keep interactive controls clickable while making the card body draggable.
-      filter: "button,input,select,textarea,[data-action],.music-card__menu-item",
+      filter:
+        "button:not(.music-card__reorder-handle),input,select,textarea,[data-action],.music-card__menu-item",
       preventOnFilter: false,
       ghostClass: "music-card--drag-ghost",
       chosenClass: "music-card--drag-chosen",
@@ -1083,6 +1088,24 @@ export class App {
         void this.persistMusicListOrder();
       },
     });
+
+    this.musicListReorderMediaQuery = window.matchMedia("(max-width: 520px)");
+    this.musicListReorderMediaQuery.addEventListener(
+      "change",
+      this.handleMusicListReorderMediaChange,
+    );
+    this.syncMusicListReorderMode();
+  }
+
+  private syncMusicListReorderMode(): void {
+    if (!this.musicListSortable) {
+      return;
+    }
+
+    const handleSelector = this.musicListReorderMediaQuery?.matches
+      ? ".music-card__reorder-handle"
+      : undefined;
+    this.musicListSortable.option("handle", handleSelector);
   }
 
   private async persistMusicListOrder(): Promise<void> {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1049,10 +1049,14 @@ select.input {
 
   .music-card .music-card__actions {
     position: relative;
-    gap: 0;
+    gap: 4px;
     align-self: flex-start;
     padding-top: 0;
     margin-top: 1px;
+  }
+
+  .music-card .music-card__reorder-handle {
+    display: inline-flex;
   }
 
   .music-card .music-card__action-btn {
@@ -1218,6 +1222,22 @@ select.input {
 
 .music-card__action-btn {
   display: inline-flex;
+}
+
+.music-card__reorder-handle {
+  display: none;
+  min-width: 30px;
+  min-height: 30px;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--chrome-darker);
+  cursor: grab;
+  touch-action: none;
+}
+
+.music-card__reorder-handle:active {
+  cursor: grabbing;
 }
 
 .music-card__menu-toggle {

--- a/src/ui/view/templates.ts
+++ b/src/ui/view/templates.ts
@@ -23,6 +23,8 @@ export function renderMusicList(
 
 export function renderMusicCard(item: MusicItemFull): string {
   const hasArtwork = Boolean(item.artwork_url);
+  const escapedTitle = escapeHtml(item.title);
+  const releaseHref = `/r/${item.id}`;
   const statusOptions = Object.entries(STATUS_LABELS)
     .map(
       ([value, label]) =>
@@ -32,16 +34,16 @@ export function renderMusicCard(item: MusicItemFull): string {
 
   return `
     <article class="music-card${hasArtwork ? "" : " music-card--no-artwork"}" data-item-id="${item.id}">
-      <a href="/r/${item.id}">
+      <a href="${releaseHref}">
         ${
           item.artwork_url
-            ? `<img class="music-card__artwork music-card__artwork--link" src="${escapeHtml(item.artwork_url)}" alt="Artwork for ${escapeHtml(item.title)}">`
+            ? `<img class="music-card__artwork music-card__artwork--link" src="${escapeHtml(item.artwork_url)}" alt="Artwork for ${escapedTitle}">`
             : `<img class="music-card__artwork music-card__artwork--placeholder" src="/favicon-32x32.png" alt="No artwork available">`
         }
       </a>
       <div class="music-card__content">
-        <a href="/r/${item.id}" class="music-card__link">
-          <div class="music-card__title">${escapeHtml(item.title)}</div>
+        <a href="${releaseHref}" class="music-card__link">
+          <div class="music-card__title">${escapedTitle}</div>
           ${item.artist_name ? `<div class="music-card__artist">${escapeHtml(item.artist_name)}</div>` : ""}
           ${
             item.stacks.length > 0
@@ -67,6 +69,21 @@ export function renderMusicCard(item: MusicItemFull): string {
         </div>
       </div>
       <div class="music-card__actions">
+        <button
+          type="button"
+          class="btn btn--ghost music-card__reorder-handle"
+          title="Reorder ${escapedTitle}"
+          aria-label="Reorder ${escapedTitle}"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
+            <rect x="2" y="2" width="2" height="2"></rect>
+            <rect x="2" y="6" width="2" height="2"></rect>
+            <rect x="2" y="10" width="2" height="2"></rect>
+            <rect x="8" y="2" width="2" height="2"></rect>
+            <rect x="8" y="6" width="2" height="2"></rect>
+            <rect x="8" y="10" width="2" height="2"></rect>
+          </svg>
+        </button>
         ${
           item.primary_url
             ? `
@@ -86,7 +103,7 @@ export function renderMusicCard(item: MusicItemFull): string {
             <line x1="5" y1="12" x2="19" y2="12"></line>
           </svg>
         </button>
-        <a href="/r/${item.id}" class="btn btn--ghost music-card__action-btn" title="View release page">
+        <a href="${releaseHref}" class="btn btn--ghost music-card__action-btn" title="View release page">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
             <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
@@ -121,7 +138,7 @@ export function renderMusicCard(item: MusicItemFull): string {
           <button type="button" class="music-card__menu-item" data-action="stack-menu">
             Manage stacks
           </button>
-          <a href="/r/${item.id}" class="music-card__menu-item">View release page</a>
+          <a href="${releaseHref}" class="music-card__menu-item">View release page</a>
           <button
             type="button"
             class="music-card__menu-item music-card__menu-item--danger"

--- a/tests/unit/music-card-template.test.ts
+++ b/tests/unit/music-card-template.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { MusicItemFull } from "../../src/types";
+import { renderMusicCard } from "../../src/ui/view/templates";
+
+const ITEM: MusicItemFull = {
+  id: 42,
+  title: 'A&B "Test"',
+  normalized_title: "aandb test",
+  item_type: "album",
+  artist_id: 7,
+  listen_status: "to-listen",
+  purchase_intent: "maybe",
+  price_cents: null,
+  currency: "EUR",
+  notes: null,
+  rating: 4,
+  created_at: "2026-03-07T00:00:00.000Z",
+  updated_at: "2026-03-07T00:00:00.000Z",
+  listened_at: null,
+  artwork_url: "https://example.com/artwork.png",
+  is_physical: 0,
+  physical_format: null,
+  label: null,
+  year: null,
+  country: null,
+  genre: null,
+  catalogue_number: null,
+  musicbrainz_release_id: null,
+  musicbrainz_artist_id: null,
+  artist_name: "Example Artist",
+  primary_url: "https://example.com/release",
+  primary_source: "bandcamp",
+  stacks: [{ id: 3, name: "Ambient" }],
+};
+
+describe("renderMusicCard", () => {
+  test("renders a dedicated reorder handle with an escaped label", () => {
+    const html = renderMusicCard(ITEM);
+
+    expect(html).toContain('class="btn btn--ghost music-card__reorder-handle"');
+    expect(html).toContain('aria-label="Reorder A&amp;B &quot;Test&quot;"');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated mobile reorder handle and only require it under the mobile breakpoint
- preserve desktop drag reordering while keeping action controls clickable
- cover the handle UI in unit tests and update Playwright mobile reorder coverage

Closes #85

## Testing
- bun run typecheck
- bun run test:unit
- /bin/zsh -lc 'PLAYWRIGHT_WORKERS=1 bun run test:e2e'