### PR TITLE
Support multiple link picker candidate selection

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -351,21 +351,19 @@ function setupLinkPicker(): void {
     ) as HTMLElement | null;
     if (!target) return;
     addFormActor.send({
-      type: "CANDIDATE_SELECTED",
+      type: "CANDIDATE_TOGGLED",
       candidateId: target.dataset.candidateId ?? "",
     });
   });
 
   submit.addEventListener("click", () => {
-    const lp = formCtx().linkPicker;
-    const candidate = lp?.candidates.find((c) => c.candidateId === lp?.selectedCandidateId);
-    if (candidate) populateAddFormFromCandidate(candidate);
     addFormActor.send({ type: "CANDIDATE_SUBMITTED" });
   });
 
   manual.addEventListener("click", () => {
     const lp = formCtx().linkPicker;
-    const candidate = lp?.candidates.find((c) => c.candidateId === lp?.selectedCandidateId);
+    const firstId = lp?.selectedCandidateIds[0];
+    const candidate = firstId ? lp?.candidates.find((c) => c.candidateId === firstId) : undefined;
     if (candidate) populateAddFormFromCandidate(candidate);
     addFormActor.send({ type: "ENTER_MANUALLY" });
     const form = document.getElementById("add-form") as HTMLFormElement | null;
@@ -394,7 +392,7 @@ function renderLinkPickerFromContext(linkPicker: {
   url: string;
   message: string;
   candidates: LinkReleaseCandidate[];
-  selectedCandidateId: string | null;
+  selectedCandidateIds: string[];
   pendingValues: AddFormValuesInput;
 }): void {
   const modal = document.getElementById("link-picker-modal");
@@ -417,9 +415,9 @@ function renderLinkPickerFromContext(linkPicker: {
   message.textContent = linkPicker.message;
   list.innerHTML = renderAmbiguousLinkCandidates(
     linkPicker.candidates,
-    linkPicker.selectedCandidateId,
+    linkPicker.selectedCandidateIds,
   );
-  submit.disabled = !linkPicker.selectedCandidateId;
+  submit.disabled = linkPicker.selectedCandidateIds.length === 0;
 }
 
 function populateAddFormFromCandidate(candidate: LinkReleaseCandidate): void {

--- a/src/ui/state/add-form-machine.ts
+++ b/src/ui/state/add-form-machine.ts
@@ -23,13 +23,13 @@ export interface AddFormContext {
   scanState: "idle" | "scanning";
   submitState: "idle" | "submitting" | "error";
   showSecondaryFields: boolean;
-  pendingValues: AddFormValuesInput | null;
+  pendingValues: AddFormValuesInput[] | null;
   createdItemId: number | null;
   linkPicker: {
     url: string;
     message: string;
     candidates: LinkReleaseCandidate[];
-    selectedCandidateId: string | null;
+    selectedCandidateIds: string[];
     pendingValues: AddFormValuesInput;
   } | null;
   pendingScanBase64: string | null;
@@ -51,7 +51,7 @@ export type AddFormEvent =
       candidates: LinkReleaseCandidate[];
       pendingValues: AddFormValuesInput;
     }
-  | { type: "CANDIDATE_SELECTED"; candidateId: string }
+  | { type: "CANDIDATE_TOGGLED"; candidateId: string }
   | { type: "CANDIDATE_SUBMITTED" }
   | { type: "LINK_PICKER_CANCELLED" }
   | { type: "ENTER_MANUALLY" }
@@ -87,51 +87,57 @@ export const addFormMachine = setup({
     ),
     submitItem: fromPromise<
       { itemId: number },
-      { api: ApiClient; values: AddFormValuesInput; selectedStackIds: number[] }
+      { api: ApiClient; valuesArray: AddFormValuesInput[]; selectedStackIds: number[] }
     >(async ({ input }) => {
-      const { api, values, selectedStackIds } = input;
+      const { api, valuesArray, selectedStackIds } = input;
+      let lastItemId = 0;
 
-      // Enrich with MusicBrainz (non-fatal)
-      let enrichedValues = { ...values };
-      let musicbrainzReleaseId: string | undefined;
-      let musicbrainzArtistId: string | undefined;
+      for (const values of valuesArray) {
+        // Enrich with MusicBrainz (non-fatal)
+        let enrichedValues = { ...values };
+        let musicbrainzReleaseId: string | undefined;
+        let musicbrainzArtistId: string | undefined;
 
-      if (values.artist.trim() && values.title.trim()) {
-        try {
-          const enrichment = await api.lookupRelease(
-            values.artist.trim(),
-            values.title.trim(),
-            values.year.trim() || undefined,
-          );
-          if (enrichment.year != null && !values.year.trim())
-            enrichedValues.year = String(enrichment.year);
-          if (enrichment.label && !values.label.trim()) enrichedValues.label = enrichment.label;
-          if (enrichment.country && !values.country.trim())
-            enrichedValues.country = enrichment.country;
-          if (enrichment.catalogueNumber && !values.catalogueNumber.trim())
-            enrichedValues.catalogueNumber = enrichment.catalogueNumber;
-          if (enrichment.artworkUrl && !values.artworkUrl.trim())
-            enrichedValues.artworkUrl = enrichment.artworkUrl;
-          if (enrichment.musicbrainzReleaseId)
-            musicbrainzReleaseId = enrichment.musicbrainzReleaseId;
-          if (enrichment.musicbrainzArtistId) musicbrainzArtistId = enrichment.musicbrainzArtistId;
-        } catch {
-          // non-fatal
+        if (values.artist.trim() && values.title.trim()) {
+          try {
+            const enrichment = await api.lookupRelease(
+              values.artist.trim(),
+              values.title.trim(),
+              values.year.trim() || undefined,
+            );
+            if (enrichment.year != null && !values.year.trim())
+              enrichedValues.year = String(enrichment.year);
+            if (enrichment.label && !values.label.trim()) enrichedValues.label = enrichment.label;
+            if (enrichment.country && !values.country.trim())
+              enrichedValues.country = enrichment.country;
+            if (enrichment.catalogueNumber && !values.catalogueNumber.trim())
+              enrichedValues.catalogueNumber = enrichment.catalogueNumber;
+            if (enrichment.artworkUrl && !values.artworkUrl.trim())
+              enrichedValues.artworkUrl = enrichment.artworkUrl;
+            if (enrichment.musicbrainzReleaseId)
+              musicbrainzReleaseId = enrichment.musicbrainzReleaseId;
+            if (enrichment.musicbrainzArtistId)
+              musicbrainzArtistId = enrichment.musicbrainzArtistId;
+          } catch {
+            // non-fatal
+          }
         }
+
+        const item = await api.createMusicItem({
+          ...buildCreateMusicItemInputFromValues(enrichedValues),
+          listenStatus: "to-listen",
+          musicbrainzReleaseId,
+          musicbrainzArtistId,
+        });
+
+        if (selectedStackIds.length > 0) {
+          await api.setItemStacks(item.id, selectedStackIds);
+        }
+
+        lastItemId = item.id;
       }
 
-      const item = await api.createMusicItem({
-        ...buildCreateMusicItemInputFromValues(enrichedValues),
-        listenStatus: "to-listen",
-        musicbrainzReleaseId,
-        musicbrainzArtistId,
-      });
-
-      if (selectedStackIds.length > 0) {
-        await api.setItemStacks(item.id, selectedStackIds);
-      }
-
-      return { itemId: item.id };
+      return { itemId: lastItemId };
     }),
   },
 }).createMachine({
@@ -224,7 +230,7 @@ export const addFormMachine = setup({
             // url is present — go to submitting
             target: "submitting",
             actions: assign(({ event }) => ({
-              pendingValues: event.pendingValues ?? null,
+              pendingValues: event.pendingValues ? [event.pendingValues] : null,
               submitState: "submitting" as const,
             })),
           },
@@ -236,7 +242,7 @@ export const addFormMachine = setup({
               url: event.url,
               message: event.message,
               candidates: event.candidates,
-              selectedCandidateId: null,
+              selectedCandidateIds: [],
               pendingValues: event.pendingValues,
             },
           })),
@@ -249,7 +255,7 @@ export const addFormMachine = setup({
           guard: ({ event }) => event.pendingValues != null,
           target: "submitting",
           actions: assign(({ event }) => ({
-            pendingValues: event.pendingValues,
+            pendingValues: event.pendingValues ? [event.pendingValues] : null,
             submitState: "submitting" as const,
           })),
         },
@@ -260,7 +266,7 @@ export const addFormMachine = setup({
               url: event.url,
               message: event.message,
               candidates: event.candidates,
-              selectedCandidateId: null,
+              selectedCandidateIds: [],
               pendingValues: event.pendingValues,
             },
           })),
@@ -269,30 +275,39 @@ export const addFormMachine = setup({
     },
     linkPickerOpen: {
       on: {
-        CANDIDATE_SELECTED: {
-          actions: assign(({ context, event }) => ({
-            linkPicker: context.linkPicker
-              ? { ...context.linkPicker, selectedCandidateId: event.candidateId }
-              : null,
-          })),
+        CANDIDATE_TOGGLED: {
+          actions: assign(({ context, event }) => {
+            if (!context.linkPicker) return {};
+            const ids = context.linkPicker.selectedCandidateIds;
+            const isSelected = ids.includes(event.candidateId);
+            return {
+              linkPicker: {
+                ...context.linkPicker,
+                selectedCandidateIds: isSelected
+                  ? ids.filter((id) => id !== event.candidateId)
+                  : [...ids, event.candidateId],
+              },
+            };
+          }),
         },
         CANDIDATE_SUBMITTED: {
-          guard: ({ context }) => context.linkPicker?.selectedCandidateId != null,
+          guard: ({ context }) => (context.linkPicker?.selectedCandidateIds.length ?? 0) > 0,
           target: "submitting",
           actions: assign(({ context }) => {
-            const candidate = context.linkPicker!.candidates.find(
-              (c) => c.candidateId === context.linkPicker!.selectedCandidateId,
-            );
-            const base = context.linkPicker!.pendingValues;
+            const { selectedCandidateIds, candidates, pendingValues: base } = context.linkPicker!;
+            const selectedCandidates = selectedCandidateIds
+              .map((id) => candidates.find((c) => c.candidateId === id))
+              .filter((c): c is LinkReleaseCandidate => c != null);
             return {
-              pendingValues: candidate
-                ? {
-                    ...base,
-                    artist: candidate.artist ?? base.artist,
-                    title: candidate.title || base.title,
-                    itemType: candidate.itemType ?? base.itemType,
-                  }
-                : base,
+              pendingValues:
+                selectedCandidates.length > 0
+                  ? selectedCandidates.map((candidate) => ({
+                      ...base,
+                      artist: candidate.artist ?? base.artist,
+                      title: candidate.title || base.title,
+                      itemType: candidate.itemType ?? base.itemType,
+                    }))
+                  : [base],
               submitState: "submitting" as const,
               linkPicker: null,
             };
@@ -364,7 +379,7 @@ export const addFormMachine = setup({
         src: "submitItem",
         input: ({ context }) => ({
           api: context.api,
-          values: context.pendingValues!,
+          valuesArray: context.pendingValues!,
           selectedStackIds: context.selectedStackIds,
         }),
         onDone: {
@@ -387,8 +402,8 @@ export const addFormMachine = setup({
                 url: (event.error as AmbiguousLinkApiError).payload.url,
                 message: (event.error as AmbiguousLinkApiError).payload.message,
                 candidates: (event.error as AmbiguousLinkApiError).payload.candidates,
-                selectedCandidateId: null,
-                pendingValues: context.pendingValues!,
+                selectedCandidateIds: [],
+                pendingValues: context.pendingValues![0],
               },
             })),
           },

--- a/src/ui/view/templates.ts
+++ b/src/ui/view/templates.ts
@@ -229,11 +229,11 @@ export function renderStackDropdownContent(
 
 export function renderAmbiguousLinkCandidates(
   candidates: LinkReleaseCandidate[],
-  selectedCandidateId: string | null,
+  selectedCandidateIds: string[],
 ): string {
   return candidates
     .map((candidate) => {
-      const isSelected = candidate.candidateId === selectedCandidateId;
+      const isSelected = selectedCandidateIds.includes(candidate.candidateId);
       return `
         <button
           type="button"

--- a/tests/unit/app-state-machines.test.ts
+++ b/tests/unit/app-state-machines.test.ts
@@ -127,7 +127,7 @@ describe("add form machine — secondary fields and link picker", () => {
     const ctx = actor.getSnapshot().context;
     expect(actor.getSnapshot().value).toBe("linkPickerOpen");
     expect(ctx.linkPicker?.candidates).toHaveLength(1);
-    expect(ctx.linkPicker?.selectedCandidateId).toBeNull();
+    expect(ctx.linkPicker?.selectedCandidateIds).toEqual([]);
   });
 
   it("selects a link picker candidate", () => {
@@ -152,8 +152,8 @@ describe("add form machine — secondary fields and link picker", () => {
       candidates: [{ candidateId: "a", title: "Release A", artist: "Artist", itemType: "album" }],
       pendingValues,
     });
-    actor.send({ type: "CANDIDATE_SELECTED", candidateId: "a" });
-    expect(actor.getSnapshot().context.linkPicker?.selectedCandidateId).toBe("a");
+    actor.send({ type: "CANDIDATE_TOGGLED", candidateId: "a" });
+    expect(actor.getSnapshot().context.linkPicker?.selectedCandidateIds).toEqual(["a"]);
   });
 
   it("cancels link picker and returns to idle", () => {
@@ -379,7 +379,7 @@ describe("add form machine — async submit flow", () => {
     await waitFor(actor, (snapshot) => snapshot.value !== "submitting", { timeout: 5000 });
     expect(actor.getSnapshot().value).toBe("linkPickerOpen");
 
-    actor.send({ type: "CANDIDATE_SELECTED", candidateId: "a" });
+    actor.send({ type: "CANDIDATE_TOGGLED", candidateId: "a" });
     actor.send({ type: "CANDIDATE_SUBMITTED" });
     expect(actor.getSnapshot().value).toBe("submitting");
 


### PR DESCRIPTION
## Summary
This PR extends the link picker functionality to support selecting and submitting multiple candidates simultaneously, rather than being limited to a single selection. This enables batch creation of music items from multiple matching releases.

## Key Changes

- **Multiple candidate selection**: Changed `selectedCandidateId` (single string) to `selectedCandidateIds` (string array) in the link picker context, allowing users to toggle multiple candidates on/off
- **Batch item creation**: Modified the `submitItem` action to accept and process an array of form values (`valuesArray`) instead of a single value, creating multiple items in a loop
- **Event rename**: Renamed `CANDIDATE_SELECTED` event to `CANDIDATE_TOGGLED` to better reflect the toggle behavior (select/deselect)
- **Pending values as array**: Changed `pendingValues` in the form context from a single object to an array to support batch submissions
- **UI updates**: Updated the link picker rendering and event handlers to work with multiple selections, including:
  - Submit button now enables when at least one candidate is selected
  - Candidate list items show selection state based on array membership
  - Manual entry flow uses the first selected candidate if available

## Implementation Details

- The `submitItem` promise now iterates through each value in the array, enriching each with MusicBrainz data and creating separate items
- The last created item ID is returned from the batch operation
- Link picker state properly handles toggling: clicking a selected candidate removes it, clicking an unselected one adds it
- When candidates are submitted, all selected candidates are mapped to enriched form values and submitted as a batch

https://claude.ai/code/session_01DEzLchUNV1u2Lh4MhP2ivs