### PR TITLE
fix: extract Bandcamp embed metadata from body and handle varied meta tag formats

### DIFF
--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -217,11 +217,14 @@ export function parseBandcampOg(og: OgData): ScrapedMetadata {
 
 export function extractBandcampEmbedMetadata(html: string): Record<string, string> | null {
   // Primary: <meta name="bc-page-properties" content='{"item_type":"album","item_id":123}'>
+  // Use flexible patterns to handle extra attributes and either attribute order.
   const metaMatch =
-    html.match(/<meta\s+name="bc-page-properties"\s+content='([^']+)'/i) ??
-    html.match(/<meta\s+name='bc-page-properties'\s+content="([^"]+)"/i) ??
-    html.match(/<meta\s+name="bc-page-properties"\s+content="([^"]+)"/i) ??
-    html.match(/<meta\s+name='bc-page-properties'\s+content='([^']+)'/i);
+    html.match(/<meta\s[^>]*?name="bc-page-properties"[^>]*?content='([^']+)'/i) ??
+    html.match(/<meta\s[^>]*?name='bc-page-properties'[^>]*?content='([^']+)'/i) ??
+    html.match(/<meta\s[^>]*?name="bc-page-properties"[^>]*?content="([^"]+)"/i) ??
+    html.match(/<meta\s[^>]*?name='bc-page-properties'[^>]*?content="([^"]+)"/i) ??
+    html.match(/<meta\s[^>]*?content='([^']+)'[^>]*?name="bc-page-properties"/i) ??
+    html.match(/<meta\s[^>]*?content="([^"]+)"[^>]*?name="bc-page-properties"/i);
   if (metaMatch) {
     try {
       const parsed = JSON.parse(decodeHtmlEntities(metaMatch[1])) as unknown;
@@ -240,16 +243,17 @@ export function extractBandcampEmbedMetadata(html: string): Record<string, strin
     } catch {
       // fall through to TralbumData
     }
-  } else {
-    // Fallback: TralbumData = { "id" : 123, "item_type" : "album" }
-    const tralbumIdMatch = html.match(/TralbumData\s*=\s*\{[\s\S]*?"id"\s*:\s*(\d+)/);
-    const tralbumTypeMatch = html.match(/TralbumData\s*=\s*\{[\s\S]*?"item_type"\s*:\s*"([^"]+)"/);
-    if (tralbumIdMatch) {
-      return {
-        album_id: tralbumIdMatch[1],
-        ...(tralbumTypeMatch ? { item_type: tralbumTypeMatch[1] } : {}),
-      };
-    }
+  }
+
+  // Fallback: TralbumData = { "id" : 123, "item_type" : "album" }
+  // This runs whether or not bc-page-properties was found, in case it was present but invalid.
+  const tralbumIdMatch = html.match(/TralbumData\s*=\s*\{[\s\S]*?"id"\s*:\s*(\d+)/);
+  const tralbumTypeMatch = html.match(/TralbumData\s*=\s*\{[\s\S]*?"item_type"\s*:\s*"([^"]+)"/);
+  if (tralbumIdMatch) {
+    return {
+      album_id: tralbumIdMatch[1],
+      ...(tralbumTypeMatch ? { item_type: tralbumTypeMatch[1] } : {}),
+    };
   }
 
   return null;
@@ -866,13 +870,15 @@ export async function scrapeUrl(
 
     let html = "";
     const decoder = new TextDecoder();
-    const maxBytes = source === "unknown" ? MAX_UNKNOWN_HTML_BYTES : MAX_HEAD_BYTES;
+    // Bandcamp needs body content too (TralbumData JS is in the body)
+    const maxBytes =
+      source === "unknown" || source === "bandcamp" ? MAX_UNKNOWN_HTML_BYTES : MAX_HEAD_BYTES;
 
     while (html.length < maxBytes) {
       const { done, value } = await reader.read();
       if (done) break;
       html += decoder.decode(value, { stream: true });
-      if (source === "unknown") {
+      if (source === "unknown" || source === "bandcamp") {
         if (html.includes("</body>")) break;
       } else if (html.includes("</head>")) {
         break;

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -751,6 +751,33 @@ describe("extractBandcampEmbedMetadata", () => {
     expect(extractBandcampEmbedMetadata(html)).toBeNull();
   });
 
+  test("handles extra attributes between name and content on meta tag", () => {
+    const html = `<meta data-react="true" name="bc-page-properties" data-other="x" content='{"item_type":"album","item_id":7777777}'>`;
+    expect(extractBandcampEmbedMetadata(html)).toEqual({
+      album_id: "7777777",
+      item_type: "album",
+    });
+  });
+
+  test("handles content attribute before name attribute on meta tag", () => {
+    const html = `<meta content='{"item_type":"track","item_id":8888888}' name="bc-page-properties">`;
+    expect(extractBandcampEmbedMetadata(html)).toEqual({
+      album_id: "8888888",
+      item_type: "track",
+    });
+  });
+
+  test("falls back to TralbumData when bc-page-properties has invalid item_id", () => {
+    const html = `
+      <meta name="bc-page-properties" content='{"item_type":"album"}'>
+      <script>TralbumData = {"id" : 9999999, "item_type" : "album"}</script>
+    `;
+    expect(extractBandcampEmbedMetadata(html)).toEqual({
+      album_id: "9999999",
+      item_type: "album",
+    });
+  });
+
   test("TralbumData fallback works with nested objects", () => {
     const html = `<script>TralbumData = {"nested": {"foo": "bar"}, "id" : 5551234, "item_type" : "album"}</script>`;
     expect(extractBandcampEmbedMetadata(html)).toEqual({
@@ -771,6 +798,20 @@ describe("scrapeUrl bandcamp embedMetadata", () => {
     );
     const result = await scrapeUrl("https://artist.bandcamp.com/album/my-album", "bandcamp");
     expect(result?.embedMetadata).toEqual({ album_id: "1234567", item_type: "album" });
+    mock.restore();
+  });
+
+  test("populates embedMetadata from TralbumData in body when bc-page-properties is absent", async () => {
+    const html = `<html><head>
+      <meta property="og:title" content="My Album, by Artist" />
+    </head><body>
+      <script>TralbumData = {"id" : 9876543, "item_type" : "album"}</script>
+    </body></html>`;
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(html, { headers: { "content-type": "text/html" } }),
+    );
+    const result = await scrapeUrl("https://artist.bandcamp.com/album/my-album", "bandcamp");
+    expect(result?.embedMetadata).toEqual({ album_id: "9876543", item_type: "album" });
     mock.restore();
   });
 });


### PR DESCRIPTION
Three bugs prevented embeds from appearing for newly added releases:

1. The scraper stopped reading at </head> for Bandcamp pages, but
   TralbumData (the fallback embed ID source) lives in the <body>.
   Bandcamp is now treated like unknown-source pages and reads up to
   250 KB or </body>, whichever comes first.

2. The TralbumData fallback only ran when the bc-page-properties meta
   tag was completely absent. If the tag existed but had an unexpected
   format the fallback was silently skipped. It now always runs as a
   secondary option when bc-page-properties fails to yield a valid ID.

3. The bc-page-properties regex required name and content to be the
   only attributes on the meta tag with no extra whitespace. Lazy
   [^>]*? quantifiers now allow arbitrary extra attributes in any
   position, and a content-before-name ordering is also accepted.

https://claude.ai/code/session_0148XGKQ7QowwGmALS5fMZXX