### PR TITLE
Add Pitchfork album review scraper support

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -23,6 +23,8 @@ const SEED_SOURCES = [
   { name: "tidal", displayName: "Tidal", urlPattern: "tidal.com" },
   { name: "deezer", displayName: "Deezer", urlPattern: "deezer.com" },
   { name: "mixcloud", displayName: "Mixcloud", urlPattern: "mixcloud.com" },
+  { name: "nts", displayName: "NTS Radio", urlPattern: "nts.live" },
+  { name: "pitchfork", displayName: "Pitchfork", urlPattern: "pitchfork.com" },
   { name: "physical", displayName: "Physical Media", urlPattern: null },
 ] as const;
 

--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -12,6 +12,7 @@ const SEED_SOURCES = [
   { name: "deezer", displayName: "Deezer", urlPattern: "deezer.com" },
   { name: "mixcloud", displayName: "Mixcloud", urlPattern: "mixcloud.com" },
   { name: "nts", displayName: "NTS Radio", urlPattern: "nts.live" },
+  { name: "pitchfork", displayName: "Pitchfork", urlPattern: "pitchfork.com" },
   { name: "physical", displayName: "Physical Media", urlPattern: null },
 ] as const;
 

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -819,6 +819,90 @@ export function parseCanonicalUrl(html: string): string | undefined {
   return match?.[1]?.trim() || undefined;
 }
 
+// Pitchfork og:title is "{Artist}: {Album} Album Review | Pitchfork".
+// For multi-artist reviews it's "{Artist1} / {Artist2}: {Album} ...".
+export function parsePitchforkOg(og: OgData): ScrapedMetadata {
+  const rawTitle = og.ogTitle || og.title || "";
+  const stripped = rawTitle
+    .replace(/\s*\|\s*Pitchfork\s*$/i, "")
+    .replace(/\s+Album\s+Review\s*$/i, "")
+    .replace(/\s+EP\s+Review\s*$/i, "")
+    .trim();
+
+  const colonIdx = stripped.indexOf(":");
+  if (colonIdx > 0) {
+    const artist = stripped
+      .slice(0, colonIdx)
+      .replace(/\s*\/\s*/g, ", ")
+      .trim();
+    const title = stripped.slice(colonIdx + 1).trim();
+    return {
+      potentialArtist: artist || undefined,
+      potentialTitle: title || undefined,
+      imageUrl: og.ogImage,
+      itemType: "album",
+    };
+  }
+
+  return {
+    potentialTitle: stripped || undefined,
+    imageUrl: og.ogImage,
+    itemType: "album",
+  };
+}
+
+function extractArtistsFromJsonLdValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const names = value
+      .map((item) => extractName(item))
+      .filter((name): name is string => Boolean(name));
+    return names.length ? names.join(", ") : undefined;
+  }
+  return extractName(value);
+}
+
+function extractYearFromJsonLdValue(value: unknown): number | undefined {
+  const str = getString(value);
+  if (!str) return undefined;
+  const match = str.match(/\b(19|20)\d{2}\b/);
+  if (!match) return undefined;
+  const year = Number.parseInt(match[0], 10);
+  return Number.isFinite(year) ? year : undefined;
+}
+
+export function parsePitchforkJsonLd(html: string): ScrapedMetadata {
+  const entries = parseJsonLdScripts(html);
+
+  for (const entry of entries) {
+    const typeText = getTypeText(entry["@type"]);
+    if (!/review/i.test(typeText)) continue;
+
+    const reviewed = entry.itemReviewed;
+    if (!isRecord(reviewed)) continue;
+
+    const reviewedType = getTypeText(reviewed["@type"]);
+    if (!/musicalbum|musicrelease/i.test(reviewedType)) continue;
+
+    const potentialTitle = getString(reviewed.name);
+    const potentialArtist = extractArtistsFromJsonLdValue(reviewed.byArtist);
+    const imageUrl =
+      extractImageFromJsonLdValue(reviewed.image) ?? extractImageFromJsonLdValue(entry.image);
+    const year = extractYearFromJsonLdValue(reviewed.datePublished);
+
+    if (potentialArtist || potentialTitle || imageUrl || year !== undefined) {
+      return {
+        potentialArtist,
+        potentialTitle,
+        imageUrl,
+        year,
+        itemType: "album",
+      };
+    }
+  }
+
+  return {};
+}
+
 export function parseNtsOg(og: OgData): ScrapedMetadata {
   const rawTitle = og.ogTitle || og.title || "";
   // NTS format: "Show Name - Episode Info | NTS Radio" or "Show Name | NTS"
@@ -840,6 +924,7 @@ export const SOURCE_PARSERS: Partial<Record<SourceName, OgParser>> = {
   apple_music: parseAppleMusicOg,
   mixcloud: parseMixcloudOg,
   nts: parseNtsOg,
+  pitchfork: parsePitchforkOg,
 };
 
 export async function scrapeUrl(
@@ -990,6 +1075,19 @@ export async function scrapeUrl(
         firstDefined(og.metaTags?.["og:url"], parseCanonicalUrl(html)) || undefined;
       if (canonicalUrl) result.canonicalUrl = canonicalUrl;
       return result;
+    }
+
+    if (source === "pitchfork") {
+      const ogResult = parsePitchforkOg(og);
+      const jsonLd = parsePitchforkJsonLd(html);
+      const merged: ScrapedMetadata = {
+        potentialArtist: firstDefined(jsonLd.potentialArtist, ogResult.potentialArtist),
+        potentialTitle: firstDefined(jsonLd.potentialTitle, ogResult.potentialTitle),
+        imageUrl: firstDefined(jsonLd.imageUrl, ogResult.imageUrl),
+        year: jsonLd.year ?? ogResult.year,
+        itemType: ogResult.itemType ?? "album",
+      };
+      return hasScrapedMetadata(merged) ? merged : null;
     }
 
     const parser = SOURCE_PARSERS[source] || parseDefaultOg;

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -82,6 +82,13 @@ const URL_PATTERNS: Array<{
       potentialTitle: match[2]?.replace(/-/g, " "),
     }),
   },
+  {
+    // Pitchfork review slugs concatenate artist(s) and album with hyphens, so
+    // they can't be split reliably from the URL alone — leave artist/title for
+    // the page scraper to recover from OG tags / JSON-LD.
+    source: "pitchfork",
+    pattern: /^https?:\/\/(?:www\.)?pitchfork\.com\/reviews\/albums\/[^/?]+/,
+  },
 ];
 
 function stripMobileSubdomain(url: string): string {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type SourceName =
   | "deezer"
   | "mixcloud"
   | "nts"
+  | "pitchfork"
   | "physical"
   | "unknown";
 

--- a/tests/unit/parse-url.test.ts
+++ b/tests/unit/parse-url.test.ts
@@ -142,6 +142,39 @@ describe("parseUrl - nts", () => {
   });
 });
 
+describe("parseUrl - pitchfork", () => {
+  test("identifies a Pitchfork album review URL", () => {
+    const result = parseUrl(
+      "https://pitchfork.com/reviews/albums/mahito-yokota-koji-kondo-super-mario-galaxy-super-mario-galaxy-2/",
+    );
+
+    expect(result.source).toBe("pitchfork");
+    expect(result.normalizedUrl).toBe(
+      "https://pitchfork.com/reviews/albums/mahito-yokota-koji-kondo-super-mario-galaxy-super-mario-galaxy-2/",
+    );
+  });
+
+  test("does not extract artist or title from the slug (ambiguous)", () => {
+    const result = parseUrl(
+      "https://pitchfork.com/reviews/albums/mahito-yokota-koji-kondo-super-mario-galaxy-super-mario-galaxy-2/",
+    );
+
+    expect(result.potentialArtist).toBeUndefined();
+    expect(result.potentialTitle).toBeUndefined();
+  });
+
+  test("matches www.pitchfork.com hosts and strips query params", () => {
+    const result = parseUrl(
+      "https://www.pitchfork.com/reviews/albums/some-artist-some-album/?utm_source=twitter",
+    );
+
+    expect(result.source).toBe("pitchfork");
+    expect(result.normalizedUrl).toBe(
+      "https://www.pitchfork.com/reviews/albums/some-artist-some-album/",
+    );
+  });
+});
+
 describe("parseUrl - apple music", () => {
   test("identifies apple music release link and extracts title", () => {
     const result = parseUrl("https://music.apple.com/es/album/el-poder-verde/1810282984?l=en-GB");

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -15,6 +15,8 @@ import {
   extractMixcloudEmbedUrl,
   searchAppleMusic,
   parseNtsOg,
+  parsePitchforkOg,
+  parsePitchforkJsonLd,
   parseCanonicalUrl,
 } from "../../server/scraper";
 
@@ -305,6 +307,79 @@ describe("parseMixcloudJsonLd", () => {
   });
 });
 
+describe("parsePitchforkOg", () => {
+  test("splits single-artist 'Artist: Album Album Review | Pitchfork' format", () => {
+    const result = parsePitchforkOg({
+      ogTitle: "Water From Your Eyes: It's a Beautiful Place Album Review | Pitchfork",
+      ogImage: "https://media.pitchfork.com/photos/cover.jpg",
+    });
+
+    expect(result.potentialArtist).toBe("Water From Your Eyes");
+    expect(result.potentialTitle).toBe("It's a Beautiful Place");
+    expect(result.imageUrl).toBe("https://media.pitchfork.com/photos/cover.jpg");
+    expect(result.itemType).toBe("album");
+  });
+
+  test("joins multi-artist 'Artist1 / Artist2: Album ...' with a comma", () => {
+    const result = parsePitchforkOg({
+      ogTitle:
+        "Mahito Yokota / Koji Kondo: Super Mario Galaxy / Super Mario Galaxy 2 Album Review | Pitchfork",
+    });
+
+    expect(result.potentialArtist).toBe("Mahito Yokota, Koji Kondo");
+    expect(result.potentialTitle).toBe("Super Mario Galaxy / Super Mario Galaxy 2");
+  });
+
+  test("falls back to the full stripped title when no colon is present", () => {
+    const result = parsePitchforkOg({ ogTitle: "Some Page | Pitchfork" });
+    expect(result.potentialArtist).toBeUndefined();
+    expect(result.potentialTitle).toBe("Some Page");
+  });
+});
+
+describe("parsePitchforkJsonLd", () => {
+  test("extracts artist, album, and year from a Review/MusicAlbum JSON-LD", () => {
+    const html = `
+      <html><head>
+        <script type="application/ld+json">
+          {
+            "@context":"https://schema.org",
+            "@type":"Review",
+            "itemReviewed":{
+              "@type":"MusicAlbum",
+              "name":"Super Mario Galaxy / Super Mario Galaxy 2",
+              "byArtist":[
+                {"@type":"MusicGroup","name":"Mahito Yokota"},
+                {"@type":"MusicGroup","name":"Koji Kondo"}
+              ],
+              "datePublished":"2025-04-22",
+              "image":"https://media.pitchfork.com/photos/cover.jpg"
+            }
+          }
+        </script>
+      </head></html>
+    `;
+
+    const result = parsePitchforkJsonLd(html);
+    expect(result.potentialArtist).toBe("Mahito Yokota, Koji Kondo");
+    expect(result.potentialTitle).toBe("Super Mario Galaxy / Super Mario Galaxy 2");
+    expect(result.year).toBe(2025);
+    expect(result.imageUrl).toBe("https://media.pitchfork.com/photos/cover.jpg");
+    expect(result.itemType).toBe("album");
+  });
+
+  test("returns empty object when no Review JSON-LD present", () => {
+    const html = `
+      <html><head>
+        <script type="application/ld+json">{"@type":"WebPage","name":"Pitchfork"}</script>
+      </head></html>
+    `;
+    const result = parsePitchforkJsonLd(html);
+    expect(result.potentialArtist).toBeUndefined();
+    expect(result.potentialTitle).toBeUndefined();
+  });
+});
+
 describe("parseDefaultOg", () => {
   test("uses og:title as potentialTitle", () => {
     const result = parseDefaultOg({
@@ -501,6 +576,75 @@ describe("scrapeUrl", () => {
     expect(result!.potentialTitle).toBe("new rap music january 2026");
     expect(result!.potentialArtist).toBe("andrew");
     expect(result!.imageUrl).toBe("https://mixcloud.com/cover.jpg");
+    mock.restore();
+  });
+
+  test("prefers Pitchfork JSON-LD over og:title for multi-artist reviews", async () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="Mahito Yokota / Koji Kondo: Super Mario Galaxy / Super Mario Galaxy 2 Album Review | Pitchfork" />
+        <meta property="og:image" content="https://media.pitchfork.com/photos/og-cover.jpg" />
+        <script type="application/ld+json">
+          {
+            "@context":"https://schema.org",
+            "@type":"Review",
+            "itemReviewed":{
+              "@type":"MusicAlbum",
+              "name":"Super Mario Galaxy / Super Mario Galaxy 2",
+              "byArtist":[
+                {"@type":"MusicGroup","name":"Mahito Yokota"},
+                {"@type":"MusicGroup","name":"Koji Kondo"}
+              ],
+              "datePublished":"2025-04-22"
+            }
+          }
+        </script>
+      </head><body></body></html>
+    `;
+
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(html, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const result = await scrapeUrl(
+      "https://pitchfork.com/reviews/albums/mahito-yokota-koji-kondo-super-mario-galaxy-super-mario-galaxy-2/",
+      "pitchfork",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.potentialArtist).toBe("Mahito Yokota, Koji Kondo");
+    expect(result!.potentialTitle).toBe("Super Mario Galaxy / Super Mario Galaxy 2");
+    expect(result!.year).toBe(2025);
+    expect(result!.imageUrl).toBe("https://media.pitchfork.com/photos/og-cover.jpg");
+    expect(result!.itemType).toBe("album");
+    mock.restore();
+  });
+
+  test("falls back to Pitchfork og:title when JSON-LD is missing", async () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="Water From Your Eyes: It&#39;s a Beautiful Place Album Review | Pitchfork" />
+        <meta property="og:image" content="https://media.pitchfork.com/photos/og-cover.jpg" />
+      </head><body></body></html>
+    `;
+
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(html, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const result = await scrapeUrl(
+      "https://pitchfork.com/reviews/albums/water-from-your-eyes-its-a-beautiful-place/",
+      "pitchfork",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.potentialArtist).toBe("Water From Your Eyes");
+    expect(result!.potentialTitle).toBe("It's a Beautiful Place");
+    expect(result!.imageUrl).toBe("https://media.pitchfork.com/photos/og-cover.jpg");
     mock.restore();
   });
 


### PR DESCRIPTION
## Summary
Add support for scraping Pitchfork album review URLs to extract artist, album title, release year, and cover art metadata.

## Key Changes
- **URL Pattern Recognition**: Added Pitchfork album review URL pattern matching (`pitchfork.com/reviews/albums/`) to the URL parser
- **OG Tag Parser**: Implemented `parsePitchforkOg()` to extract artist and album from Pitchfork's og:title format, which follows the pattern `{Artist(s)}: {Album} Album Review | Pitchfork`. Handles multi-artist reviews by converting forward slashes to commas.
- **JSON-LD Parser**: Implemented `parsePitchforkJsonLd()` to extract structured metadata from Review/MusicAlbum JSON-LD, including artist names, album title, release year, and cover image
- **Hybrid Scraping Strategy**: In `scrapeUrl()`, when source is "pitchfork", both OG and JSON-LD data are parsed and merged, with JSON-LD taking precedence for artist and title (more reliable for multi-artist reviews), while OG tags provide the og:image fallback
- **Source Registration**: Added "pitchfork" to the `SourceName` type and `SOURCE_PARSERS` mapping
- **Database Seeds**: Updated seed data to include Pitchfork as a supported source

## Implementation Details
- The OG parser intelligently handles the Pitchfork title format by stripping the "| Pitchfork" suffix and "Album/EP Review" text, then splitting on the colon separator
- Multi-artist names separated by forward slashes in og:title are normalized to comma-separated format for consistency
- JSON-LD parsing extracts artist names from the `byArtist` array and release year from `datePublished`
- URL slugs are intentionally not parsed for artist/title extraction due to ambiguity (hyphens can't be reliably split), deferring to page metadata instead

https://claude.ai/code/session_01XMQAV26mcwJERanxm93KE2