### PR TITLE
test(visual): stop release-page snapshot depending on iTunes

### DIFF
--- a/playwright/fixtures/parallel-test.ts
+++ b/playwright/fixtures/parallel-test.ts
@@ -29,6 +29,9 @@ export const test = base.extend<{}, WorkerFixtures>({
         ...process.env,
         NODE_ENV: "test",
         DATABASE_PATH: databasePath,
+        // Block server-side calls to external lookup APIs (iTunes etc.) so
+        // tests never depend on third-party availability or timing.
+        OTB_DISABLE_EXTERNAL_LOOKUPS: "1",
       };
 
       clearDatabaseFiles(databasePath);

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -1152,6 +1152,10 @@ export async function searchAppleMusic(
   artist: string | null,
   timeoutMs = 8000,
 ): Promise<string | null> {
+  // Test environments set this to keep the release page deterministic — the
+  // visual snapshot can't depend on whether iTunes responds in time.
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
+
   try {
     const term = [artist, title].filter(Boolean).join(" ");
     const searchUrl = `https://itunes.apple.com/search?term=${encodeURIComponent(term)}&media=music&entity=album,musicTrack,mix&limit=10`;


### PR DESCRIPTION
## Summary

The release page's client JS fires `POST /api/release/apple-music-lookup/:id` on load, which calls the real iTunes Search API server-side. When iTunes responds before the screenshot stabilises, an "Apple Music" link is appended to the DOM — making the `release-page-view` visual snapshot non-deterministic.

PR #200's CI surfaced this: `visual-mobile › captures main and release views` failed on both runs (~4% pixel diff) for reasons unrelated to that PR's changes. Same flake will recur on the next visual-regression run unless we cut iTunes out of the loop.

## Changes

- **`server/scraper.ts`** — `searchAppleMusic` short-circuits to `null` when `OTB_DISABLE_EXTERNAL_LOOKUPS` is set. Single-line guard at the network boundary; production behaviour unchanged.
- **`playwright/fixtures/parallel-test.ts`** — Worker server is spawned with `OTB_DISABLE_EXTERNAL_LOOKUPS=1`, so every Playwright test (e2e and visual) gets a deterministic page render. Test still flows through our `/api/release/apple-music-lookup` handler.

## Test plan

- [x] Unit tests pass locally (`bun test tests/unit/scraper.test.ts`, `release-route.test.ts`, `release-page-route.test.ts` — unaffected because the guard only triggers when the env var is set, and unit tests don't set it).
- [x] Sanity check: with `OTB_DISABLE_EXTERNAL_LOOKUPS=1`, `searchAppleMusic` returns `null` and never hits `fetch`. Without the env, behaviour is unchanged (returns a real Apple Music URL).
- [ ] CI Visual Regression passes — this PR's own run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)