### PR TITLE
Fix filter bar overflow and prevent button shrinking

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1227,6 +1227,7 @@ select.input {
     height: 32px;
     padding: 0 12px;
     font-size: 12px;
+    flex-shrink: 0;
   }
 
   .filter-bar {
@@ -1234,6 +1235,8 @@ select.input {
     gap: 4px;
     flex-wrap: nowrap;
     align-items: center;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .filter-bar::before {


### PR DESCRIPTION
## Summary
Improved the filter bar layout to handle overflow scenarios and prevent filter buttons from shrinking unexpectedly.

## Key Changes
- Added `flex-shrink: 0` to filter buttons to maintain their minimum width and prevent compression
- Enabled horizontal scrolling on the filter bar with `overflow-x: auto` for better handling of many filters
- Added `-webkit-overflow-scrolling: touch` for smooth momentum scrolling on iOS devices

## Implementation Details
These changes ensure that when the filter bar contains many buttons and exceeds the available width, the buttons remain at their intended size and the container becomes horizontally scrollable rather than causing layout distortion. This provides a better user experience on both desktop and mobile devices.

https://claude.ai/code/session_01FJmdMKnnvt1BVRxha4A4m1