### PR TITLE
Add max-height to release page stack input to prevent viewport overflow

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2122,6 +2122,7 @@ body::after {
   background: var(--chrome-white);
   overflow: hidden;
   min-width: 0;
+  max-height: 50vh;
 }
 
 .release-page__edit-stacks-header {


### PR DESCRIPTION
Limits the stacks panel to 50vh so it never grows beyond the viewport. The inner list already has overflow-y: auto, so it will scroll when there are more stacks than fit in the constrained height.