### PR TITLE
fix: stop clipping source dropdown in release link editor

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2641,7 +2641,6 @@ a:hover {
   border-width: 2px;
   border-style: solid;
   border-color: var(--chrome-dark) var(--chrome-white) var(--chrome-white) var(--chrome-dark);
-  overflow: hidden;
 }
 
 #link-list {


### PR DESCRIPTION
The source picker opens an absolutely-positioned dropdown with
top: 100%, but .release-page__edit-links had overflow: hidden,
clipping it once it extended past the links section. On mobile this
made the autocomplete options appear hidden beneath the Stacks
section below.

https://claude.ai/code/session_01VfUyzd9zDKvB9taEgftoy6