### PR TITLE
Remove 'Done' listen status

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -113,7 +113,6 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
   const statusOptions = [
     { value: "to-listen", label: "To Listen" },
     { value: "listened", label: "Listened" },
-    { value: "done", label: "Done" },
   ]
     .map(
       ({ value, label }) =>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -37,7 +37,6 @@
   /* Status colors (Winamp-palette) */
   --status-listen: #6699ff;
   --status-playing: #ffcc44;
-  --status-done: #44ff88;
   --status-grey: #888888;
 
   /* Danger */
@@ -1453,12 +1452,6 @@ select.input {
   color: #44ff88;
   border-color: #006622;
   text-shadow: 0 0 4px #00ff44;
-}
-
-.badge--done {
-  background: #111111;
-  color: #777777;
-  border-color: #444444;
 }
 
 .badge--source {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // Listen/purchase status types
-export type ListenStatus = "to-listen" | "listened" | "done";
+export type ListenStatus = "to-listen" | "listened";
 export type PurchaseIntent = "no" | "maybe" | "want" | "owned";
 export type ItemType = "album" | "ep" | "single" | "track" | "mix" | "compilation";
 export type PhysicalFormat = "vinyl" | "cd" | "cassette" | "minidisc" | "other";

--- a/src/ui/domain/status.ts
+++ b/src/ui/domain/status.ts
@@ -5,5 +5,4 @@ export type DisplayListenStatus = ListenStatus;
 export const STATUS_LABELS: Record<DisplayListenStatus, string> = {
   "to-listen": "To Listen",
   listened: "Listened",
-  done: "Done",
 };


### PR DESCRIPTION
Remove the 'Done' status option from the release page status selector and all supporting code — type definition, status labels map, and CSS badge styles.

https://claude.ai/code/session_013G4wGmxEiLQ4xRkTJ9cqMk