### PR TITLE
Remove vinyl disc loading indicator from add-to-collection dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,6 @@
           </div>
         </div>
         <div class="add-loading-dialog__body">
-          <div class="add-loading-dialog__disc" aria-hidden="true"></div>
           <div class="add-loading-dialog__content">
             <p class="add-loading-dialog__status" id="add-loading-status">
               Adding to collection...

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -445,7 +445,6 @@ function renderMainPage(opts: {
             </div>
           </div>
           <div class="add-loading-dialog__body">
-            <div class="add-loading-dialog__disc" aria-hidden="true"></div>
             <div class="add-loading-dialog__content">
               <p class="add-loading-dialog__status" id="add-loading-status">
                 Adding to collection...

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2294,19 +2294,6 @@ body::after {
   gap: 14px;
 }
 
-/* CSS-art vinyl disc */
-.add-loading-dialog__disc {
-  flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at center, #111 0px, #111 5px, transparent 5px),
-    radial-gradient(circle at center, #1a1a1a 0px, #1a1a1a 8px, #333 8px, #333 13px, #222 13px, #222 18px, #444 18px, #444 19px, #111 19px);
-  border: 2px solid #000;
-  animation: dialog-disc-spin 2s linear infinite;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
 
 .add-loading-dialog__content {
   flex: 1;


### PR DESCRIPTION
## Summary
Removes the decorative vinyl disc CSS-art animation from the add-to-collection loading dialog, simplifying the UI and reducing CSS complexity.

## Changes
- Removed `.add-loading-dialog__disc` CSS class definition including the radial-gradient background, animation, and styling (13 lines)
- Removed the vinyl disc HTML element from the loading dialog in `index.html`
- Removed the vinyl disc HTML element from the server-rendered loading dialog in `server/routes/main-page.ts`

## Details
The vinyl disc was a decorative CSS-art element that displayed a spinning animation during the "Adding to collection..." operation. This change removes it entirely, leaving only the text status message in the dialog. The `dialog-disc-spin` animation definition may also be removed in a follow-up if it's no longer referenced elsewhere.

https://claude.ai/code/session_01AtcuQJCRkWs5Ry7RzR6MLp