### PR TITLE
Skip Apple Music lookup when primaryUrl is already Apple Music

### DIFF
--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -10,6 +10,7 @@ import type { ScanResult } from "../../src/types";
 import type { MusicBrainzFields } from "../musicbrainz";
 import { getUploadsDir, toUploadsPublicPath } from "../uploads";
 import { searchAppleMusic } from "../scraper";
+import { parseUrl } from "../utils";
 import { db } from "../db/index";
 import { musicItems, musicLinks, sources, artists } from "../db/schema";
 
@@ -62,6 +63,7 @@ export interface ItemInfoForLookup {
   title: string;
   artistName: string | null;
   primarySource: string | null;
+  primaryUrl: string | null;
 }
 
 export type FetchItemForLookupFn = (id: number) => Promise<ItemInfoForLookup | null>;
@@ -87,6 +89,7 @@ async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup 
       title: musicItems.title,
       artistName: artists.name,
       primarySource: sources.name,
+      primaryUrl: musicLinks.url,
     })
     .from(musicItems)
     .leftJoin(artists, eq(musicItems.artistId, artists.id))
@@ -105,6 +108,7 @@ async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup 
     title: row.title,
     artistName: row.artistName ?? null,
     primarySource: row.primarySource ?? null,
+    primaryUrl: row.primaryUrl ?? null,
   };
 }
 
@@ -276,6 +280,10 @@ export function createReleaseRoutes(
     }
 
     if (item.primarySource && PLAYABLE_SOURCES.has(item.primarySource)) {
+      return c.json({ skipped: true }, 200);
+    }
+
+    if (item.primaryUrl && parseUrl(item.primaryUrl).source === "apple_music") {
       return c.json({ skipped: true }, 200);
     }
 

--- a/tests/unit/release-route.test.ts
+++ b/tests/unit/release-route.test.ts
@@ -419,9 +419,26 @@ describe("POST /api/release/apple-music-lookup/:id", () => {
       title: "Some Album",
       artistName: "Some Artist",
       primarySource: "bandcamp",
+      primaryUrl: null,
     });
     const app = makeApp();
     const res = await app.request("http://localhost/api/release/apple-music-lookup/3", {
+      method: "POST",
+    });
+    const body = await res.json();
+    expect(body.skipped).toBe(true);
+    expect(mockSearchAppleMusic).not.toHaveBeenCalled();
+  });
+
+  test("skips search when primary URL is Apple Music even if primarySource is null", async () => {
+    mockFetchItemForLookup.mockResolvedValue({
+      title: "The Band (Remastered)",
+      artistName: "The Band",
+      primarySource: null,
+      primaryUrl: "https://music.apple.com/es/album/the-band-remastered/1440846597",
+    });
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/release/apple-music-lookup/4", {
       method: "POST",
     });
     const body = await res.json();


### PR DESCRIPTION
## Summary
Enhanced the Apple Music lookup endpoint to skip the search when the item's primary URL is already an Apple Music link, even if the primarySource field is null or not set.

## Key Changes
- Added `primaryUrl` field to the `ItemInfoForLookup` interface to track the URL of the primary music source
- Updated `defaultFetchItemForLookup` to retrieve and return the `primaryUrl` from the database query
- Added logic to the Apple Music lookup route to check if `primaryUrl` points to Apple Music and skip the search if it does
- Imported `parseUrl` utility function to extract the source from URLs
- Added test case to verify the endpoint correctly skips search when `primaryUrl` is an Apple Music link with null `primarySource`

## Implementation Details
The check uses the existing `parseUrl` utility to extract the source identifier from the URL, allowing the endpoint to recognize Apple Music URLs regardless of how the `primarySource` field is populated. This prevents redundant lookups and API calls when the item is already linked to Apple Music.

https://claude.ai/code/session_01JdYs4Wa4mU8MB8JEwWSx4H