### PR TITLE
Add client-side router for audio-preserving SPA navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       </div>
     </header>
 
-    <main class="main">
+    <main id="main" class="main">
       <section class="add-section">
         <form id="add-form" class="add-form" method="post">
           <div class="add-form__primary">
@@ -336,6 +336,9 @@
     </div>
 
     <div id="now-playing-player" aria-hidden="true"></div>
+
+    <!-- Persistent release-page view: populated by src/router.ts on SPA navigation -->
+    <div id="release-view" hidden></div>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -147,7 +147,7 @@ function renderMainPage(opts: {
         </div>
       </header>
 
-      <main class="main">
+      <main id="main" class="main">
         <section class="add-section">
           <form id="add-form" class="add-form" method="post">
             <div class="add-form__primary">
@@ -446,6 +446,9 @@ function renderMainPage(opts: {
       </div>
 
       <div id="now-playing-player" aria-hidden="true"></div>
+
+      <!-- Persistent release-page view: populated by src/router.ts on SPA navigation -->
+      <div id="release-view" hidden></div>
 
       <div id="add-loading-overlay" class="add-loading-overlay" aria-hidden="true">
         <div

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { initialize } from "./app";
+import { initRouter } from "./router";
 
 async function bootstrap() {
   try {
     await initialize();
+    initRouter();
     console.log("[App] Initialized successfully");
   } catch (error) {
     console.error("[App] Failed to initialize:", error);

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,115 @@
+/**
+ * Client-side router for seamless audio-preserving navigation.
+ *
+ * Strategy: show/hide rather than replace.
+ * - <main id="main"> stays in the DOM throughout (preserving all app.ts state/listeners).
+ * - <div id="release-view"> is a sibling that receives fetched release-page content.
+ * - #now-playing-player (the audio iframe container) is never touched.
+ *
+ * Dev server: /r/* is already handled by Hono SSR — fetch works as-is.
+ * Production:  Hono serves /r/* via SSR and has a static catch-all; no nginx needed.
+ */
+
+let activeBackdropEl: HTMLElement | null = null;
+
+function runScripts(sourceDoc: Document): void {
+  // Execute inline scripts as type="module" so each has its own lexical scope.
+  // Module scripts run asynchronously but DOM is already in place by the time they run.
+  sourceDoc.body.querySelectorAll("script:not([src])").forEach((old) => {
+    const el = document.createElement("script");
+    el.type = "module";
+    el.textContent = old.textContent ?? "";
+    document.head.appendChild(el);
+  });
+}
+
+async function navigateToRelease(path: string): Promise<void> {
+  const main = document.getElementById("main") as HTMLElement | null;
+  const releaseView = document.getElementById("release-view");
+  if (!main || !releaseView) return;
+
+  let res: Response;
+  try {
+    res = await fetch(path);
+  } catch {
+    return;
+  }
+  if (!res.ok) return;
+
+  const doc = new DOMParser().parseFromString(await res.text(), "text/html");
+  const remoteMain = doc.querySelector("main");
+  if (!remoteMain) return;
+
+  // Backdrop (release pages with artwork inject a fixed bg element directly in <body>)
+  activeBackdropEl?.remove();
+  activeBackdropEl = null;
+  const backdrop = doc.querySelector<HTMLElement>(".release-page__backdrop");
+  if (backdrop) {
+    activeBackdropEl = backdrop.cloneNode(true) as HTMLElement;
+    document.body.insertBefore(activeBackdropEl, document.body.firstChild);
+  }
+
+  releaseView.innerHTML = remoteMain.innerHTML;
+  document.body.classList.toggle(
+    "release-page-body",
+    doc.body.classList.contains("release-page-body"),
+  );
+  main.hidden = true;
+  releaseView.hidden = false;
+
+  runScripts(doc);
+}
+
+function navigateToMain(): void {
+  const main = document.getElementById("main") as HTMLElement | null;
+  const releaseView = document.getElementById("release-view");
+  if (!main || !releaseView) return;
+
+  releaseView.hidden = true;
+  releaseView.innerHTML = "";
+  activeBackdropEl?.remove();
+  activeBackdropEl = null;
+  document.body.classList.remove("release-page-body");
+  main.hidden = false;
+}
+
+function handleClick(e: MouseEvent): void {
+  const a = (e.target as Element).closest<HTMLAnchorElement>("a[href]");
+  if (!a) return;
+  let url: URL;
+  try {
+    url = new URL(a.href, location.href);
+  } catch {
+    return;
+  }
+  if (url.hostname !== location.hostname) return;
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+  if (a.target && a.target !== "_self") return;
+
+  const { pathname } = url;
+  if (/^\/r\/\d+/.test(pathname)) {
+    e.preventDefault();
+    history.pushState({}, "", pathname);
+    void navigateToRelease(pathname);
+  } else if (pathname === "/") {
+    // Only intercept the back-link when we're already in the release view
+    if (!document.getElementById("release-view")?.hidden) {
+      e.preventDefault();
+      history.pushState({}, "", pathname);
+      navigateToMain();
+    }
+  }
+}
+
+function handlePopstate(): void {
+  if (/^\/r\/\d+/.test(location.pathname)) {
+    void navigateToRelease(location.pathname);
+  } else {
+    navigateToMain();
+  }
+}
+
+export function initRouter(): void {
+  document.addEventListener("click", handleClick);
+  window.addEventListener("popstate", handlePopstate);
+}


### PR DESCRIPTION
## Summary
Implements a client-side router that enables seamless navigation between the main page and release pages while preserving audio playback state. The router uses a show/hide strategy rather than full page replacement, keeping the main app DOM and audio player intact throughout navigation.

## Key Changes
- **New `src/router.ts` module**: Implements client-side routing with the following features:
  - Intercepts internal link clicks and uses `history.pushState` for SPA-style navigation
  - Fetches release page content and injects it into a persistent `#release-view` container
  - Manages backdrop elements (artwork backgrounds) for release pages
  - Executes inline scripts from fetched pages as ES modules
  - Handles browser back/forward via `popstate` events
  - Preserves `#main` and `#now-playing-player` in the DOM at all times

- **Updated `index.html` and `server/routes/main-page.ts`**:
  - Added `id="main"` to the main element for router reference
  - Added persistent `<div id="release-view" hidden>` container for release page content

- **Updated `src/main.ts`**:
  - Calls `initRouter()` during app bootstrap to enable client-side routing

## Implementation Details
- The router distinguishes between release page paths (`/r/\d+`) and the main page (`/`)
- Respects standard link behavior: ignores modifier keys (cmd/ctrl/shift/alt), target attributes, and cross-origin links
- Manages CSS class toggling on `<body>` for release page styling
- Cleans up backdrop elements when navigating away from release pages
- Works with both dev server (Hono SSR) and production (static catch-all) without additional server configuration

https://claude.ai/code/session_01K4s57eWFz9H5GuCEUw7qiJ