### PR TITLE
Refactor release page stacks UI layout and styling

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -178,7 +178,6 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
                 ${item.catalogue_number ? `<p class="release-page__catalogue">${escapeHtml(item.catalogue_number)}</p>` : ""}
                 ${item.notes ? `<p class="release-page__notes">${escapeHtml(item.notes)}</p>` : ""}
                 ${renderStarRating(item.id, item.rating, "star-rating--large")}
-                <div id="stack-chips" class="release-page__stacks"></div>
                 ${item.primary_url && !extractYouTubeVideoId(item.primary_url) && !extractYouTubePlaylistId(item.primary_url) && !item.primary_url.includes("bandcamp.com") ? `<a class="release-page__source-link" href="${escapeHtml(item.primary_url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(sourceDisplayName(item.primary_source ?? parseUrl(item.primary_url).source))}</a>` : ""}
                 ${item.primary_url?.includes("bandcamp.com") ? renderBandcampEmbed(item) : ""}
                 <div id="secondary-links"></div>
@@ -206,12 +205,14 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
                     <button type="button" class="btn" id="cancel-btn">Cancel</button>
                   </div>
                 </div>
-                <div class="release-page__edit-stacks">
-                  <div class="release-page__edit-stacks-header">Stacks</div>
-                  <div id="stack-picker-list" class="release-page__edit-stacks-list"></div>
-                  <div class="release-page__edit-stacks-new">
-                    <input type="text" class="input stack-dropdown__new-input" id="new-stack-input" placeholder="New stack…" />
-                  </div>
+              </div>
+
+              <div class="release-page__edit-stacks">
+                <div class="release-page__edit-stacks-header">Stacks</div>
+                <div id="stack-chips" class="release-page__stacks release-page__stacks--inline"></div>
+                <div id="stack-picker-list" class="release-page__edit-stacks-list"></div>
+                <div class="release-page__edit-stacks-new">
+                  <input type="text" class="input stack-dropdown__new-input" id="new-stack-input" placeholder="New stack…" />
                 </div>
               </div>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2087,9 +2087,7 @@ body::after {
 }
 
 .release-page #edit-mode {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: 8px;
+  display: block;
   padding: 8px;
   border-width: 2px;
   border-style: solid;
@@ -2133,6 +2131,15 @@ body::after {
   border-bottom: 1px solid var(--chrome-dark);
   font-weight: bold;
   color: var(--chrome-black);
+}
+
+.release-page__stacks--inline {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--chrome-dark);
+}
+
+.release-page__stacks--inline:empty {
+  display: none;
 }
 
 .release-page__edit-stacks-list {


### PR DESCRIPTION
## Summary
Reorganized the stacks section on the release page to improve layout structure and styling. The stacks display has been moved from the main content area into the edit mode section, and the edit mode layout has been changed from a grid to a block layout.

## Key Changes
- Moved the `#stack-chips` container from the main release info section into the `release-page__edit-stacks` section
- Added `release-page__stacks--inline` class to the stacks container for inline display styling
- Changed `#edit-mode` from a 2-column grid layout (`grid-template-columns: 2fr 1fr`) to a block layout
- Added new CSS styles for `.release-page__stacks--inline` with padding and bottom border
- Added rule to hide the stacks container when empty

## Implementation Details
- The stacks section is now visually grouped with other stack-related controls (picker list and new stack input)
- The inline stacks styling includes a subtle bottom border separator and padding for better visual hierarchy
- The empty state is handled with CSS (`display: none`) to avoid unnecessary whitespace
- The edit mode section now uses a vertical block layout instead of a side-by-side grid, allowing for better responsive behavior

https://claude.ai/code/session_014eMZt77xBAfNQJKRv9mQMz