### PR TITLE
Exclude scheduled items from listen-status filters

### DIFF
--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from "hono";
-import { eq, inArray, count, asc, desc } from "drizzle-orm";
+import { eq, inArray, count, asc, desc, and, isNull } from "drizzle-orm";
 import { db } from "../db/index";
 import { musicItems, musicItemStacks, stacks, musicItemOrder, stackParents } from "../db/schema";
 import { fullItemSelect } from "../queries/full-item-select";
@@ -89,8 +89,14 @@ async function fetchInitialItems(stackId: number | null): Promise<MusicItemFull[
   // pages the JS view shows all statuses, so the SSR must too — otherwise the
   // first paint shows global to-listen items that get replaced with the real
   // (mixed-status) stack contents a moment later.
+  //
+  // Scheduled items (remind_at IS NOT NULL) are owned by the "Scheduled"
+  // filter — exclude them here so they don't double up under "To Listen" with
+  // a label the release page then contradicts.
   if (filter !== "all") {
-    baseQuery = baseQuery.where(eq(musicItems.listenStatus, filter));
+    baseQuery = baseQuery.where(
+      and(eq(musicItems.listenStatus, filter), isNull(musicItems.remindAt)),
+    );
   }
 
   if (stackId !== null) {

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, inArray, isNotNull, sql, desc, asc, lte } from "drizzle-orm";
+import { eq, and, inArray, isNotNull, isNull, sql, desc, asc, lte } from "drizzle-orm";
 import { db } from "../db/index";
 import {
   musicItems,
@@ -202,7 +202,10 @@ musicItemRoutes.get("/", async (c) => {
     conditions.push(isNotNull(musicItems.remindAt));
   } else if (listenStatus) {
     const statuses = listenStatus.split(",") as ListenStatus[];
-    conditions.push(inArray(musicItems.listenStatus, statuses));
+    // Scheduled items (remind_at IS NOT NULL) belong to the "Scheduled" filter
+    // only — exclude them from listen-status buckets so a scheduled item never
+    // shows up under "To Listen"/"Listened" with a misleading label.
+    conditions.push(and(inArray(musicItems.listenStatus, statuses), isNull(musicItems.remindAt))!);
   }
 
   if (purchaseIntent) {

--- a/server/routes/rss.ts
+++ b/server/routes/rss.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { db } from "../db/index";
 import { musicItems, artists, musicLinks, sources, stacks, musicItemStacks } from "../db/schema";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and, inArray, isNull } from "drizzle-orm";
 import type { MusicItemFull } from "../../src/types";
 import type { PrimaryFeedKey } from "../../shared/rss";
 
@@ -268,7 +268,9 @@ async function defaultFetchPrimaryFeedItems(feed: PrimaryFeedKey): Promise<Music
             and(eq(musicLinks.musicItemId, musicItems.id), eq(musicLinks.isPrimary, 1)),
           )
           .leftJoin(sources, eq(sources.id, musicLinks.sourceId))
-          .where(eq(musicItems.listenStatus, feed))
+          // Scheduled items (remind_at IS NOT NULL) belong to the Scheduled
+          // bucket only — keep them out of the to-listen/listened feeds.
+          .where(and(eq(musicItems.listenStatus, feed), isNull(musicItems.remindAt)))
           .orderBy(musicItems.createdAt);
 
   return rows.map((row) => ({

--- a/tests/unit/main-page-ssr.test.ts
+++ b/tests/unit/main-page-ssr.test.ts
@@ -61,6 +61,43 @@ describe("SSR /", () => {
     }
   });
 
+  test("excludes scheduled items (remind_at set) from the to-listen view", async () => {
+    const { db } = await import("../../server/db/index");
+    const { musicItems } = await import("../../server/db/schema");
+    const { createMainPageRoutes } = await import("../../server/routes/main-page");
+
+    const inserted = await db
+      .insert(musicItems)
+      .values([
+        {
+          title: "ScheduledItem",
+          normalizedTitle: "scheduleditem",
+          listenStatus: "to-listen",
+          remindAt: new Date("2030-01-01T00:00:00Z"),
+        },
+        {
+          title: "PlainToListen",
+          normalizedTitle: "plaintolisten",
+          listenStatus: "to-listen",
+        },
+      ])
+      .returning({ id: musicItems.id, title: musicItems.title });
+
+    const scheduledId = inserted.find((i) => i.title === "ScheduledItem")!.id;
+    const plainId = inserted.find((i) => i.title === "PlainToListen")!.id;
+
+    const app = createMainPageRoutes();
+    const res = await app.request("http://localhost/");
+    const html = await res.text();
+
+    const renderedIds = [
+      ...new Set([...html.matchAll(/data-item-id="(\d+)"/g)].map((m) => Number(m[1]))),
+    ];
+
+    expect(renderedIds).toContain(plainId);
+    expect(renderedIds).not.toContain(scheduledId);
+  });
+
   test("filter-bar marks 'To Listen' as the active filter", async () => {
     const { createMainPageRoutes } = await import("../../server/routes/main-page");
 


### PR DESCRIPTION
## Summary
Scheduled items (those with `remind_at` set) are now excluded from listen-status filters ("To Listen", "Listened") across the application. These items belong exclusively to the "Scheduled" filter to prevent them from appearing under misleading labels.

## Changes
- **main-page.ts**: Added `isNull(musicItems.remindAt)` condition to the listen-status filter query to exclude scheduled items from SSR rendering
- **music-items.ts**: Updated the listen-status filter endpoint to exclude scheduled items using `isNull(musicItems.remindAt)` alongside the status filter
- **rss.ts**: Modified the primary feed queries to exclude scheduled items from to-listen and listened feeds
- **main-page-ssr.test.ts**: Added test case verifying that scheduled items are excluded from the to-listen view while regular to-listen items are included

## Implementation Details
- All changes use `isNull(musicItems.remindAt)` to identify non-scheduled items
- The exclusion is applied consistently across three route handlers (main-page, music-items, rss)
- Added clarifying comments explaining that scheduled items belong to the "Scheduled" filter only
- The test confirms the filtering works correctly at the SSR level

https://claude.ai/code/session_01TLGqN7Jqnzxef79padFXey