### PR TITLE
feat(release-page): surface scheduled state in status dropdown

### DIFF
--- a/server/routes/release-page.ts
+++ b/server/routes/release-page.ts
@@ -171,21 +171,27 @@ function reminderDateValue(item: MusicItemFull): string {
     const d = new Date(item.remind_at as unknown as string | Date);
     return d.toISOString().slice(0, 10);
   }
-  if (item.year) {
-    return `${item.year}-01-01`;
-  }
-  return "";
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const yyyy = tomorrow.getFullYear();
+  const mm = String(tomorrow.getMonth() + 1).padStart(2, "0");
+  const dd = String(tomorrow.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
 }
 
 function renderReleasePage(item: MusicItemFull, cssHref: string): string {
+  const isScheduled = item.remind_at != null;
+  const displayedStatus = isScheduled ? "scheduled" : item.listen_status;
   const statusOptions = [
     { value: "to-listen", label: "To Listen" },
     { value: "listened", label: "Listened" },
+    ...(isScheduled ? [{ value: "scheduled", label: "Scheduled" }] : []),
   ]
-    .map(
-      ({ value, label }) =>
-        `<option value="${value}"${item.listen_status === value ? " selected" : ""}>${label}</option>`,
-    )
+    .map(({ value, label }) => {
+      const selected = displayedStatus === value ? " selected" : "";
+      const disabled = value === "scheduled" ? " disabled" : "";
+      return `<option value="${value}"${selected}${disabled}>${label}</option>`;
+    })
     .join("");
 
   const metaFields = [item.year ? String(item.year) : null, item.label, item.country, item.genre]
@@ -331,6 +337,51 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
     </div>
     <script>
       const ITEM_ID = ${item.id};
+      let currentListenStatus = ${JSON.stringify(item.listen_status)};
+      let currentRemindAt = ${JSON.stringify(item.remind_at ? new Date(item.remind_at as unknown as string | Date).toISOString() : null)};
+
+      function syncStatusDropdown() {
+        const select = document.getElementById('status-select');
+        if (!select) return;
+        const existing = select.querySelector('option[value="scheduled"]');
+        if (currentRemindAt && !existing) {
+          const opt = document.createElement('option');
+          opt.value = 'scheduled';
+          opt.textContent = 'Scheduled';
+          opt.disabled = true;
+          select.appendChild(opt);
+        } else if (!currentRemindAt && existing) {
+          existing.remove();
+        }
+        select.value = currentRemindAt ? 'scheduled' : currentListenStatus;
+      }
+
+      function ensureClearReminderBtn() {
+        if (document.getElementById('clear-reminder-btn')) return;
+        const setBtn = document.getElementById('set-reminder-btn');
+        if (!setBtn) return;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn';
+        btn.id = 'clear-reminder-btn';
+        btn.textContent = 'Clear';
+        btn.addEventListener('click', clearReminder);
+        setBtn.insertAdjacentElement('afterend', btn);
+      }
+
+      async function clearReminder() {
+        const res = await fetch('/api/music-items/' + ITEM_ID + '/reminder', { method: 'DELETE' });
+        if (!res.ok) {
+          alert('Failed to clear reminder');
+          syncStatusDropdown();
+          return;
+        }
+        currentRemindAt = null;
+        const input = document.getElementById('remind-at');
+        if (input) input.value = '';
+        document.getElementById('clear-reminder-btn')?.remove();
+        syncStatusDropdown();
+      }
 
       // Init player if not already loaded (direct page load vs SPA navigation)
       if (!window.__player) {
@@ -470,12 +521,19 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
       });
 
       document.getElementById('status-select').addEventListener('change', async (e) => {
+        const newStatus = e.target.value;
+        if (newStatus === 'scheduled') return;
+        const wasScheduled = currentRemindAt !== null;
         const res = await fetch('/api/music-items/' + ITEM_ID, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ listenStatus: e.target.value }),
+          body: JSON.stringify({ listenStatus: newStatus }),
         });
-        if (!res.ok) alert('Failed to update status.');
+        if (!res.ok) { alert('Failed to update status.'); return; }
+        currentListenStatus = newStatus;
+        if (wasScheduled) {
+          await clearReminder();
+        }
       });
 
       document.getElementById('delete-btn').addEventListener('click', async () => {
@@ -856,6 +914,9 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
         });
         if (!res.ok) { alert('Failed to set reminder'); return; }
         input.dataset.saved = remindAt;
+        currentRemindAt = new Date(remindAt).toISOString();
+        ensureClearReminderBtn();
+        syncStatusDropdown();
         const originalText = btn.textContent;
         btn.textContent = 'Saved!';
         btn.classList.add('btn--saved');
@@ -865,12 +926,7 @@ function renderReleasePage(item: MusicItemFull, cssHref: string): string {
         }, 2000);
       });
 
-      document.getElementById('clear-reminder-btn')?.addEventListener('click', async () => {
-        const res = await fetch('/api/music-items/' + ITEM_ID + '/reminder', { method: 'DELETE' });
-        if (!res.ok) { alert('Failed to clear reminder'); return; }
-        document.getElementById('remind-at').value = '';
-        document.getElementById('clear-reminder-btn').remove();
-      });
+      document.getElementById('clear-reminder-btn')?.addEventListener('click', clearReminder);
     </script>
   </body>
 </html>`;

--- a/tests/unit/release-page-route.test.ts
+++ b/tests/unit/release-page-route.test.ts
@@ -111,6 +111,51 @@ describe("GET /r/:id", () => {
     expect(html).toContain("selected");
   });
 
+  test("status select omits Scheduled option when no reminder is set", async () => {
+    mockFetchItem.mockResolvedValue(baseItem);
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).not.toContain('<option value="scheduled"');
+  });
+
+  test("status select shows Scheduled as the disabled+selected option when reminder is set", async () => {
+    mockFetchItem.mockResolvedValue({
+      ...baseItem,
+      remind_at: new Date("2026-06-15T00:00:00.000Z"),
+    });
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).toContain('<option value="scheduled" selected disabled>Scheduled</option>');
+    expect(html).toContain('<option value="to-listen">To Listen</option>');
+  });
+
+  test("status select shows Scheduled regardless of underlying listen_status", async () => {
+    mockFetchItem.mockResolvedValue({
+      ...baseItem,
+      listen_status: "listened" as const,
+      remind_at: new Date("2026-06-15T00:00:00.000Z"),
+    });
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).toContain('<option value="scheduled" selected disabled>Scheduled</option>');
+    expect(html).toContain('<option value="listened">Listened</option>');
+  });
+
+  test("inline script exposes current state for dropdown sync", async () => {
+    mockFetchItem.mockResolvedValue({
+      ...baseItem,
+      remind_at: new Date("2026-06-15T00:00:00.000Z"),
+    });
+    const app = makeApp();
+    const res = await app.request("http://localhost/r/42");
+    const html = await res.text();
+    expect(html).toContain('let currentListenStatus = "to-listen"');
+    expect(html).toContain('let currentRemindAt = "2026-06-15T00:00:00.000Z"');
+  });
+
   test("escapes HTML special characters in title", async () => {
     mockFetchItem.mockResolvedValue({
       ...baseItem,
@@ -416,12 +461,17 @@ describe("YouTube embed", () => {
     expect(html).toContain("Remind me");
   });
 
-  test("prefills reminder date from item year when available", async () => {
+  test("prefills reminder date with tomorrow when no remind_at is set", async () => {
     mockFetchItem.mockResolvedValue({ ...baseItem, year: 2026, remind_at: null });
     const app = makeApp();
     const res = await app.request("http://localhost/r/42");
     const html = await res.text();
-    expect(html).toContain('value="2026-01-01"');
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const yyyy = tomorrow.getFullYear();
+    const mm = String(tomorrow.getMonth() + 1).padStart(2, "0");
+    const dd = String(tomorrow.getDate()).padStart(2, "0");
+    expect(html).toContain(`value="${yyyy}-${mm}-${dd}"`);
   });
 
   test("prefills reminder date from remind_at when set", async () => {


### PR DESCRIPTION
## Summary

- The `/r/:id` status dropdown now reflects the **scheduled** state. When an item has `remind_at` set, the dropdown shows "Scheduled" as a disabled+selected option, mirroring the main-page filter bar (which already derives the scheduled state from the same field). Picking a real status (To Listen / Listened) from the dropdown also clears the reminder so the displayed state stays consistent with the DB.
- The reminder date input now defaults to **tomorrow** when no reminder is set, replacing the previous `${year}-01-01` fallback (which was usually in the past for older releases).

## What changed

- `server/routes/release-page.ts`
  - SSR: include a `<option value="scheduled" disabled selected>` only when `item.remind_at` is set; the underlying `listen_status` option is not marked selected in that case.
  - Inline JS: tracks `currentListenStatus` / `currentRemindAt` plus a `syncStatusDropdown()` helper. Status `change` handler does PATCH then DELETE (clearing the reminder) when leaving the scheduled state. Reminder set/clear buttons add/remove the "Scheduled" option in lockstep. Dropdown re-syncs on partial failure so it can't lie about reality.
  - `reminderDateValue()` defaults to tomorrow (server local time) when no `remind_at` is set.
- `tests/unit/release-page-route.test.ts`
  - 4 new SSR tests covering: no "Scheduled" option when reminder is unset; "Scheduled" disabled+selected when reminder is set; behaviour holds regardless of underlying `listen_status`; initial JS state vars exposed.
  - Existing year-based prefill test updated to assert on the tomorrow default.

## Notes for reviewers

- **Why "Scheduled" is display-only:** `scheduled` is a virtual filter in this codebase, not a real `listen_status` enum value (DB enum is just `"to-listen" | "listened"`). The dropdown surfaces the derived state but can't directly *set* it — setting a reminder in the row below is the only way to reach the scheduled state, which matches how the main-page filter works.
- **PATCH + DELETE coordination:** the `/api/music-items/:id` PATCH endpoint doesn't accept `remindAt`; reminders live behind `/:id/reminder`. So "pick Listened while scheduled" needs two HTTP calls. They run sequentially with explicit re-sync on either outcome.
- **Tomorrow uses server local time.** For containerised deployments running in UTC, a UK user clicking late at night (BST) could see what feels like "the day after tomorrow." If that matters we can move the default to client-side compute.
- **Not browser-verified.** Unit tests cover the SSR render and the inline state-var exposure, but the dropdown DOM-sync paths only run client-side and weren't smoke-tested in a real browser.

## Test plan

- [ ] Open an item with no reminder set: dropdown shows just "To Listen" / "Listened", date input defaults to tomorrow.
- [ ] Set a reminder: dropdown switches to "Scheduled" (disabled), Clear button appears.
- [ ] Click "Clear": dropdown reverts to the underlying listen_status, date input empties.
- [ ] On a scheduled item, pick "Listened" from the dropdown: status updates *and* reminder is cleared.
- [ ] Pick "To Listen" on a scheduled item: same — status updates and reminder is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)