### PR TITLE
feat: add NTS Radio as a supported source

### DIFF
--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -11,6 +11,7 @@ const SEED_SOURCES = [
   { name: "tidal", displayName: "Tidal", urlPattern: "tidal.com" },
   { name: "deezer", displayName: "Deezer", urlPattern: "deezer.com" },
   { name: "mixcloud", displayName: "Mixcloud", urlPattern: "mixcloud.com" },
+  { name: "nts", displayName: "NTS Radio", urlPattern: "nts.live" },
   { name: "physical", displayName: "Physical Media", urlPattern: null },
 ] as const;
 

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -271,7 +271,7 @@ async function resolveReleaseCandidates(
     const artistName = overrides?.artistName || scraped?.potentialArtist || parsed.potentialArtist;
 
     return {
-      normalizedUrl: parsed.normalizedUrl,
+      normalizedUrl: scraped?.canonicalUrl || parsed.normalizedUrl,
       source: parsed.source,
       candidates: [
         {

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -23,6 +23,7 @@ export interface ScrapedMetadata {
   embedMetadata?: Record<string, string>;
   year?: number;
   genre?: string;
+  canonicalUrl?: string;
 }
 
 type OgParser = (og: OgData) => ScrapedMetadata;
@@ -792,11 +793,34 @@ export function parseDefaultOg(og: OgData): ScrapedMetadata {
   };
 }
 
+export function parseCanonicalUrl(html: string): string | undefined {
+  const match =
+    html.match(/<link\s[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["']/i) ??
+    html.match(/<link\s[^>]*href=["']([^"']+)["'][^>]*rel=["']canonical["']/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+export function parseNtsOg(og: OgData): ScrapedMetadata {
+  const rawTitle = og.ogTitle || og.title || "";
+  // NTS format: "Show Name - Episode Info | NTS Radio" or "Show Name | NTS"
+  const title = rawTitle
+    .replace(/\s*\|\s*NTS(?:\s+Radio)?\s*$/i, "")
+    .replace(/\s+on\s+NTS(?:\s+Radio)?\s*$/i, "")
+    .trim();
+
+  return {
+    potentialTitle: title || undefined,
+    imageUrl: og.ogImage,
+    itemType: "mix",
+  };
+}
+
 export const SOURCE_PARSERS: Partial<Record<SourceName, OgParser>> = {
   bandcamp: parseBandcampOg,
   soundcloud: parseSoundcloudOg,
   apple_music: parseAppleMusicOg,
   mixcloud: parseMixcloudOg,
+  nts: parseNtsOg,
 };
 
 export async function scrapeUrl(
@@ -923,6 +947,14 @@ export async function scrapeUrl(
     if (source === "apple_music") {
       const appleMusicOg = parseAppleMusicOg(og);
       return mergeScrapedMetadata(appleMusicOEmbed, appleMusicLookup, appleMusicOg);
+    }
+
+    if (source === "nts") {
+      const result = parseNtsOg(og);
+      const canonicalUrl =
+        firstDefined(og.metaTags?.["og:url"], parseCanonicalUrl(html)) || undefined;
+      if (canonicalUrl) result.canonicalUrl = canonicalUrl;
+      return result;
     }
 
     const parser = SOURCE_PARSERS[source] || parseDefaultOg;

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -74,6 +74,14 @@ const URL_PATTERNS: Array<{
     source: "deezer",
     pattern: /^https?:\/\/(?:www\.)?deezer\.com\/[a-z]{2}\/(album|track|playlist)\/(\d+)/,
   },
+  {
+    source: "nts",
+    pattern: /^https?:\/\/(?:www\.)?nts\.live\/shows\/([^/]+)(?:\/episodes\/([^/?]+))?/,
+    extractor: (match) => ({
+      potentialArtist: match[1]?.replace(/-/g, " "),
+      potentialTitle: match[2]?.replace(/-/g, " "),
+    }),
+  },
 ];
 
 export function parseUrl(url: string): ParsedUrl {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export type SourceName =
   | "tidal"
   | "deezer"
   | "mixcloud"
+  | "nts"
   | "physical"
   | "unknown";
 

--- a/tests/unit/parse-url.test.ts
+++ b/tests/unit/parse-url.test.ts
@@ -54,6 +54,57 @@ describe("extractYouTubePlaylistId", () => {
   });
 });
 
+describe("parseUrl - nts", () => {
+  test("identifies NTS episode link", () => {
+    const result = parseUrl(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+
+    expect(result.source).toBe("nts");
+  });
+
+  test("strips query params from normalized URL", () => {
+    const result = parseUrl(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026?some=param",
+    );
+
+    expect(result.normalizedUrl).toBe(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+  });
+
+  test("extracts show slug as potentialArtist", () => {
+    const result = parseUrl(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+
+    expect(result.potentialArtist).toBe("tropic of cancer");
+  });
+
+  test("extracts episode slug as potentialTitle", () => {
+    const result = parseUrl(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+
+    expect(result.potentialTitle).toBe("tropic of cancer 6th march 2026");
+  });
+
+  test("identifies NTS show index page (no episode)", () => {
+    const result = parseUrl("https://www.nts.live/shows/tropic-of-cancer");
+
+    expect(result.source).toBe("nts");
+    expect(result.potentialArtist).toBe("tropic of cancer");
+  });
+
+  test("matches nts.live URLs without www prefix", () => {
+    const result = parseUrl(
+      "https://nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+
+    expect(result.source).toBe("nts");
+  });
+});
+
 describe("parseUrl - apple music", () => {
   test("identifies apple music release link and extracts title", () => {
     const result = parseUrl("https://music.apple.com/es/album/el-poder-verde/1810282984?l=en-GB");

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -13,6 +13,8 @@ import {
   UnsupportedMusicLinkError,
   extractBandcampEmbedMetadata,
   searchAppleMusic,
+  parseNtsOg,
+  parseCanonicalUrl,
 } from "../../server/scraper";
 
 function mockChatCompletionResponse(
@@ -904,5 +906,68 @@ describe("searchAppleMusic", () => {
     const result = await searchAppleMusic("A Song", "Artist");
     expect(result).toBe("https://music.apple.com/track/999");
     mock.restore();
+  });
+});
+
+describe("parseNtsOg", () => {
+  test("strips '| NTS Radio' suffix from title", () => {
+    const og = { ogTitle: "Tropic Of Cancer - 6th March 2026 | NTS Radio" };
+    const result = parseNtsOg(og);
+    expect(result.potentialTitle).toBe("Tropic Of Cancer - 6th March 2026");
+  });
+
+  test("strips '| NTS' suffix from title", () => {
+    const og = { ogTitle: "Hessle Audio | NTS" };
+    const result = parseNtsOg(og);
+    expect(result.potentialTitle).toBe("Hessle Audio");
+  });
+
+  test("strips 'on NTS Radio' suffix from title", () => {
+    const og = { ogTitle: "Tropic Of Cancer on NTS Radio" };
+    const result = parseNtsOg(og);
+    expect(result.potentialTitle).toBe("Tropic Of Cancer");
+  });
+
+  test("sets itemType to mix", () => {
+    const og = { ogTitle: "Some Show | NTS Radio" };
+    const result = parseNtsOg(og);
+    expect(result.itemType).toBe("mix");
+  });
+
+  test("returns og:image as imageUrl", () => {
+    const og = {
+      ogTitle: "Some Show | NTS Radio",
+      ogImage: "https://nts.live/images/show.jpg",
+    };
+    const result = parseNtsOg(og);
+    expect(result.imageUrl).toBe("https://nts.live/images/show.jpg");
+  });
+
+  test("handles title with no NTS suffix", () => {
+    const og = { ogTitle: "Tropic Of Cancer - 6th March 2026" };
+    const result = parseNtsOg(og);
+    expect(result.potentialTitle).toBe("Tropic Of Cancer - 6th March 2026");
+    expect(result.itemType).toBe("mix");
+  });
+});
+
+describe("parseCanonicalUrl", () => {
+  test("extracts canonical URL from link tag (rel before href)", () => {
+    const html = `<link rel="canonical" href="https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026" />`;
+    expect(parseCanonicalUrl(html)).toBe(
+      "https://www.nts.live/shows/tropic-of-cancer/episodes/tropic-of-cancer-6th-march-2026",
+    );
+  });
+
+  test("extracts canonical URL from link tag (href before rel)", () => {
+    const html = `<link href="https://www.nts.live/shows/my-show/episodes/ep-1" rel="canonical" />`;
+    expect(parseCanonicalUrl(html)).toBe(
+      "https://www.nts.live/shows/my-show/episodes/ep-1",
+    );
+  });
+
+  test("returns undefined when no canonical tag is present", () => {
+    const html = `<head><title>No canonical here</title></head>`;
+    expect(parseCanonicalUrl(html)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Recognises nts.live episode and show URLs as radio shows, scraping og:title (with NTS suffix stripped) and og:image. Sets itemType to 'mix' so tracks are never extracted from the tracklisting. Also reads og:url and the canonical link tag to normalise the stored URL.

- Add `nts` to SourceName, URL_PATTERNS, SOURCE_PARSERS, and seed data
- Add parseNtsOg, parseCanonicalUrl helpers in scraper.ts
- Add canonicalUrl field to ScrapedMetadata; use it in music-item-creator
- Add tests for URL parsing and OG/canonical parsing

https://claude.ai/code/session_011E1gu43BW9mYhDY1bZfAMG