### PR TITLE
feat: sort direction toggle with explicit date-added and date-listened options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@ This project uses Bun, not node.
 ### On pushing
 - Create a PR
 - check the the Github checks for the branch have passed. If they fail investigate and fix the error.
+
+- When making visual changes always consider how they will look on smaller screens (mobiles/tablets etc).

--- a/docs/plans/2026-04-09-sort-direction-design.md
+++ b/docs/plans/2026-04-09-sort-direction-design.md
@@ -1,0 +1,77 @@
+# Sort Direction Design
+
+**Date:** 2026-04-09
+
+## Goal
+
+Add explicit "Date added" and "Date listened" sort options with a reversible sort direction toggle. All existing sorts (artist name, release name, star rating) also become reversible.
+
+## Decisions
+
+- `"default"` sort is replaced by `"date-added"`, which is the default selection
+- `"date-listened"` is only available when the Listened filter is active
+- A single direction toggle applies to whichever sort is active
+- Nulls always sort last regardless of direction
+
+## Types (`src/types/index.ts`)
+
+```ts
+type MusicItemSort =
+  | "date-added"
+  | "date-listened"
+  | "artist-name"
+  | "release-name"
+  | "star-rating";
+
+type MusicItemSortDirection = "asc" | "desc";
+```
+
+`MusicItemFilters` gains `sortDirection?: MusicItemSortDirection`.
+
+## State machine (`src/ui/state/app-machine.ts`)
+
+- `currentSort: MusicItemSort` — default `"date-added"`
+- `currentSortDirection: MusicItemSortDirection` — default `"desc"`
+- New event `SORT_DIRECTION_UPDATED` increments `listVersion`
+- `isBrowseOrderLocked()` check becomes `currentSort !== "date-added"`
+
+## Server (`server/routes/music-items.ts`)
+
+New `sortDirection` query param (`"asc" | "desc"`, default `"desc"`).
+
+Each sort branch applies direction dynamically. Null-pushdown `CASE WHEN ... IS NULL` clauses always push nulls last regardless of direction.
+
+```ts
+// date-added
+query = query.orderBy(
+  direction === "asc" ? asc(musicItems.createdAt) : desc(musicItems.createdAt),
+  direction === "asc" ? asc(musicItems.id) : desc(musicItems.id),
+);
+
+// date-listened
+query = query.orderBy(
+  direction === "asc" ? asc(musicItems.listenedAt) : desc(musicItems.listenedAt),
+  direction === "asc" ? asc(musicItems.id) : desc(musicItems.id),
+);
+
+// artist-name
+query = query.orderBy(
+  sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
+  direction === "asc" ? asc(artists.normalizedName) : desc(artists.normalizedName),
+  direction === "asc" ? asc(musicItems.normalizedTitle) : desc(musicItems.normalizedTitle),
+  desc(musicItems.id),
+);
+```
+
+## API client (`src/services/api-client.ts`)
+
+Sends `sortDirection` as a query param alongside `sort`.
+
+## UI (`server/routes/main-page.ts`, `src/app.ts`)
+
+- Sort `<select>`: remove `"default"`, add `"date-added"` as first/selected option
+- Add `"date-listened"` option — hidden unless active filter is `"listened"`
+- Direction toggle button alongside the select:
+  - Date sorts: `↓ Newest first` / `↑ Oldest first`
+  - Name/rating sorts: `↓ Z–A` / `↑ A–Z` and `↓ Lowest` / `↑ Highest`
+- Button label updates when sort or direction changes

--- a/docs/plans/2026-04-10-mobile-sort-panel-design.md
+++ b/docs/plans/2026-04-10-mobile-sort-panel-design.md
@@ -1,0 +1,57 @@
+# Mobile Sort Panel Design
+
+**Date:** 2026-04-10
+
+## Problem
+
+On mobile the sort panel opens as a floating overlay from the sort icon button. The direction button stacks awkwardly below the select with no styling. Separately, there is a visual gap below the filter buttons caused by the icon buttons being stacked vertically (~63px tall vs ~34px for the filter bar).
+
+## Design
+
+CSS-only fix. No HTML changes.
+
+### Fix the gap
+
+Change `.browse-tools__mobile-actions` from `flex-direction: column` to `flex-direction: row`. The two icon buttons (search, sort) sit side-by-side, matching the filter bar height. Gap disappears by default.
+
+### Reposition the sort panel
+
+Make `.browse-controls` the positioning context (`position: relative`). The sort panel uses `position: absolute; top: 100%; left: 0; right: 0` — anchored to the bottom of the browse-controls row, full width.
+
+Change `.browse-tools__panel--sort.is-open` from `display: block` to `display: flex` so the select and direction button sit side-by-side on one line.
+
+## Result
+
+```
+[FILTER: All | To Listen | Listened | Scheduled] [🔍][↕]   ← single tight row, no gap
+[Sort ──────────────────────────── ↓ Newest first]          ← appears on tap, full width
+```
+
+The search panel is unchanged (narrower overlay from the right).
+
+## CSS Changes (mobile breakpoint only)
+
+```css
+.browse-controls {
+  position: relative;
+}
+
+.browse-tools__mobile-actions {
+  flex-direction: row;       /* was column */
+  align-items: center;       /* was stretch */
+}
+
+.browse-tools__panel--sort {
+  top: 100%;                 /* anchor below browse-controls row */
+  left: 0;
+  right: 0;
+  width: auto;
+  min-width: 0;
+}
+
+.browse-tools__panel--sort.is-open {
+  display: flex;             /* was block — allows select + button side-by-side */
+  align-items: center;
+  gap: 6px;
+}
+```

--- a/docs/plans/2026-04-10-sort-direction.md
+++ b/docs/plans/2026-04-10-sort-direction.md
@@ -1,0 +1,443 @@
+# Sort Direction Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the implicit "default" sort with explicit "Date added" / "Date listened" options, add a sort direction toggle (asc/desc) that applies to all sort fields.
+
+**Architecture:** Types change first, then the data flows downstream: state machine → domain helper → API client → server route → HTML. Each step is small and self-contained. No migrations needed — `listenedAt` and `createdAt` columns already exist.
+
+**Tech Stack:** TypeScript, XState v5, Hono, Drizzle ORM, SQLite
+
+---
+
+### Task 1: Update types
+
+**Files:**
+- Modify: `src/types/index.ts:6`
+- Modify: `src/types/index.ts` (MusicItemFilters interface, line ~134)
+
+**Step 1: Update MusicItemSort, add MusicItemSortDirection**
+
+Replace line 6:
+```ts
+export type MusicItemSort = "date-added" | "date-listened" | "artist-name" | "release-name" | "star-rating";
+export type MusicItemSortDirection = "asc" | "desc";
+```
+
+**Step 2: Add sortDirection to MusicItemFilters**
+
+Find the `MusicItemFilters` interface and add:
+```ts
+sortDirection?: MusicItemSortDirection;
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: errors only from downstream callers of the changed types (state machine, api-client etc) — not from types/index.ts itself.
+
+**Step 4: Commit**
+
+```bash
+git add src/types/index.ts
+git commit -m "feat: add date-added/date-listened sort options and sort direction type"
+```
+
+---
+
+### Task 2: Update state machine
+
+**Files:**
+- Modify: `src/ui/state/app-machine.ts`
+
+**Step 1: Add import and new fields**
+
+Import `MusicItemSortDirection` alongside `MusicItemSort` (line 2):
+```ts
+import type { ListenStatus, MusicItemSort, MusicItemSortDirection, StackWithCount } from "../../types";
+```
+
+Add `currentSortDirection: MusicItemSortDirection;` to the `AppContext` interface.
+
+Add `SORT_DIRECTION_UPDATED` event to `AppEvent`:
+```ts
+| { type: "SORT_DIRECTION_UPDATED"; direction: MusicItemSortDirection }
+```
+
+**Step 2: Update context defaults**
+
+Change `currentSort: "default"` → `currentSort: "date-added"` (line 41).
+
+Add `currentSortDirection: "desc"` alongside it.
+
+**Step 3: Add SORT_DIRECTION_UPDATED handler**
+
+After the `SORT_UPDATED` handler (line ~87), add:
+```ts
+SORT_DIRECTION_UPDATED: {
+  actions: assign(({ context, event }) => ({
+    currentSortDirection: event.direction,
+    listVersion: context.listVersion + 1,
+  })),
+},
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: errors only in app.ts and domain helper, not in app-machine.ts.
+
+**Step 5: Commit**
+
+```bash
+git add src/ui/state/app-machine.ts
+git commit -m "feat: add sort direction to app state machine"
+```
+
+---
+
+### Task 3: Update domain helper
+
+**Files:**
+- Modify: `src/ui/domain/music-list.ts`
+
+**Step 1: Update import and signature**
+
+Add `MusicItemSortDirection` to the import on line 1.
+
+Add `currentSortDirection: MusicItemSortDirection = "desc"` as a 5th parameter to `buildMusicItemFilters`.
+
+**Step 2: Pass direction into filters and remove the "default" guard**
+
+Replace the current sort block:
+```ts
+// Old:
+if (currentSort !== "default") {
+  filters.sort = currentSort;
+}
+
+// New:
+filters.sort = currentSort;
+filters.sortDirection = currentSortDirection;
+```
+
+**Step 3: Verify build**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: error only in app.ts call site.
+
+**Step 4: Commit**
+
+```bash
+git add src/ui/domain/music-list.ts
+git commit -m "feat: pass sort direction through music list filters"
+```
+
+---
+
+### Task 4: Update API client
+
+**Files:**
+- Modify: `src/services/api-client.ts:148-150`
+
+**Step 1: Send sort and sortDirection**
+
+Replace the existing sort block (lines 148-150):
+```ts
+if (filters?.sort) {
+  params.set("sort", filters.sort);
+}
+if (filters?.sortDirection) {
+  params.set("sortDirection", filters.sortDirection);
+}
+```
+
+(The `!== "default"` guard is removed because `"default"` no longer exists.)
+
+**Step 2: Verify build**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: errors only in server route.
+
+**Step 3: Commit**
+
+```bash
+git add src/services/api-client.ts
+git commit -m "feat: send sortDirection query param in API client"
+```
+
+---
+
+### Task 5: Update server route
+
+**Files:**
+- Modify: `server/routes/music-items.ts:174-271`
+
+**Step 1: Parse sortDirection**
+
+In the GET `/` handler, destructure `sortDirection` alongside the other query params (line 175):
+```ts
+const { listenStatus, purchaseIntent, search, sort, sortDirection, stackId, hasReminder } = c.req.query();
+```
+
+Add a local helper just before the sort branches:
+```ts
+const dir = sortDirection === "asc" ? "asc" : "desc";
+```
+
+**Step 2: Update sort validation**
+
+Replace the `requestedSort` assignment and validation block (lines 181-185):
+```ts
+const validSorts = ["date-added", "date-listened", "artist-name", "release-name", "star-rating"] as const;
+type ValidSort = typeof validSorts[number];
+const requestedSort: ValidSort =
+  validSorts.includes(sort as ValidSort) ? (sort as ValidSort) : "date-added";
+if (sort && !validSorts.includes(sort as ValidSort)) {
+  return c.json({ error: "Invalid sort" }, 400);
+}
+```
+
+**Step 3: Replace all sort branches**
+
+Replace the entire if/else sort block (lines 240-271) with:
+```ts
+if (requestedSort === "artist-name") {
+  query = query.orderBy(
+    sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
+    dir === "asc" ? asc(artists.normalizedName) : desc(artists.normalizedName),
+    dir === "asc" ? asc(musicItems.normalizedTitle) : desc(musicItems.normalizedTitle),
+    desc(musicItems.id),
+  );
+} else if (requestedSort === "release-name") {
+  query = query.orderBy(
+    dir === "asc" ? asc(musicItems.normalizedTitle) : desc(musicItems.normalizedTitle),
+    sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
+    dir === "asc" ? asc(artists.normalizedName) : desc(artists.normalizedName),
+    desc(musicItems.id),
+  );
+} else if (requestedSort === "star-rating") {
+  query = query.orderBy(
+    sql`CASE WHEN ${musicItems.rating} IS NULL THEN 1 ELSE 0 END`,
+    dir === "asc" ? asc(musicItems.rating) : desc(musicItems.rating),
+    sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
+    asc(artists.normalizedName),
+    asc(musicItems.normalizedTitle),
+    desc(musicItems.id),
+  );
+} else if (requestedSort === "date-listened") {
+  query = query.orderBy(
+    sql`CASE WHEN ${musicItems.listenedAt} IS NULL THEN 1 ELSE 0 END`,
+    dir === "asc" ? asc(musicItems.listenedAt) : desc(musicItems.listenedAt),
+    dir === "asc" ? asc(musicItems.id) : desc(musicItems.id),
+  );
+} else {
+  // date-added (default)
+  query = query.orderBy(
+    dir === "asc" ? asc(musicItems.createdAt) : desc(musicItems.createdAt),
+    dir === "asc" ? asc(musicItems.id) : desc(musicItems.id),
+  );
+}
+```
+
+**Step 4: Verify build**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: clean build.
+
+**Step 5: Commit**
+
+```bash
+git add server/routes/music-items.ts
+git commit -m "feat: implement sort direction on all server sort branches"
+```
+
+---
+
+### Task 6: Update HTML (sort panel)
+
+**Files:**
+- Modify: `server/routes/main-page.ts:379-389`
+
+**Step 1: Replace sort panel contents**
+
+Replace the sort panel div (lines 379-389):
+```html
+<div id="browse-sort-panel" class="browse-tools__panel browse-tools__panel--sort">
+  <label class="browse-tools__sort" for="browse-sort">
+    <span>Sort</span>
+    <select id="browse-sort" class="input">
+      <option value="date-added">Date added</option>
+      <option value="date-listened" id="sort-option-date-listened" hidden>Date listened</option>
+      <option value="artist-name">Artist A–Z</option>
+      <option value="release-name">Release A–Z</option>
+      <option value="star-rating">Star rating</option>
+    </select>
+  </label>
+  <button
+    type="button"
+    id="sort-direction-btn"
+    class="btn btn--ghost browse-tools__direction-btn"
+    aria-label="Sort direction: newest first"
+    data-direction="desc"
+  >↓ Newest first</button>
+</div>
+```
+
+**Step 2: Verify build**
+
+Run: `npm run build 2>&1 | head -20`
+Expected: clean.
+
+**Step 3: Commit**
+
+```bash
+git add server/routes/main-page.ts
+git commit -m "feat: update sort panel HTML with new options and direction button"
+```
+
+---
+
+### Task 7: Wire up direction button and date-listened visibility in app.ts
+
+**Files:**
+- Modify: `src/app.ts:763-841`
+
+**Step 1: Update setupBrowseControls to handle direction button**
+
+In `setupBrowseControls()`, after the sort select listener (line ~806), add:
+
+```ts
+const sortDirectionBtn = document.getElementById("sort-direction-btn");
+const sortOptionDateListened = document.getElementById("sort-option-date-listened");
+
+if (sortDirectionBtn instanceof HTMLButtonElement) {
+  sortDirectionBtn.addEventListener("click", () => {
+    const next = appCtx().currentSortDirection === "desc" ? "asc" : "desc";
+    appActor.send({ type: "SORT_DIRECTION_UPDATED", direction: next });
+    updateSortDirectionBtn(sortDirectionBtn, appCtx().currentSort, next);
+  });
+}
+```
+
+**Step 2: Add updateSortDirectionBtn helper**
+
+Add this function just before `setupBrowseControls`:
+```ts
+function updateSortDirectionBtn(
+  btn: HTMLButtonElement,
+  sort: MusicItemSort,
+  direction: MusicItemSortDirection,
+): void {
+  const isDate = sort === "date-added" || sort === "date-listened";
+  const isRating = sort === "star-rating";
+  if (isDate) {
+    btn.textContent = direction === "desc" ? "↓ Newest first" : "↑ Oldest first";
+    btn.setAttribute("aria-label", direction === "desc" ? "Sort direction: newest first" : "Sort direction: oldest first");
+  } else if (isRating) {
+    btn.textContent = direction === "desc" ? "↓ Highest first" : "↑ Lowest first";
+    btn.setAttribute("aria-label", direction === "desc" ? "Sort direction: highest first" : "Sort direction: lowest first");
+  } else {
+    btn.textContent = direction === "asc" ? "↑ A–Z" : "↓ Z–A";
+    btn.setAttribute("aria-label", direction === "asc" ? "Sort direction: A to Z" : "Sort direction: Z to A");
+  }
+  btn.dataset.direction = direction;
+}
+```
+
+**Step 3: Also update direction btn label when sort changes**
+
+In the sort select change listener, after dispatching `SORT_UPDATED`:
+```ts
+sortSelect.addEventListener("change", () => {
+  const newSort = sortSelect.value as MusicItemSort;
+  appActor.send({ type: "SORT_UPDATED", sort: newSort });
+
+  // Show/hide date-listened option
+  if (sortOptionDateListened instanceof HTMLOptionElement) {
+    sortOptionDateListened.hidden = newSort !== "date-listened";
+  }
+
+  // Update direction button label
+  if (sortDirectionBtn instanceof HTMLButtonElement) {
+    updateSortDirectionBtn(sortDirectionBtn, newSort, appCtx().currentSortDirection);
+  }
+});
+```
+
+**Step 4: Show/hide date-listened based on active filter**
+
+Find the `FILTER_SELECTED` dispatch in `setupBrowseControls` or wherever filters are applied in app.ts. After a filter change, call:
+```ts
+function syncDateListenedOption(): void {
+  const opt = document.getElementById("sort-option-date-listened");
+  const sel = document.getElementById("browse-sort");
+  if (!(opt instanceof HTMLOptionElement) || !(sel instanceof HTMLSelectElement)) return;
+  const isListened = appCtx().currentFilter === "listened";
+  opt.hidden = !isListened;
+  // If date-listened is selected but filter changed away from listened, reset to date-added
+  if (!isListened && sel.value === "date-listened") {
+    sel.value = "date-added";
+    appActor.send({ type: "SORT_UPDATED", sort: "date-added" });
+  }
+}
+```
+
+Call `syncDateListenedOption()` inside the `FILTER_SELECTED` dispatch handler (wherever `appActor.send({ type: "FILTER_SELECTED" ... })` is called in the UI).
+
+**Step 5: Update isBrowseOrderLocked**
+
+Change line 841:
+```ts
+// Old:
+return getNormalizedSearchQuery().length > 0 || appCtx().currentSort !== "default";
+// New:
+return getNormalizedSearchQuery().length > 0 || appCtx().currentSort !== "date-added" || appCtx().currentSortDirection !== "desc";
+```
+
+**Step 6: Update buildMusicItemFilters call site**
+
+In `renderMusicList` (line ~1780), pass `currentSortDirection`:
+```ts
+const filters = buildMusicItemFilters(
+  appCtx().currentFilter,
+  appCtx().currentStack,
+  appCtx().searchQuery,
+  appCtx().currentSort,
+  appCtx().currentSortDirection,
+);
+```
+
+**Step 7: Verify build**
+
+Run: `npm run build 2>&1 | head -40`
+Expected: clean build.
+
+**Step 8: Commit**
+
+```bash
+git add src/app.ts
+git commit -m "feat: wire direction button and date-listened visibility in UI"
+```
+
+---
+
+### Task 8: Manual smoke test
+
+Start the app: `npm run dev`
+
+1. Open the app — sort panel shows "Date added" selected, "↓ Newest first" button
+2. Click "↓ Newest first" → changes to "↑ Oldest first", list reverses
+3. Switch to Listened filter → "Date listened" option appears in select
+4. Select "Date listened" → list reorders by listened date
+5. Click direction button → reverses listened date order
+6. Switch back to To Listen → "Date listened" option disappears, sort resets to "Date added"
+7. Select "Artist A–Z", click direction → becomes "↓ Z–A"
+8. Select "Star rating", click direction → becomes "↑ Lowest first"
+
+**Step 9: Final commit if any fixes needed**
+
+```bash
+git add -p
+git commit -m "fix: sort direction smoke test fixes"
+```

--- a/drizzle/0007_item_suggestions.sql
+++ b/drizzle/0007_item_suggestions.sql
@@ -9,4 +9,5 @@ CREATE TABLE `item_suggestions` (
   `status` text NOT NULL DEFAULT 'pending',
   `created_at` integer NOT NULL
 );
+--> statement-breakpoint
 CREATE INDEX `idx_item_suggestions_source_item_id` ON `item_suggestions` (`source_item_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -54,6 +54,13 @@
     {
       "idx": 7,
       "version": "6",
+      "when": 1775150000000,
+      "tag": "0007_item_suggestions",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
       "when": 1775243975137,
       "tag": "0008_drop_stack_parent_unique",
       "breakpoints": true

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -46,6 +46,8 @@ export function fullItemSelect() {
       country: musicItems.country,
       genre: musicItems.genre,
       catalogue_number: musicItems.catalogueNumber,
+      musicbrainz_release_id: musicItems.musicbrainzReleaseId,
+      musicbrainz_artist_id: musicItems.musicbrainzArtistId,
       artist_name: artists.name,
       primary_url: musicLinks.url,
       primary_source: sources.name,

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -380,12 +380,20 @@ function renderMainPage(opts: {
                 <label class="browse-tools__sort" for="browse-sort">
                   <span>Sort</span>
                   <select id="browse-sort" class="input">
-                    <option value="default">Default</option>
-                    <option value="artist-name">Artist A-Z</option>
-                    <option value="release-name">Release A-Z</option>
-                    <option value="star-rating">Star Rating</option>
+                    <option value="date-added">Date added</option>
+                    <option value="date-listened" id="sort-option-date-listened" hidden>Date listened</option>
+                    <option value="artist-name">Artist A–Z</option>
+                    <option value="release-name">Release A–Z</option>
+                    <option value="star-rating">Star rating</option>
                   </select>
                 </label>
+                <button
+                  type="button"
+                  id="sort-direction-btn"
+                  class="btn btn--ghost browse-tools__direction-btn"
+                  aria-label="Sort direction: newest first"
+                  data-direction="desc"
+                >↓ Newest first</button>
               </div>
             </div>
           </div>

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -378,7 +378,6 @@ function renderMainPage(opts: {
               </div>
               <div id="browse-sort-panel" class="browse-tools__panel browse-tools__panel--sort">
                 <label class="browse-tools__sort" for="browse-sort">
-                  <span>Sort</span>
                   <select id="browse-sort" class="input">
                     <option value="date-added">Date added</option>
                     <option value="date-listened" id="sort-option-date-listened" hidden>Date listened</option>

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -29,7 +29,6 @@ import type {
   CreateMusicItemInput,
   UpdateMusicItemInput,
   ListenStatus,
-  MusicItemSort,
   PurchaseIntent,
   ItemType,
 } from "../../src/types";
@@ -172,17 +171,29 @@ async function applyArtistUpdate(
 // ---------------------------------------------------------------------------
 
 musicItemRoutes.get("/", async (c) => {
-  const { listenStatus, purchaseIntent, search, sort, stackId, hasReminder } = c.req.query();
+  const { listenStatus, purchaseIntent, search, sort, sortDirection, stackId, hasReminder } =
+    c.req.query();
   const parsedStackId = stackId ? Number(stackId) : null;
   if (parsedStackId !== null && (!Number.isInteger(parsedStackId) || parsedStackId <= 0)) {
     return c.json({ error: "Invalid stack ID" }, 400);
   }
 
-  const requestedSort: MusicItemSort =
-    sort === "artist-name" || sort === "release-name" || sort === "star-rating" ? sort : "default";
-  if (sort && sort !== "artist-name" && sort !== "release-name" && sort !== "star-rating") {
+  const validSorts = [
+    "date-added",
+    "date-listened",
+    "artist-name",
+    "release-name",
+    "star-rating",
+  ] as const;
+  type ValidSort = (typeof validSorts)[number];
+  const requestedSort: ValidSort = validSorts.includes(sort as ValidSort)
+    ? (sort as ValidSort)
+    : "date-added";
+  if (sort && !validSorts.includes(sort as ValidSort)) {
     return c.json({ error: "Invalid sort" }, 400);
   }
+
+  const dir = sortDirection === "asc" ? "asc" : "desc";
 
   // Start building conditions
   const conditions = [];
@@ -240,33 +251,37 @@ musicItemRoutes.get("/", async (c) => {
   if (requestedSort === "artist-name") {
     query = query.orderBy(
       sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
-      asc(artists.normalizedName),
-      asc(musicItems.normalizedTitle),
+      dir === "asc" ? asc(artists.normalizedName) : desc(artists.normalizedName),
+      dir === "asc" ? asc(musicItems.normalizedTitle) : desc(musicItems.normalizedTitle),
       desc(musicItems.id),
     );
   } else if (requestedSort === "release-name") {
     query = query.orderBy(
-      asc(musicItems.normalizedTitle),
+      dir === "asc" ? asc(musicItems.normalizedTitle) : desc(musicItems.normalizedTitle),
       sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
-      asc(artists.normalizedName),
+      dir === "asc" ? asc(artists.normalizedName) : desc(artists.normalizedName),
       desc(musicItems.id),
     );
   } else if (requestedSort === "star-rating") {
     query = query.orderBy(
       sql`CASE WHEN ${musicItems.rating} IS NULL THEN 1 ELSE 0 END`,
-      desc(musicItems.rating),
+      dir === "asc" ? asc(musicItems.rating) : desc(musicItems.rating),
       sql`CASE WHEN ${artists.normalizedName} IS NULL OR ${artists.normalizedName} = '' THEN 1 ELSE 0 END`,
       asc(artists.normalizedName),
       asc(musicItems.normalizedTitle),
       desc(musicItems.id),
     );
-  } else {
-    // For listened items, sort by when they were marked listened; otherwise by when added.
-    // Both timestamps are only second-resolution in SQLite, so break ties by id.
-    const isListenedOnly = listenStatus === "listened" || listenStatus === "done";
+  } else if (requestedSort === "date-listened") {
     query = query.orderBy(
-      isListenedOnly ? desc(musicItems.listenedAt) : desc(musicItems.createdAt),
-      desc(musicItems.id),
+      sql`CASE WHEN ${musicItems.listenedAt} IS NULL THEN 1 ELSE 0 END`,
+      dir === "asc" ? asc(musicItems.listenedAt) : desc(musicItems.listenedAt),
+      dir === "asc" ? asc(musicItems.id) : desc(musicItems.id),
+    );
+  } else {
+    // date-added (default)
+    query = query.orderBy(
+      dir === "asc" ? asc(musicItems.createdAt) : desc(musicItems.createdAt),
+      dir === "asc" ? asc(musicItems.id) : desc(musicItems.id),
     );
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -852,7 +852,7 @@ function setupBrowseControls(): void {
 
       // Show/hide date-listened option
       if (sortOptionDateListened instanceof HTMLOptionElement) {
-        sortOptionDateListened.hidden = newSort !== "date-listened";
+        sortOptionDateListened.hidden = appCtx().currentFilter !== "listened";
       }
 
       // Update direction button label

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import type {
   ListenStatus,
   MusicItemFull,
   MusicItemSort,
+  MusicItemSortDirection,
   StackWithCount,
 } from "./types";
 import { getCoverScanErrorMessage } from "./ui/domain/add-form";
@@ -741,6 +742,19 @@ function loadImage(dataUrl: string): Promise<HTMLImageElement> {
   });
 }
 
+function syncDateListenedOption(): void {
+  const opt = document.getElementById("sort-option-date-listened");
+  const sel = document.getElementById("browse-sort");
+  if (!(opt instanceof HTMLOptionElement) || !(sel instanceof HTMLSelectElement)) return;
+  const isListened = appCtx().currentFilter === "listened";
+  opt.hidden = !isListened;
+  // If date-listened is selected but filter changed away from listened, reset to date-added
+  if (!isListened && sel.value === "date-listened") {
+    sel.value = "date-added";
+    appActor.send({ type: "SORT_UPDATED", sort: "date-added" });
+  }
+}
+
 function setupFilterBar(): void {
   const filterBar = document.getElementById("filter-bar");
   if (!filterBar) {
@@ -757,7 +771,37 @@ function setupFilterBar(): void {
       type: "FILTER_SELECTED",
       filter: target.dataset.filter as ListenStatus | "all" | "scheduled",
     });
+    syncDateListenedOption();
   });
+}
+
+function updateSortDirectionBtn(
+  btn: HTMLButtonElement,
+  sort: MusicItemSort,
+  direction: MusicItemSortDirection,
+): void {
+  const isDate = sort === "date-added" || sort === "date-listened";
+  const isRating = sort === "star-rating";
+  if (isDate) {
+    btn.textContent = direction === "desc" ? "↓ Newest first" : "↑ Oldest first";
+    btn.setAttribute(
+      "aria-label",
+      direction === "desc" ? "Sort direction: newest first" : "Sort direction: oldest first",
+    );
+  } else if (isRating) {
+    btn.textContent = direction === "desc" ? "↓ Highest first" : "↑ Lowest first";
+    btn.setAttribute(
+      "aria-label",
+      direction === "desc" ? "Sort direction: highest first" : "Sort direction: lowest first",
+    );
+  } else {
+    btn.textContent = direction === "asc" ? "↑ A–Z" : "↓ Z–A";
+    btn.setAttribute(
+      "aria-label",
+      direction === "asc" ? "Sort direction: A to Z" : "Sort direction: Z to A",
+    );
+  }
+  btn.dataset.direction = direction;
 }
 
 function setupBrowseControls(): void {
@@ -768,6 +812,8 @@ function setupBrowseControls(): void {
   const sortToggle = document.getElementById("browse-sort-toggle");
 
   const searchClearBtn = document.getElementById("search-clear-btn");
+  const sortDirectionBtn = document.getElementById("sort-direction-btn");
+  const sortOptionDateListened = document.getElementById("sort-option-date-listened");
 
   if (searchInput instanceof HTMLInputElement) {
     const updateClearBtn = () => {
@@ -798,10 +844,29 @@ function setupBrowseControls(): void {
 
   if (sortSelect instanceof HTMLSelectElement) {
     sortSelect.addEventListener("change", () => {
+      const newSort = sortSelect.value as MusicItemSort;
       appActor.send({
         type: "SORT_UPDATED",
-        sort: sortSelect.value as MusicItemSort,
+        sort: newSort,
       });
+
+      // Show/hide date-listened option
+      if (sortOptionDateListened instanceof HTMLOptionElement) {
+        sortOptionDateListened.hidden = newSort !== "date-listened";
+      }
+
+      // Update direction button label
+      if (sortDirectionBtn instanceof HTMLButtonElement) {
+        updateSortDirectionBtn(sortDirectionBtn, newSort, appCtx().currentSortDirection);
+      }
+    });
+  }
+
+  if (sortDirectionBtn instanceof HTMLButtonElement) {
+    sortDirectionBtn.addEventListener("click", () => {
+      const next = appCtx().currentSortDirection === "desc" ? "asc" : "desc";
+      appActor.send({ type: "SORT_DIRECTION_UPDATED", direction: next });
+      updateSortDirectionBtn(sortDirectionBtn, appCtx().currentSort, next);
     });
   }
 
@@ -838,7 +903,11 @@ function getNormalizedSearchQuery(): string {
 }
 
 function isBrowseOrderLocked(): boolean {
-  return getNormalizedSearchQuery().length > 0 || appCtx().currentSort !== "default";
+  return (
+    getNormalizedSearchQuery().length > 0 ||
+    appCtx().currentSort !== "date-added" ||
+    appCtx().currentSortDirection !== "desc"
+  );
 }
 
 async function renderStackBar(): Promise<void> {
@@ -1782,6 +1851,7 @@ async function renderMusicListView(): Promise<void> {
     appCtx().currentStack,
     appCtx().searchQuery,
     appCtx().currentSort,
+    appCtx().currentSortDirection,
   );
   const result = await api.listMusicItems(filters);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -752,6 +752,10 @@ function syncDateListenedOption(): void {
   if (!isListened && sel.value === "date-listened") {
     sel.value = "date-added";
     appActor.send({ type: "SORT_UPDATED", sort: "date-added" });
+    const btn = document.getElementById("sort-direction-btn");
+    if (btn instanceof HTMLButtonElement) {
+      updateSortDirectionBtn(btn, "date-added", appCtx().currentSortDirection);
+    }
   }
 }
 
@@ -866,7 +870,7 @@ function setupBrowseControls(): void {
     sortDirectionBtn.addEventListener("click", () => {
       const next = appCtx().currentSortDirection === "desc" ? "asc" : "desc";
       appActor.send({ type: "SORT_DIRECTION_UPDATED", direction: next });
-      updateSortDirectionBtn(sortDirectionBtn, appCtx().currentSort, next);
+      updateSortDirectionBtn(sortDirectionBtn, appCtx().currentSort, appCtx().currentSortDirection);
     });
   }
 

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -145,8 +145,11 @@ export class ApiClient {
       params.set("stackId", String(filters.stackId));
     }
 
-    if (filters?.sort && filters.sort !== "default") {
+    if (filters?.sort) {
       params.set("sort", filters.sort);
+    }
+    if (filters?.sortDirection) {
+      params.set("sortDirection", filters.sortDirection);
     }
 
     if (filters?.hasReminder) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1251,6 +1251,14 @@ select.input {
     position: relative;
   }
 
+  .filter-section {
+    background: #d4d0c8;
+  }
+
+  .filter-section:has(#browse-sort-panel.is-open) {
+    padding-bottom: 46px; /* make room for the floating sort panel */
+  }
+
   .browse-tools {
     min-height: 0;
     padding: 4px 3px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1248,6 +1248,7 @@ select.input {
   .browse-controls {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: start;
+    position: relative;
   }
 
   .browse-tools {
@@ -1257,8 +1258,8 @@ select.input {
 
   .browse-tools__mobile-actions {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: center;
     gap: 3px;
   }
 
@@ -1295,8 +1296,22 @@ select.input {
     width: 100%;
   }
 
+  .browse-tools__panel--sort {
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: auto;
+    min-width: 0;
+  }
+
+  .browse-tools__panel--sort.is-open {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .browse-tools__panel--sort .browse-tools__sort {
-    width: 100%;
+    flex: 1;
     justify-content: space-between;
     font-size: 10px;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1254,12 +1254,13 @@ select.input {
   .browse-tools {
     min-height: 0;
     padding: 4px 3px;
+    position: static; /* sort panel positions relative to .browse-controls instead */
   }
 
   .browse-tools__mobile-actions {
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     gap: 3px;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,13 @@ export type ListenStatus = "to-listen" | "listened";
 export type PurchaseIntent = "no" | "maybe" | "want" | "owned";
 export type ItemType = "album" | "ep" | "single" | "track" | "mix" | "compilation";
 export type PhysicalFormat = "vinyl" | "cd" | "cassette" | "minidisc" | "other";
-export type MusicItemSort = "default" | "artist-name" | "release-name" | "star-rating";
+export type MusicItemSort =
+  | "date-added"
+  | "date-listened"
+  | "artist-name"
+  | "release-name"
+  | "star-rating";
+export type MusicItemSortDirection = "asc" | "desc";
 
 export type SourceName =
   | "bandcamp"
@@ -137,6 +143,7 @@ export interface MusicItemFilters {
   search?: string;
   stackId?: number;
   sort?: MusicItemSort;
+  sortDirection?: MusicItemSortDirection;
   hasReminder?: boolean;
 }
 

--- a/src/ui/domain/music-list.ts
+++ b/src/ui/domain/music-list.ts
@@ -1,4 +1,9 @@
-import type { ListenStatus, MusicItemFilters, MusicItemSort } from "../../types";
+import type {
+  ListenStatus,
+  MusicItemFilters,
+  MusicItemSort,
+  MusicItemSortDirection,
+} from "../../types";
 import { applyOrder, buildContextKey } from "../../../shared/music-list-context";
 import { STATUS_LABELS } from "./status";
 
@@ -9,6 +14,7 @@ export function buildMusicItemFilters(
   currentStack: number | null,
   searchQuery = "",
   currentSort: MusicItemSort = "default",
+  currentSortDirection: MusicItemSortDirection = "desc",
 ): MusicItemFilters | undefined {
   const filters: MusicItemFilters = {};
   const trimmedSearch = searchQuery.trim();
@@ -27,9 +33,8 @@ export function buildMusicItemFilters(
     filters.search = trimmedSearch;
   }
 
-  if (currentSort !== "default") {
-    filters.sort = currentSort;
-  }
+  filters.sort = currentSort;
+  filters.sortDirection = currentSortDirection;
 
   return Object.keys(filters).length > 0 ? filters : undefined;
 }

--- a/src/ui/domain/music-list.ts
+++ b/src/ui/domain/music-list.ts
@@ -13,7 +13,7 @@ export function buildMusicItemFilters(
   currentFilter: FilterSelection,
   currentStack: number | null,
   searchQuery = "",
-  currentSort: MusicItemSort = "default",
+  currentSort: MusicItemSort = "date-added",
   currentSortDirection: MusicItemSortDirection = "desc",
 ): MusicItemFilters | undefined {
   const filters: MusicItemFilters = {};

--- a/src/ui/state/app-machine.ts
+++ b/src/ui/state/app-machine.ts
@@ -1,11 +1,17 @@
 import { assign, createMachine } from "xstate";
-import type { ListenStatus, MusicItemSort, StackWithCount } from "../../types";
+import type {
+  ListenStatus,
+  MusicItemSort,
+  MusicItemSortDirection,
+  StackWithCount,
+} from "../../types";
 
 export interface AppContext {
   currentFilter: ListenStatus | "all" | "scheduled";
   currentStack: number | null;
   searchQuery: string;
   currentSort: MusicItemSort;
+  currentSortDirection: MusicItemSortDirection;
   stacks: StackWithCount[];
   isReady: boolean;
   stackManageOpen: boolean;
@@ -22,6 +28,7 @@ export type AppEvent =
   | { type: "STACK_SELECTED_ALL" }
   | { type: "SEARCH_UPDATED"; query: string }
   | { type: "SORT_UPDATED"; sort: MusicItemSort }
+  | { type: "SORT_DIRECTION_UPDATED"; direction: MusicItemSortDirection }
   | { type: "STACKS_LOADED"; stacks: StackWithCount[] }
   | { type: "STACK_MANAGE_TOGGLED" }
   | { type: "STACK_DELETED"; stackId: number }
@@ -38,7 +45,8 @@ export const appMachine = createMachine({
     currentFilter: "to-listen",
     currentStack: null,
     searchQuery: "",
-    currentSort: "default",
+    currentSort: "date-added",
+    currentSortDirection: "desc",
     stacks: [],
     isReady: false,
     stackManageOpen: false,
@@ -82,6 +90,12 @@ export const appMachine = createMachine({
     SORT_UPDATED: {
       actions: assign(({ context, event }) => ({
         currentSort: event.sort,
+        listVersion: context.listVersion + 1,
+      })),
+    },
+    SORT_DIRECTION_UPDATED: {
+      actions: assign(({ context, event }) => ({
+        currentSortDirection: event.direction,
         listVersion: context.listVersion + 1,
       })),
     },

--- a/tests/unit/app-domain.test.ts
+++ b/tests/unit/app-domain.test.ts
@@ -97,16 +97,29 @@ describe("app domain helpers", () => {
     });
   });
 
-  it("returns API filter object only when needed", () => {
-    expect(buildMusicItemFilters("all", null)).toBeUndefined();
-    expect(buildMusicItemFilters("listened", null)).toEqual({ listenStatus: "listened" });
-    expect(buildMusicItemFilters("all", 7)).toEqual({ stackId: 7 });
+  it("always includes sort and sortDirection in API filter object", () => {
+    expect(buildMusicItemFilters("all", null)).toEqual({
+      sort: "date-added",
+      sortDirection: "desc",
+    });
+    expect(buildMusicItemFilters("listened", null)).toEqual({
+      listenStatus: "listened",
+      sort: "date-added",
+      sortDirection: "desc",
+    });
+    expect(buildMusicItemFilters("all", 7)).toEqual({
+      stackId: 7,
+      sort: "date-added",
+      sortDirection: "desc",
+    });
     expect(buildMusicItemFilters("all", null, "  dub  ", "artist-name")).toEqual({
       search: "dub",
       sort: "artist-name",
+      sortDirection: "desc",
     });
     expect(buildMusicItemFilters("all", null, "", "star-rating")).toEqual({
       sort: "star-rating",
+      sortDirection: "desc",
     });
   });
 

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -3,10 +3,20 @@ import { Hono } from "hono";
 
 const mockCreateMany = mock();
 
-// Mock createMusicItemFromUrl before importing the route
+// Mock the entire music-item-creator module before importing any route.
+// All named exports must be present: bun's mock.module() persists across
+// the full test run, so a partial mock will break any later test file
+// that imports a route which uses a non-mocked export.
 mock.module("../../server/music-item-creator", () => ({
   createMusicItemsFromUrl: mockCreateMany,
+  createMusicItemFromUrl: mock(),
+  createMusicItemDirect: mock(),
   fetchFullItem: mock(),
+  fullItemSelect: mock(),
+  getOrCreateArtist: mock(),
+  getSourceId: mock(),
+  hydrateItemStacks: mock(),
+  AmbiguousLinkSelectionError: class AmbiguousLinkSelectionError extends Error {},
 }));
 
 // Import after mock is set up


### PR DESCRIPTION
## Summary

- Replaces the implicit `"default"` sort with explicit **Date added** and **Date listened** sort options
- Adds a **sort direction toggle button** (↓/↑) that applies to all sort fields — dates, names, and star rating
- **Date listened** option only appears when the Listened filter is active; switching away resets sort to Date added
- All sort branches on the server respect the direction, with nulls always sorted last regardless of direction

## Changes

- `src/types/index.ts` — new `MusicItemSort` values, new `MusicItemSortDirection` type, `sortDirection` on `MusicItemFilters`
- `src/ui/state/app-machine.ts` — `currentSortDirection` state field, `SORT_DIRECTION_UPDATED` event
- `src/ui/domain/music-list.ts` — passes `sortDirection` through to filters
- `src/services/api-client.ts` — sends `sortDirection` query param
- `server/routes/music-items.ts` — all 5 sort branches respect `dir`, new `date-added` and `date-listened` branches
- `server/routes/main-page.ts` — updated sort panel HTML with new options and direction button
- `src/app.ts` — wires direction button, `syncDateListenedOption` helper, `updateSortDirectionBtn` helper

## Test plan

- [ ] Sort panel shows "Date added" selected, "↓ Newest first" on load
- [ ] Clicking the direction button flips label and reverses list order
- [ ] Switching to Listened filter reveals "Date listened" option
- [ ] Selecting "Date listened" reorders by listened date; direction button works
- [ ] Switching away from Listened resets sort to "Date added" and hides "Date listened"
- [ ] "Artist A–Z" with direction → "↓ Z–A"
- [ ] "Star rating" with direction → "↑ Lowest first"

🤖 Generated with [Claude Code](https://claude.com/claude-code)