### PR TITLE
Add Discogs metadata scraping support

### DIFF
--- a/server/discogs.ts
+++ b/server/discogs.ts
@@ -1,0 +1,164 @@
+import type { ItemType } from "../src/types";
+
+const DISCOGS_API_BASE = "https://api.discogs.com";
+const USER_AGENT = "on-the-beach/1.0 (https://github.com/richpjames/on-the-beach)";
+
+interface DiscogsArtist {
+  name?: unknown;
+}
+
+interface DiscogsImage {
+  type?: unknown;
+  uri?: unknown;
+}
+
+interface DiscogsFormat {
+  name?: unknown;
+  descriptions?: unknown;
+}
+
+interface DiscogsRelease {
+  title?: unknown;
+  year?: unknown;
+  artists?: unknown;
+  genres?: unknown;
+  styles?: unknown;
+  images?: unknown;
+  formats?: unknown;
+}
+
+export interface DiscogsScrapedData {
+  potentialTitle?: string;
+  potentialArtist?: string;
+  imageUrl?: string;
+  itemType: ItemType;
+  year?: number;
+  genre?: string;
+}
+
+function parseArtistName(artists: unknown): string | undefined {
+  if (!Array.isArray(artists) || artists.length === 0) return undefined;
+  const first = artists[0] as DiscogsArtist;
+  if (typeof first?.name !== "string") return undefined;
+  // Remove Discogs disambiguation suffix like " (2)"
+  return first.name.replace(/\s+\(\d+\)$/, "").trim() || undefined;
+}
+
+function parsePrimaryGenre(genres: unknown, styles: unknown): string | undefined {
+  const styleList = Array.isArray(styles)
+    ? styles.filter((s): s is string => typeof s === "string")
+    : [];
+  const genreList = Array.isArray(genres)
+    ? genres.filter((g): g is string => typeof g === "string")
+    : [];
+  return styleList[0] ?? genreList[0] ?? undefined;
+}
+
+function parsePrimaryImageUri(images: unknown): string | undefined {
+  if (!Array.isArray(images) || images.length === 0) return undefined;
+  const primary =
+    images.find((img) => (img as DiscogsImage).type === "primary") ?? images[0];
+  const uri = (primary as DiscogsImage).uri;
+  return typeof uri === "string" ? uri : undefined;
+}
+
+function parseYear(year: unknown): number | undefined {
+  const num =
+    typeof year === "number"
+      ? year
+      : typeof year === "string"
+        ? parseInt(year, 10)
+        : NaN;
+  return Number.isFinite(num) && num > 0 ? num : undefined;
+}
+
+function parseItemType(formats: unknown): ItemType {
+  if (!Array.isArray(formats) || formats.length === 0) return "album";
+
+  const first = formats[0] as DiscogsFormat;
+  const descriptions = Array.isArray(first.descriptions)
+    ? first.descriptions.filter((d): d is string => typeof d === "string")
+    : [];
+  const formatName = typeof first.name === "string" ? first.name.toLowerCase() : "";
+  const allTerms = [...descriptions.map((d) => d.toLowerCase()), formatName];
+
+  if (allTerms.some((t) => t === "single" || t === '7"')) return "single";
+  if (allTerms.some((t) => t === "ep" || t === '12"' || t === "mini-album")) return "ep";
+  if (allTerms.some((t) => t === "compilation")) return "compilation";
+  if (allTerms.some((t) => t === "mixtape")) return "mix";
+
+  return "album";
+}
+
+function extractDiscogsTypeAndId(
+  url: string,
+): { type: "release" | "master"; id: string } | null {
+  const match = url.match(/discogs\.com\/(release|master)\/(\d+)/);
+  if (!match) return null;
+  return { type: match[1] as "release" | "master", id: match[2] };
+}
+
+export function parseDiscogsRelease(data: unknown): DiscogsScrapedData | null {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+
+  const release = data as DiscogsRelease;
+
+  const potentialTitle =
+    typeof release.title === "string" ? release.title.trim() || undefined : undefined;
+  const potentialArtist = parseArtistName(release.artists);
+  const year = parseYear(release.year);
+  const genre = parsePrimaryGenre(release.genres, release.styles);
+  const imageUrl = parsePrimaryImageUri(release.images);
+  const itemType = parseItemType(release.formats);
+
+  if (!potentialTitle && !potentialArtist && !imageUrl) return null;
+
+  return {
+    potentialTitle,
+    potentialArtist,
+    imageUrl,
+    itemType,
+    ...(year !== undefined ? { year } : {}),
+    ...(genre !== undefined ? { genre } : {}),
+  };
+}
+
+export async function fetchDiscogsRelease(
+  url: string,
+  timeoutMs: number,
+): Promise<DiscogsScrapedData | null> {
+  const info = extractDiscogsTypeAndId(url);
+  if (!info) return null;
+
+  const endpoint = info.type === "master" ? "masters" : "releases";
+  const apiUrl = `${DISCOGS_API_BASE}/${endpoint}/${info.id}`;
+
+  const headers: Record<string, string> = {
+    "User-Agent": USER_AGENT,
+    Accept: "application/json",
+  };
+
+  const token = process.env.DISCOGS_TOKEN;
+  if (token) {
+    headers["Authorization"] = `Discogs token=${token}`;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(apiUrl, { signal: controller.signal, headers });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      console.warn(`[discogs] API returned ${response.status} for ${apiUrl}`);
+      return null;
+    }
+
+    const data = (await response.json()) as unknown;
+    return parseDiscogsRelease(data);
+  } catch (err) {
+    console.error("[discogs] Fetch failed:", err);
+    return null;
+  }
+}

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -134,6 +134,8 @@ interface ReleaseCandidateInput {
   evidence?: string;
   isPrimary?: boolean;
   embedMetadata?: Record<string, string>;
+  year?: number;
+  genre?: string;
 }
 
 export class AmbiguousLinkSelectionError extends Error {
@@ -216,9 +218,9 @@ async function insertMusicItemWithLink(
       notes: overrides?.notes ?? null,
       artworkUrl: overrides?.artworkUrl ?? candidate.artworkUrl ?? null,
       label: overrides?.label ?? null,
-      year: overrides?.year ?? null,
+      year: overrides?.year ?? candidate.year ?? null,
       country: overrides?.country ?? null,
-      genre: overrides?.genre ?? null,
+      genre: overrides?.genre ?? candidate.genre ?? null,
       catalogueNumber: overrides?.catalogueNumber ?? null,
       musicbrainzReleaseId: overrides?.musicbrainzReleaseId ?? null,
       musicbrainzArtistId: overrides?.musicbrainzArtistId ?? null,
@@ -278,6 +280,8 @@ async function resolveReleaseCandidates(
           itemType: overrides?.itemType ?? scraped?.itemType ?? "album",
           artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
           embedMetadata: scraped?.embedMetadata,
+          year: overrides?.year ?? scraped?.year,
+          genre: overrides?.genre ?? scraped?.genre,
         },
       ],
     };

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -3,6 +3,7 @@ import {
   extractReleaseCandidatesFromWebText,
   type ExtractedReleaseCandidate,
 } from "./link-extractor";
+import { fetchDiscogsRelease } from "./discogs";
 
 export interface OgData {
   ogTitle?: string;
@@ -20,6 +21,8 @@ export interface ScrapedMetadata {
   imageUrl?: string;
   releases?: ExtractedReleaseCandidate[];
   embedMetadata?: Record<string, string>;
+  year?: number;
+  genre?: string;
 }
 
 type OgParser = (og: OgData) => ScrapedMetadata;
@@ -825,6 +828,10 @@ export async function scrapeUrl(
   }
 
   try {
+    if (source === "discogs") {
+      return await fetchDiscogsRelease(url, timeoutMs);
+    }
+
     if (source === "youtube") {
       return await scrapeYouTubeOEmbed(url, timeoutMs);
     }

--- a/tests/unit/discogs.test.ts
+++ b/tests/unit/discogs.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { fetchDiscogsRelease, parseDiscogsRelease } from "../../server/discogs";
+
+function makeDiscogsResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const MASTER_FIXTURE = {
+  id: 1033558,
+  title: "Rotten Riddims Vol. 1",
+  year: 2014,
+  artists: [{ name: "Dot Rotten", id: 1234 }],
+  genres: ["Electronic"],
+  styles: ["Grime", "UK Funky"],
+  images: [
+    { type: "primary", uri: "https://img.discogs.com/cover.jpg", uri150: "https://img.discogs.com/cover150.jpg" },
+    { type: "secondary", uri: "https://img.discogs.com/back.jpg" },
+  ],
+};
+
+const RELEASE_FIXTURE = {
+  id: 5678,
+  title: "Some EP",
+  year: 2016,
+  artists: [{ name: "Test Artist (2)" }],
+  genres: ["Electronic"],
+  styles: ["Techno"],
+  country: "UK",
+  labels: [{ name: "Test Label", catno: "TL001" }],
+  formats: [{ name: "Vinyl", qty: "1", descriptions: ["EP", "12\""] }],
+  images: [
+    { type: "secondary", uri: "https://img.discogs.com/secondary.jpg" },
+    { type: "primary", uri: "https://img.discogs.com/primary.jpg" },
+  ],
+};
+
+describe("parseDiscogsRelease", () => {
+  test("parses master release data", () => {
+    const result = parseDiscogsRelease(MASTER_FIXTURE);
+    expect(result).toEqual({
+      potentialTitle: "Rotten Riddims Vol. 1",
+      potentialArtist: "Dot Rotten",
+      imageUrl: "https://img.discogs.com/cover.jpg",
+      itemType: "album",
+      year: 2014,
+      genre: "Grime",
+    });
+  });
+
+  test("strips disambiguation suffix from artist name", () => {
+    const data = { title: "Test", artists: [{ name: "Test Artist (2)" }] };
+    const result = parseDiscogsRelease(data);
+    expect(result?.potentialArtist).toBe("Test Artist");
+  });
+
+  test("picks primary image when available", () => {
+    const result = parseDiscogsRelease(RELEASE_FIXTURE);
+    expect(result?.imageUrl).toBe("https://img.discogs.com/primary.jpg");
+  });
+
+  test("falls back to first image when no primary image", () => {
+    const data = {
+      title: "Test",
+      images: [
+        { type: "secondary", uri: "https://img.discogs.com/first.jpg" },
+        { type: "secondary", uri: "https://img.discogs.com/second.jpg" },
+      ],
+    };
+    const result = parseDiscogsRelease(data);
+    expect(result?.imageUrl).toBe("https://img.discogs.com/first.jpg");
+  });
+
+  test("infers EP itemType from formats", () => {
+    const result = parseDiscogsRelease(RELEASE_FIXTURE);
+    expect(result?.itemType).toBe("ep");
+  });
+
+  test("infers single itemType from formats", () => {
+    const data = {
+      title: "Test",
+      formats: [{ name: "Vinyl", descriptions: ["Single", "7\""] }],
+    };
+    const result = parseDiscogsRelease(data);
+    expect(result?.itemType).toBe("single");
+  });
+
+  test("infers compilation itemType from formats", () => {
+    const data = {
+      title: "Test",
+      formats: [{ name: "CD", descriptions: ["Compilation"] }],
+    };
+    const result = parseDiscogsRelease(data);
+    expect(result?.itemType).toBe("compilation");
+  });
+
+  test("defaults to album when formats is absent", () => {
+    const data = { title: "Test", artists: [{ name: "Artist" }] };
+    const result = parseDiscogsRelease(data);
+    expect(result?.itemType).toBe("album");
+  });
+
+  test("prefers styles over genres for genre field", () => {
+    const data = {
+      title: "Test",
+      genres: ["Electronic"],
+      styles: ["Grime"],
+    };
+    const result = parseDiscogsRelease(data);
+    expect(result?.genre).toBe("Grime");
+  });
+
+  test("falls back to genre when styles is empty", () => {
+    const data = {
+      title: "Test",
+      genres: ["Electronic"],
+      styles: [],
+    };
+    const result = parseDiscogsRelease(data);
+    expect(result?.genre).toBe("Electronic");
+  });
+
+  test("omits year when year is 0 or missing", () => {
+    expect(parseDiscogsRelease({ title: "Test", year: 0 })?.year).toBeUndefined();
+    expect(parseDiscogsRelease({ title: "Test" })?.year).toBeUndefined();
+  });
+
+  test("returns null for non-object input", () => {
+    expect(parseDiscogsRelease(null)).toBeNull();
+    expect(parseDiscogsRelease("string")).toBeNull();
+    expect(parseDiscogsRelease([])).toBeNull();
+  });
+
+  test("returns null when no title, artist, or image", () => {
+    expect(parseDiscogsRelease({ year: 2020 })).toBeNull();
+  });
+});
+
+describe("fetchDiscogsRelease", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("fetches master release from correct API endpoint", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeDiscogsResponse(MASTER_FIXTURE),
+    );
+
+    await fetchDiscogsRelease("https://www.discogs.com/master/1033558-Dot-Rotten-Rotten-Riddims-Vol-1", 5000);
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.discogs.com/masters/1033558");
+  });
+
+  test("fetches regular release from correct API endpoint", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeDiscogsResponse(RELEASE_FIXTURE),
+    );
+
+    await fetchDiscogsRelease("https://www.discogs.com/release/5678-Some-Release", 5000);
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.discogs.com/releases/5678");
+  });
+
+  test("sends correct User-Agent header", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeDiscogsResponse(MASTER_FIXTURE),
+    );
+
+    await fetchDiscogsRelease("https://www.discogs.com/master/1033558", 5000);
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers as HeadersInit);
+    expect(headers.get("User-Agent")).toContain("on-the-beach");
+  });
+
+  test("returns parsed metadata on success", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(makeDiscogsResponse(MASTER_FIXTURE));
+
+    const result = await fetchDiscogsRelease("https://www.discogs.com/master/1033558", 5000);
+
+    expect(result).toEqual({
+      potentialTitle: "Rotten Riddims Vol. 1",
+      potentialArtist: "Dot Rotten",
+      imageUrl: "https://img.discogs.com/cover.jpg",
+      itemType: "album",
+      year: 2014,
+      genre: "Grime",
+    });
+  });
+
+  test("returns null for non-discogs URL", async () => {
+    const result = await fetchDiscogsRelease("https://bandcamp.com/album/foo", 5000);
+    expect(result).toBeNull();
+  });
+
+  test("returns null on non-200 response", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeDiscogsResponse({ message: "Not Found" }, 404),
+    );
+
+    const result = await fetchDiscogsRelease("https://www.discogs.com/master/1033558", 5000);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when fetch throws", async () => {
+    spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network error"));
+
+    const result = await fetchDiscogsRelease("https://www.discogs.com/master/1033558", 5000);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds support for scraping music metadata directly from Discogs URLs, enabling automatic extraction of release information including title, artist, artwork, format type, year, and genre.

## Key Changes
- **New Discogs scraper module** (`server/discogs.ts`): Implements `fetchDiscogsRelease()` and `parseDiscogsRelease()` functions to fetch and parse Discogs API responses
  - Extracts both master releases and regular releases from Discogs URLs
  - Intelligently parses format descriptions to infer item type (album, EP, single, compilation, mix)
  - Prioritizes styles over genres for genre classification
  - Handles artist name disambiguation (removes Discogs suffixes like " (2)")
  - Selects primary images when available, falls back to first image
  - Includes proper error handling and timeout support with optional API token authentication

- **Comprehensive test suite** (`tests/unit/discogs.test.ts`): 215 lines of unit tests covering:
  - Parsing logic for all metadata fields
  - Image selection priority (primary vs. fallback)
  - Item type inference from format descriptions
  - Genre/style preference logic
  - Edge cases (missing data, invalid input, network errors)
  - API endpoint construction for both release types
  - User-Agent header validation

- **Integration with scraper** (`server/scraper.ts`): Added Discogs as a recognized source in `scrapeUrl()` function

- **Enhanced release candidate model** (`server/music-item-creator.ts`): Extended `ReleaseCandidateInput` interface to include `year` and `genre` fields, allowing Discogs metadata to flow through to music item creation

## Implementation Details
- Uses Discogs API v3 with proper User-Agent header and optional token-based authentication
- Implements timeout handling via AbortController
- Defensive parsing with type guards to handle malformed API responses gracefully
- Returns null on any error (network, parsing, invalid URL) rather than throwing

https://claude.ai/code/session_011C2KC5Ftbeva7LkxUKumTt