### PR TITLE
feat: open player links in new tab on mobile

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -68,7 +68,8 @@ function youTubeEmbedSrc(url: string): string | null {
 function youTubePlayerAttrs(item: MusicItemFull): string {
   const src = item.primary_url ? youTubeEmbedSrc(item.primary_url) : null;
   if (!src) return "";
-  return ` data-src="${src}" data-title="${escapeHtml(item.title)}" data-artist="${escapeHtml(item.artist_name ?? "")}" data-player-type="video"`;
+  const href = item.primary_url ? ` data-href="${escapeHtml(item.primary_url)}"` : "";
+  return ` data-src="${src}" data-title="${escapeHtml(item.title)}" data-artist="${escapeHtml(item.artist_name ?? "")}" data-player-type="video"${href}`;
 }
 
 function renderYouTubeButton(item: MusicItemFull): string {
@@ -88,11 +89,12 @@ function renderBandcampEmbed(item: MusicItemFull): string {
   const title = escapeHtml(item.title);
   const artist = escapeHtml(item.artist_name ?? "");
 
+  const href = item.primary_url ? `\n    data-href="${escapeHtml(item.primary_url)}"` : "";
   return `<button
     class="release-page__listen-btn"
     data-src="${src}"
     data-title="${title}"
-    data-artist="${artist}"
+    data-artist="${artist}"${href}
   >▶ Listen</button>`;
 }
 
@@ -109,6 +111,7 @@ function renderAppleMusicButton(item: MusicItemFull): string {
     data-src="${escapeHtml(src)}"
     data-title="${title}"
     data-artist="${artist}"
+    data-href="${escapeHtml(item.primary_url)}"
   >▶ Listen</button>`;
   } catch {
     return "";
@@ -413,7 +416,10 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
       document.querySelectorAll('.release-page__listen-btn').forEach(btn => {
         btn.addEventListener('click', () => {
           const src = btn.dataset.src;
-          if (src) {
+          if (!src) return;
+          if (window.matchMedia('(pointer: coarse)').matches && btn.dataset.href) {
+            window.open(btn.dataset.href, '_blank', 'noopener,noreferrer');
+          } else {
             window.__player?.load(
               src,
               btn.dataset.title ?? '',


### PR DESCRIPTION
## Summary

- On touch devices (`pointer: coarse`), listen buttons for Apple Music, YouTube, and Bandcamp now open the original URL in a new tab instead of launching the embedded player window
- Adds `data-href` attribute to all listen buttons with the original platform URL
- Uses `window.matchMedia('(pointer: coarse)')` to detect touch/mobile devices

## Test plan

- [ ] On desktop: listen buttons still open the embedded player window as before
- [ ] On mobile/touch device: Apple Music button opens music.apple.com in a new tab
- [ ] On mobile/touch device: YouTube button opens youtube.com in a new tab
- [ ] On mobile/touch device: Bandcamp button opens bandcamp URL in a new tab
- [ ] Artwork play button (YouTube) also opens in new tab on mobile

🤖 Generated with [Claude Code](https://claude.ai/claude-code)