### PR TITLE
Skip Apple Music lookup if secondary link already exists

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -691,7 +691,8 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
       // ── Apple Music secondary link lookup ────────────────────────────────
       const PLAYABLE_SOURCES = new Set(['bandcamp','spotify','soundcloud','youtube','apple_music','tidal','deezer','mixcloud']);
       const primarySource = ${JSON.stringify(item.primary_source)};
-      if (!primarySource || !PLAYABLE_SOURCES.has(primarySource)) {
+      const hasAppleMusicSecondary = ${JSON.stringify(item.links.some((l) => l.source_name === "apple_music" && !l.is_primary))};
+      if (!hasAppleMusicSecondary && (!primarySource || !PLAYABLE_SOURCES.has(primarySource))) {
         fetch('/api/release/apple-music-lookup/' + ITEM_ID, { method: 'POST' })
           .then(r => r.ok ? r.json() : null)
           .then(data => {


### PR DESCRIPTION
## Summary
Optimize the Apple Music secondary link lookup by skipping the API call when a secondary Apple Music link already exists on the release item.

## Key Changes
- Added check for existing Apple Music secondary links before triggering the lookup API call
- The lookup is now only performed when there's no secondary Apple Music link AND either no primary source is set or the primary source is not in the playable sources list
- This reduces unnecessary API calls and improves performance for releases that already have Apple Music secondary links populated

## Implementation Details
- Extracted `hasAppleMusicSecondary` from the item's links array to check if any non-primary Apple Music links exist
- Modified the conditional logic to short-circuit the fetch request when a secondary Apple Music link is already available
- The change maintains backward compatibility while optimizing the lookup behavior

https://claude.ai/code/session_01XBFcz3Jd9amcnFduCZQUFX