### PR TITLE
fix: support YouTube playlists, fix Apple Music duplicate links, sort stacks alphabetically

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -3,7 +3,7 @@ import { fetchFullItem } from "../music-item-creator";
 import type { MusicItemFull } from "../../src/types";
 import { getPageAssets } from "../page-assets";
 import { renderStarRating } from "../../src/ui/view/templates";
-import { parseUrl, extractYouTubeVideoId } from "../utils";
+import { parseUrl, extractYouTubeVideoId, extractYouTubePlaylistId } from "../utils";
 
 export type FetchItemFn = (id: number) => Promise<MusicItemFull | null>;
 
@@ -55,11 +55,11 @@ function parseLinkMetadata(raw: string | null): Record<string, string> | null {
 
 function renderYouTubeEmbed(item: MusicItemFull): string {
   if (!item.primary_url) return "";
-  const videoId = extractYouTubeVideoId(item.primary_url);
-  if (!videoId || !/^[\w-]+$/.test(videoId)) return "";
 
-  const src = `https://www.youtube-nocookie.com/embed/${escapeHtml(videoId)}`;
-  return `<iframe
+  const videoId = extractYouTubeVideoId(item.primary_url);
+  if (videoId && /^[\w-]+$/.test(videoId)) {
+    const src = `https://www.youtube-nocookie.com/embed/${escapeHtml(videoId)}`;
+    return `<iframe
     class="release-page__youtube-embed"
     src="${src}"
     style="border:0;width:100%;aspect-ratio:16/9;"
@@ -67,6 +67,22 @@ function renderYouTubeEmbed(item: MusicItemFull): string {
     allowfullscreen
     title="YouTube player"
   ></iframe>`;
+  }
+
+  const playlistId = extractYouTubePlaylistId(item.primary_url);
+  if (playlistId && /^[\w-]+$/.test(playlistId)) {
+    const src = `https://www.youtube-nocookie.com/embed/videoseries?list=${escapeHtml(playlistId)}`;
+    return `<iframe
+    class="release-page__youtube-embed"
+    src="${src}"
+    style="border:0;width:100%;aspect-ratio:16/9;"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    title="YouTube playlist player"
+  ></iframe>`;
+  }
+
+  return "";
 }
 
 function renderBandcampEmbed(item: MusicItemFull): string {
@@ -151,7 +167,7 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
 
           <div class="release-page__body">
 
-            ${extractYouTubeVideoId(item.primary_url ?? "") ? renderYouTubeEmbed(item) : safeArtworkUrl(item.artwork_url ?? "") ? `<img class="release-page__artwork" src="${escapeHtml(item.artwork_url!)}" alt="Artwork for ${escapeHtml(item.title)}" />` : ""}
+            ${extractYouTubeVideoId(item.primary_url ?? "") || extractYouTubePlaylistId(item.primary_url ?? "") ? renderYouTubeEmbed(item) : safeArtworkUrl(item.artwork_url ?? "") ? `<img class="release-page__artwork" src="${escapeHtml(item.artwork_url!)}" alt="Artwork for ${escapeHtml(item.title)}" />` : ""}
 
             <div class="release-page__content">
 
@@ -163,7 +179,7 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
                 ${item.notes ? `<p class="release-page__notes">${escapeHtml(item.notes)}</p>` : ""}
                 ${renderStarRating(item.id, item.rating, "star-rating--large")}
                 <div id="stack-chips" class="release-page__stacks"></div>
-                ${item.primary_url && !extractYouTubeVideoId(item.primary_url) && !item.primary_url.includes("bandcamp.com") ? `<a class="release-page__source-link" href="${escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(sourceDisplayName(item.primary_source ?? parseUrl(item.primary_url).source))}</a>` : ""}
+                ${item.primary_url && !extractYouTubeVideoId(item.primary_url) && !extractYouTubePlaylistId(item.primary_url) && !item.primary_url.includes("bandcamp.com") ? `<a class="release-page__source-link" href="${escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(sourceDisplayName(item.primary_source ?? parseUrl(item.primary_url).source))}</a>` : ""}
                 ${item.primary_url?.includes("bandcamp.com") ? renderBandcampEmbed(item) : ""}
                 <div id="secondary-links"></div>
               </div>
@@ -316,9 +332,13 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
         }
       }
 
+      function sortStacks(stacks) {
+        return stacks.sort((a, b) => a.name.localeCompare(b.name));
+      }
+
       async function loadStacks() {
         const res = await fetch('/api/stacks');
-        if (res.ok) { allStacks = await res.json(); renderStackChips(); renderStackPicker(); }
+        if (res.ok) { allStacks = sortStacks(await res.json()); renderStackChips(); renderStackPicker(); }
       }
 
       document.getElementById('new-stack-input').addEventListener('keydown', async e => {
@@ -334,6 +354,7 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
           const stack = await res.json();
           e.target.value = '';
           allStacks.push(stack);
+          sortStacks(allStacks);
           await toggleStack(stack.id, true);
         }
       });

--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -283,7 +283,11 @@ export function createReleaseRoutes(
       return c.json({ skipped: true }, 200);
     }
 
-    if (item.primaryUrl && parseUrl(item.primaryUrl).source === "apple_music") {
+    if (
+      item.primaryUrl &&
+      (parseUrl(item.primaryUrl).source === "apple_music" ||
+        item.primaryUrl.includes("music.apple.com"))
+    ) {
       return c.json({ skipped: true }, 200);
     }
 

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -39,6 +39,11 @@ const URL_PATTERNS: Array<{
     normalizer: (match) => `https://www.youtube.com/watch?v=${match[2]}`,
   },
   {
+    source: "youtube",
+    pattern: /^https?:\/\/(?:(?:www|m)\.)?youtube\.com\/playlist\?list=([a-zA-Z0-9_-]+)/,
+    normalizer: (match) => `https://www.youtube.com/playlist?list=${match[1]}`,
+  },
+  {
     source: "apple_music",
     pattern:
       /^https?:\/\/music\.apple\.com\/[a-z]{2}\/(album|playlist|artist|music-video|station)\/([^/]+)/,
@@ -103,6 +108,22 @@ export function extractYouTubeVideoId(url: string): string | null {
     }
     if (parsed.hostname === "youtu.be") {
       return parsed.pathname.slice(1) || null;
+    }
+  } catch {
+    // invalid URL
+  }
+  return null;
+}
+
+export function extractYouTubePlaylistId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.hostname === "www.youtube.com" ||
+      parsed.hostname === "youtube.com" ||
+      parsed.hostname === "m.youtube.com"
+    ) {
+      return parsed.searchParams.get("list");
     }
   } catch {
     // invalid URL

--- a/tests/unit/parse-url.test.ts
+++ b/tests/unit/parse-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { parseUrl } from "../../src/repository/utils";
+import { parseUrl, extractYouTubePlaylistId } from "../../src/repository/utils";
 
 describe("parseUrl - youtube", () => {
   test("identifies youtube watch link and preserves video ID in normalizedUrl", () => {
@@ -21,6 +21,36 @@ describe("parseUrl - youtube", () => {
 
     expect(result.source).toBe("youtube");
     expect(result.normalizedUrl).toBe("https://www.youtube.com/watch?v=C9CkvAQkQLs");
+  });
+
+  test("identifies youtube playlist link", () => {
+    const result = parseUrl("https://www.youtube.com/playlist?list=PLE31AAD9114F343C4");
+
+    expect(result.source).toBe("youtube");
+    expect(result.normalizedUrl).toBe("https://www.youtube.com/playlist?list=PLE31AAD9114F343C4");
+  });
+
+  test("normalizes youtube playlist link by stripping extra params", () => {
+    const result = parseUrl("https://www.youtube.com/playlist?list=PLE31AAD9114F343C4&si=abc123");
+
+    expect(result.source).toBe("youtube");
+    expect(result.normalizedUrl).toBe("https://www.youtube.com/playlist?list=PLE31AAD9114F343C4");
+  });
+});
+
+describe("extractYouTubePlaylistId", () => {
+  test("extracts playlist ID from standard playlist URL", () => {
+    expect(
+      extractYouTubePlaylistId("https://www.youtube.com/playlist?list=PLE31AAD9114F343C4"),
+    ).toBe("PLE31AAD9114F343C4");
+  });
+
+  test("returns null for a video watch URL", () => {
+    expect(extractYouTubePlaylistId("https://www.youtube.com/watch?v=C9CkvAQkQLs")).toBeNull();
+  });
+
+  test("returns null for non-youtube URLs", () => {
+    expect(extractYouTubePlaylistId("https://soundcloud.com/artist/track")).toBeNull();
   });
 });
 

--- a/tests/unit/release-page-route.test.ts
+++ b/tests/unit/release-page-route.test.ts
@@ -302,4 +302,33 @@ describe("YouTube embed", () => {
     const html = await res.text();
     expect(html).not.toContain("youtube-nocookie.com/embed");
   });
+
+  test("renders YouTube playlist embed for playlist URL", async () => {
+    const item = {
+      ...baseItem,
+      primary_url: "https://www.youtube.com/playlist?list=PLE31AAD9114F343C4",
+      primary_source: "youtube" as const,
+      primary_link_metadata: null,
+    };
+    mockFetchItem.mockResolvedValue(item);
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).toContain("youtube-nocookie.com/embed/videoseries?list=PLE31AAD9114F343C4");
+    expect(html).toContain("<iframe");
+  });
+
+  test("does not render YouTube playlist URL as a standalone source link", async () => {
+    const item = {
+      ...baseItem,
+      primary_url: "https://www.youtube.com/playlist?list=PLE31AAD9114F343C4",
+      primary_source: "youtube" as const,
+      primary_link_metadata: null,
+    };
+    mockFetchItem.mockResolvedValue(item);
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).not.toContain('href="https://www.youtube.com/playlist?list=PLE31AAD9114F343C4"');
+  });
 });

--- a/tests/unit/release-route.test.ts
+++ b/tests/unit/release-route.test.ts
@@ -445,4 +445,20 @@ describe("POST /api/release/apple-music-lookup/:id", () => {
     expect(body.skipped).toBe(true);
     expect(mockSearchAppleMusic).not.toHaveBeenCalled();
   });
+
+  test("skips search when primary URL is Apple Music with unusual format not matched by parseUrl", async () => {
+    mockFetchItemForLookup.mockResolvedValue({
+      title: "Some Song",
+      artistName: "Some Artist",
+      primarySource: null,
+      primaryUrl: "https://music.apple.com/us/song/some-song/123456789",
+    });
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/release/apple-music-lookup/5", {
+      method: "POST",
+    });
+    const body = await res.json();
+    expect(body.skipped).toBe(true);
+    expect(mockSearchAppleMusic).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION

- Add YouTube playlist URL pattern and extractYouTubePlaylistId util (#114)
- Render playlist embed using videoseries?list= format on release page
- Broaden Apple Music primary URL check to catch unusual URL formats (#115)
- Sort stacks alphabetically when loading or adding new stacks (#51)