### PR TITLE
fix(ssr): scope main-page SSR by stack and reflect active filter

### DIFF
--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -1,10 +1,11 @@
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { assign, createActor, fromPromise, setup, waitFor } from "xstate";
 import { db } from "./db/index";
 import { musicItems, artists, musicLinks, sources, musicItemStacks, stacks } from "./db/schema";
 import { parseUrl, isValidUrl, normalize, capitalize } from "./utils";
 import { scrapeUrl, UnsupportedMusicLinkError } from "./scraper";
 import { pickPrimaryReleaseCandidate } from "./link-extractor";
+import { fullItemSelect } from "./queries/full-item-select";
 import type {
   AmbiguousLinkPayload,
   CreateMusicItemInput,
@@ -17,52 +18,11 @@ import type {
 // Helpers (moved from routes/music-items.ts for shared use)
 // ---------------------------------------------------------------------------
 
-/**
- * Build the "full" music-item query that joins artists, primary music_link,
- * and sources to produce the MusicItemFull shape the frontend expects.
- */
-export function fullItemSelect() {
-  return db
-    .select({
-      id: musicItems.id,
-      title: musicItems.title,
-      normalized_title: musicItems.normalizedTitle,
-      item_type: musicItems.itemType,
-      artist_id: musicItems.artistId,
-      listen_status: musicItems.listenStatus,
-      purchase_intent: musicItems.purchaseIntent,
-      price_cents: musicItems.priceCents,
-      currency: musicItems.currency,
-      notes: musicItems.notes,
-      rating: musicItems.rating,
-      created_at: musicItems.createdAt,
-      updated_at: musicItems.updatedAt,
-      listened_at: musicItems.listenedAt,
-      artwork_url: musicItems.artworkUrl,
-      is_physical: musicItems.isPhysical,
-      physical_format: musicItems.physicalFormat,
-      label: musicItems.label,
-      year: musicItems.year,
-      country: musicItems.country,
-      genre: musicItems.genre,
-      catalogue_number: musicItems.catalogueNumber,
-      musicbrainz_release_id: musicItems.musicbrainzReleaseId,
-      musicbrainz_artist_id: musicItems.musicbrainzArtistId,
-      artist_name: artists.name,
-      primary_url: musicLinks.url,
-      primary_source: sources.name,
-      primary_link_metadata: musicLinks.metadata,
-      remind_at: musicItems.remindAt,
-      reminder_pending: musicItems.reminderPending,
-    })
-    .from(musicItems)
-    .leftJoin(artists, eq(musicItems.artistId, artists.id))
-    .leftJoin(
-      musicLinks,
-      and(eq(musicLinks.musicItemId, musicItems.id), eq(musicLinks.isPrimary, true)),
-    )
-    .leftJoin(sources, eq(musicLinks.sourceId, sources.id));
-}
+// Re-exported for backwards compatibility — see ./queries/full-item-select.ts
+// for the actual implementation. New code should prefer importing it from
+// there directly so that mocking this module in tests doesn't accidentally
+// break SSR paths that need the real query builder.
+export { fullItemSelect };
 
 /** Look up an existing artist by normalized name, or create a new one. */
 export async function getOrCreateArtist(name: string): Promise<number> {

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -58,7 +58,11 @@ export async function getSourceId(sourceName: string): Promise<number | null> {
 }
 
 export type { ItemWithStacks } from "./hydrate-item-stacks";
-export { hydrateItemStacks } from "./hydrate-item-stacks";
+// `hydrateItemStacks` is intentionally not re-exported. Importing it from this
+// module would let `mock.module(".../music-item-creator")` (used by ingest
+// tests) shadow the real implementation, which then breaks unrelated tests
+// that import the helper from `./hydrate-item-stacks` directly. New code
+// should import it from `./hydrate-item-stacks`.
 
 /** Fetch a single full item by its id, including stacks and all links. */
 export async function fetchFullItem(id: number): Promise<MusicItemFull | null> {

--- a/server/queries/full-item-select.ts
+++ b/server/queries/full-item-select.ts
@@ -1,0 +1,55 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/index";
+import { musicItems, artists, musicLinks, sources } from "../db/schema";
+
+/**
+ * Build the "full" music-item query that joins artists, primary music_link,
+ * and sources to produce the MusicItemFull shape the frontend expects.
+ *
+ * Lives in its own module (rather than `music-item-creator.ts`) so it can be
+ * imported from server-side render paths without dragging in the broader
+ * creator surface — this also lets unit tests mock the heavyweight creator
+ * helpers without breaking SSR tests that need the real query builder.
+ */
+export function fullItemSelect() {
+  return db
+    .select({
+      id: musicItems.id,
+      title: musicItems.title,
+      normalized_title: musicItems.normalizedTitle,
+      item_type: musicItems.itemType,
+      artist_id: musicItems.artistId,
+      listen_status: musicItems.listenStatus,
+      purchase_intent: musicItems.purchaseIntent,
+      price_cents: musicItems.priceCents,
+      currency: musicItems.currency,
+      notes: musicItems.notes,
+      rating: musicItems.rating,
+      created_at: musicItems.createdAt,
+      updated_at: musicItems.updatedAt,
+      listened_at: musicItems.listenedAt,
+      artwork_url: musicItems.artworkUrl,
+      is_physical: musicItems.isPhysical,
+      physical_format: musicItems.physicalFormat,
+      label: musicItems.label,
+      year: musicItems.year,
+      country: musicItems.country,
+      genre: musicItems.genre,
+      catalogue_number: musicItems.catalogueNumber,
+      musicbrainz_release_id: musicItems.musicbrainzReleaseId,
+      musicbrainz_artist_id: musicItems.musicbrainzArtistId,
+      artist_name: artists.name,
+      primary_url: musicLinks.url,
+      primary_source: sources.name,
+      primary_link_metadata: musicLinks.metadata,
+      remind_at: musicItems.remindAt,
+      reminder_pending: musicItems.reminderPending,
+    })
+    .from(musicItems)
+    .leftJoin(artists, eq(musicItems.artistId, artists.id))
+    .leftJoin(
+      musicLinks,
+      and(eq(musicLinks.musicItemId, musicItems.id), eq(musicLinks.isPrimary, true)),
+    )
+    .leftJoin(sources, eq(musicLinks.sourceId, sources.id));
+}

--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -2,15 +2,19 @@ import { Hono, type Context } from "hono";
 import { eq, inArray, count, asc, desc } from "drizzle-orm";
 import { db } from "../db/index";
 import { musicItems, musicItemStacks, stacks, musicItemOrder, stackParents } from "../db/schema";
-import { fullItemSelect, hydrateItemStacks } from "../music-item-creator";
+import { fullItemSelect } from "../queries/full-item-select";
+import { hydrateItemStacks } from "../hydrate-item-stacks";
+import { collectDescendantStackIds } from "./music-items";
 import { applyOrder, buildContextKey } from "../../shared/music-list-context";
 import { renderPrimaryFeedAlternateLinks, renderStackFeedAlternateLinks } from "../../shared/rss";
 import { renderMusicList } from "../../src/ui/view/templates";
+import type { FilterSelection } from "../../src/ui/domain/music-list";
 import type { MusicItemFull, StackWithCount } from "../../src/types";
 import { getPageAssets } from "../page-assets";
 import pkg from "../../package.json";
 
 const DEFAULT_FILTER = "to-listen" as const;
+const STACK_DEFAULT_FILTER: FilterSelection = "all";
 
 function escapeHtml(str: string): string {
   return str
@@ -65,10 +69,44 @@ async function fetchInitialStacks(): Promise<StackWithCount[]> {
   }));
 }
 
-async function fetchInitialItems(): Promise<MusicItemFull[]> {
-  const items = await fullItemSelect()
-    .where(eq(musicItems.listenStatus, DEFAULT_FILTER))
-    .orderBy(desc(musicItems.createdAt), desc(musicItems.id));
+/**
+ * Fetch the items to render in the SSR'd music list.
+ *
+ * Mirrors what the client-side `renderMusicListView` does after hydration:
+ * - On `/`, the default filter is "to-listen" and there is no stack scope, so
+ *   we filter strictly by `listen_status = 'to-listen'`. Listed items must
+ *   never appear in this view.
+ * - On `/s/:id/:name`, the JS state machine forces `currentFilter` to "all"
+ *   and scopes by `stackId`, so the SSR mirrors that: items are restricted to
+ *   the stack (and its descendants) regardless of listen status.
+ */
+async function fetchInitialItems(stackId: number | null): Promise<MusicItemFull[]> {
+  const filter: FilterSelection = stackId === null ? DEFAULT_FILTER : STACK_DEFAULT_FILTER;
+
+  let baseQuery = fullItemSelect().$dynamic();
+
+  // Apply listen-status filter only when we're not scoping by stack. On stack
+  // pages the JS view shows all statuses, so the SSR must too — otherwise the
+  // first paint shows global to-listen items that get replaced with the real
+  // (mixed-status) stack contents a moment later.
+  if (filter !== "all") {
+    baseQuery = baseQuery.where(eq(musicItems.listenStatus, filter));
+  }
+
+  if (stackId !== null) {
+    const stackIds = await collectDescendantStackIds(stackId);
+    const memberships = await db
+      .select({ musicItemId: musicItemStacks.musicItemId })
+      .from(musicItemStacks)
+      .where(inArray(musicItemStacks.stackId, stackIds));
+    const itemIds = [...new Set(memberships.map((m) => m.musicItemId))];
+
+    if (itemIds.length === 0) return [];
+
+    baseQuery = baseQuery.where(inArray(musicItems.id, itemIds));
+  }
+
+  const items = await baseQuery.orderBy(desc(musicItems.createdAt), desc(musicItems.id));
 
   if (items.length === 0) return [];
 
@@ -89,7 +127,7 @@ async function fetchInitialItems(): Promise<MusicItemFull[]> {
 
   const enriched = hydrateItemStacks(items, stackRows);
 
-  const contextKey = buildContextKey(DEFAULT_FILTER, null);
+  const contextKey = buildContextKey(filter, stackId);
   const orderRow = await db
     .select()
     .from(musicItemOrder)
@@ -112,9 +150,25 @@ async function fetchInitialItems(): Promise<MusicItemFull[]> {
   return enriched as unknown as MusicItemFull[];
 }
 
+function renderFilterBarButtons(activeFilter: FilterSelection): string {
+  const buttons: Array<{ value: FilterSelection; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "to-listen", label: "To Listen" },
+    { value: "listened", label: "Listened" },
+    { value: "scheduled", label: "Scheduled" },
+  ];
+  return buttons
+    .map(
+      ({ value, label }) =>
+        `<button class="filter-btn${value === activeFilter ? " active" : ""}" data-filter="${value}">${label}</button>`,
+    )
+    .join("\n              ");
+}
+
 function renderMainPage(opts: {
   musicListHtml: string;
   stackBarTabsHtml: string;
+  filterBarHtml: string;
   stacksJson: string;
   cssHref: string;
   scriptSrc: string;
@@ -320,10 +374,7 @@ function renderMainPage(opts: {
         <section class="filter-section">
           <div class="browse-controls">
             <div id="filter-bar" class="filter-bar">
-              <button class="filter-btn" data-filter="all">All</button>
-              <button class="filter-btn active" data-filter="to-listen">To Listen</button>
-              <button class="filter-btn" data-filter="listened">Listened</button>
-              <button class="filter-btn" data-filter="scheduled">Scheduled</button>
+              ${opts.filterBarHtml}
             </div>
             <div class="browse-tools">
               <div class="browse-tools__mobile-actions">
@@ -599,14 +650,22 @@ export function createMainPageRoutes(): Hono {
   const isDev = process.env.NODE_ENV !== "production";
 
   async function serveMainPage(c: Context) {
+    const stackIdParam = c.req.param("id");
+    const stackId = stackIdParam ? Number(stackIdParam) : null;
+    const validStackId =
+      stackId !== null && Number.isInteger(stackId) && stackId > 0 ? stackId : null;
+    const activeFilter: FilterSelection =
+      validStackId === null ? DEFAULT_FILTER : STACK_DEFAULT_FILTER;
+
     const [initialItems, initialStacks, { cssHref, scriptSrc }] = await Promise.all([
-      fetchInitialItems(),
+      fetchInitialItems(validStackId),
       fetchInitialStacks(),
       getPageAssets(),
     ]);
 
-    const musicListHtml = renderMusicList(initialItems, DEFAULT_FILTER, "");
+    const musicListHtml = renderMusicList(initialItems, activeFilter, "");
     const stackBarTabsHtml = initialStacks.map((s) => renderStackTab(s)).join("");
+    const filterBarHtml = renderFilterBarButtons(activeFilter);
     const stacksJson = safeJson({ stacks: initialStacks });
     const primaryRssAlternateLinksHtml = renderPrimaryFeedAlternateLinks();
     const rssAlternateLinksHtml = renderStackFeedAlternateLinks(initialStacks);
@@ -615,6 +674,7 @@ export function createMainPageRoutes(): Hono {
       renderMainPage({
         musicListHtml,
         stackBarTabsHtml,
+        filterBarHtml,
         stacksJson,
         cssHref,
         scriptSrc,

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -67,7 +67,7 @@ const DIRECT_UPDATE_FIELDS: ReadonlyArray<
   "musicbrainzArtistId",
 ];
 
-async function collectDescendantStackIds(rootStackId: number): Promise<number[]> {
+export async function collectDescendantStackIds(rootStackId: number): Promise<number[]> {
   const links = await db
     .select({
       parentStackId: stackParents.parentStackId,

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -21,8 +21,8 @@ import {
   getOrCreateArtist,
   createMusicItemFromUrl,
   createMusicItemDirect,
-  hydrateItemStacks,
 } from "../music-item-creator";
+import { hydrateItemStacks } from "../hydrate-item-stacks";
 import { UnsupportedMusicLinkError } from "../scraper";
 import { fetchAndStoreSuggestion } from "../suggestions";
 import type {

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -15,7 +15,6 @@ mock.module("../../server/music-item-creator", () => ({
   fullItemSelect: mock(),
   getOrCreateArtist: mock(),
   getSourceId: mock(),
-  hydrateItemStacks: mock(),
   AmbiguousLinkSelectionError: class AmbiguousLinkSelectionError extends Error {},
 }));
 

--- a/tests/unit/main-page-ssr.test.ts
+++ b/tests/unit/main-page-ssr.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, mock, test } from "bun:test";
+import * as fs from "node:fs";
+
+// Use a dedicated test database so we don't pollute the dev DB.
+// We set this once at module load — the db module reads the env var at first import.
+const TEST_DB = `/tmp/main-page-ssr-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+process.env.DATABASE_PATH = TEST_DB;
+for (const suffix of ["", "-shm", "-wal"]) {
+  try {
+    fs.rmSync(TEST_DB + suffix, { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+// `ingest.test.ts` calls `mock.module("../../server/music-item-creator", ...)`
+// to stub out helpers like `fullItemSelect`. bun's module mocks are
+// process-wide and persist across test files, so any module that imports
+// `music-item-creator` after that point gets stubs. The SSR (`main-page.ts`)
+// now imports `fullItemSelect` from `server/queries/full-item-select.ts`
+// directly to sidestep that mock, so this file does not need to re-register
+// anything — but we keep the `mock` import to make the dependency explicit
+// in case the module organization changes again.
+void mock;
+
+describe("SSR /", () => {
+  test("renders only items with to-listen status", async () => {
+    const { db } = await import("../../server/db/index");
+    const { musicItems } = await import("../../server/db/schema");
+    const { createMainPageRoutes } = await import("../../server/routes/main-page");
+
+    const inserted = await db
+      .insert(musicItems)
+      .values([
+        { title: "ToListenA", normalizedTitle: "tolistena", listenStatus: "to-listen" },
+        { title: "ListenedA", normalizedTitle: "listeneda", listenStatus: "listened" },
+        { title: "ToListenB", normalizedTitle: "tolistenb", listenStatus: "to-listen" },
+        { title: "ListenedB", normalizedTitle: "listenedb", listenStatus: "listened" },
+      ])
+      .returning({ id: musicItems.id, status: musicItems.listenStatus });
+
+    const expectedToListenIds = inserted.filter((i) => i.status === "to-listen").map((i) => i.id);
+    const expectedListenedIds = inserted.filter((i) => i.status === "listened").map((i) => i.id);
+
+    const app = createMainPageRoutes();
+    const res = await app.request("http://localhost/");
+    const html = await res.text();
+
+    const renderedIds = [
+      ...new Set([...html.matchAll(/data-item-id="(\d+)"/g)].map((m) => Number(m[1]))),
+    ];
+
+    // Sanity check: all to-listen items rendered
+    for (const id of expectedToListenIds) {
+      expect(renderedIds).toContain(id);
+    }
+
+    // Bug check: NO listened items should be rendered on the default route
+    for (const id of expectedListenedIds) {
+      expect(renderedIds).not.toContain(id);
+    }
+  });
+
+  test("filter-bar marks 'To Listen' as the active filter", async () => {
+    const { createMainPageRoutes } = await import("../../server/routes/main-page");
+
+    const app = createMainPageRoutes();
+    const res = await app.request("http://localhost/");
+    const html = await res.text();
+
+    expect(html).toContain('class="filter-btn active" data-filter="to-listen"');
+    // No other filter button should be active
+    expect(html).not.toContain('class="filter-btn active" data-filter="all"');
+    expect(html).not.toContain('class="filter-btn active" data-filter="listened"');
+    expect(html).not.toContain('class="filter-btn active" data-filter="scheduled"');
+  });
+});
+
+describe("SSR /s/:id/:name", () => {
+  test("renders items in the stack regardless of listen status", async () => {
+    const { db } = await import("../../server/db/index");
+    const { musicItems, stacks, musicItemStacks } = await import("../../server/db/schema");
+    const { createMainPageRoutes } = await import("../../server/routes/main-page");
+
+    const [stack] = await db
+      .insert(stacks)
+      .values({ name: "TestStack" })
+      .returning({ id: stacks.id });
+
+    const inserted = await db
+      .insert(musicItems)
+      .values([
+        {
+          title: "InStackToListen",
+          normalizedTitle: "instacktolisten",
+          listenStatus: "to-listen",
+        },
+        {
+          title: "InStackListened",
+          normalizedTitle: "instacklistened",
+          listenStatus: "listened",
+        },
+        {
+          title: "OutOfStackToListen",
+          normalizedTitle: "outofstacktolisten",
+          listenStatus: "to-listen",
+        },
+      ])
+      .returning({ id: musicItems.id, status: musicItems.listenStatus });
+
+    // Add the first two items to the stack; the third stays orphaned
+    await db.insert(musicItemStacks).values([
+      { musicItemId: inserted[0].id, stackId: stack.id },
+      { musicItemId: inserted[1].id, stackId: stack.id },
+    ]);
+
+    const app = createMainPageRoutes();
+    const res = await app.request(`http://localhost/s/${stack.id}/teststack`);
+    const html = await res.text();
+
+    const renderedIds = [
+      ...new Set([...html.matchAll(/data-item-id="(\d+)"/g)].map((m) => Number(m[1]))),
+    ];
+
+    // Both stack items must render — including the listened one
+    expect(renderedIds).toContain(inserted[0].id);
+    expect(renderedIds).toContain(inserted[1].id);
+    // The non-stack item must NOT render even though it's to-listen
+    expect(renderedIds).not.toContain(inserted[2].id);
+  });
+
+  test("filter-bar marks 'All' as the active filter on stack URLs", async () => {
+    const { db } = await import("../../server/db/index");
+    const { stacks } = await import("../../server/db/schema");
+    const { createMainPageRoutes } = await import("../../server/routes/main-page");
+
+    const [stack] = await db
+      .insert(stacks)
+      .values({ name: "FilterStack" })
+      .returning({ id: stacks.id });
+
+    const app = createMainPageRoutes();
+    const res = await app.request(`http://localhost/s/${stack.id}/filterstack`);
+    const html = await res.text();
+
+    // On stack URLs, JS forces filter to "all" via STACK_SELECTED — the SSR
+    // must mirror that or the user sees a filter/items mismatch on first paint.
+    expect(html).toContain('class="filter-btn active" data-filter="all"');
+    expect(html).not.toContain('class="filter-btn active" data-filter="to-listen"');
+  });
+});


### PR DESCRIPTION
## Summary

The `/s/:id/:name` route shares the `serveMainPage` handler with `/`, but the SSR was hardcoded to filter items by `listen_status = 'to-listen'` globally and to mark the "To Listen" filter button as active — regardless of whether the URL targeted a stack.

After hydration the JS state machine forces `currentFilter` to `"all"` and scopes by `stackId` (via `STACK_SELECTED`), so the first paint of any stack page showed the wrong list (global to-listen items under a "To Listen" button) before snapping to the real, mixed-status stack contents a moment later. To a user landing on a stack URL, that flash looks exactly like "items show in the To Listen column even if they have a Listened status."

This PR aligns the SSR with the post-hydration JS state.

### Changes

- `serveMainPage` now extracts `:id` from the URL params and passes it through.
- `fetchInitialItems(stackId)` filters by stack membership (and descendants) when a stack ID is given, and skips the listen-status filter — matching what the JS view does after hydration.
- A new `renderFilterBarButtons(activeFilter)` helper renders the filter bar dynamically so "All" is active on stack URLs and "To Listen" is active on `/`.
- `fullItemSelect` is extracted to `server/queries/full-item-select.ts`. SSR paths import it from there directly so `ingest.test.ts`'s process-wide `mock.module("server/music-item-creator")` doesn't shadow the real query builder during tests. `music-item-creator.ts` re-exports it for backwards compatibility.
- `collectDescendantStackIds` is exported from `routes/music-items.ts` for reuse by the SSR.

### Tests

Added `tests/unit/main-page-ssr.test.ts` covering the contract for both routes:
- `/` renders only `to-listen` items and marks `to-listen` as active.
- `/s/:id/:name` renders items in the stack regardless of status, omits items not in the stack, and marks `all` as active.

## Test plan

- [x] `bun test tests/unit` — 381 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — same warning count as `main`, no new warnings introduced
- [x] Manual verification: `/s/2/latin` SSR now shows only items in stack 2 (mixed statuses) with "All" highlighted; `/` SSR is unchanged (only to-listen items, "To Listen" highlighted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)