### PR TITLE
Pick One button, music link detection, visual test stability

### DIFF
--- a/server/routes/main-page.ts
+++ b/server/routes/main-page.ts
@@ -163,12 +163,14 @@ function renderFilterBarButtons(activeFilter: FilterSelection): string {
     { value: "listened", label: "Listened" },
     { value: "scheduled", label: "Scheduled" },
   ];
-  return buttons
+  const filterButtons = buttons
     .map(
       ({ value, label }) =>
         `<button class="filter-btn${value === activeFilter ? " active" : ""}" data-filter="${value}">${label}</button>`,
     )
     .join("\n              ");
+  const pickRandomButton = `<button type="button" id="pick-random-btn" class="filter-btn filter-btn--action" title="Pick a random item from To Listen" aria-label="Pick a random item from To Listen">🎲 Pick One</button>`;
+  return `${filterButtons}\n              ${pickRandomButton}`;
 }
 
 function renderMainPage(opts: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -179,6 +179,7 @@ function readServerState(): { stacks: StackWithCount[] } | null {
 
 function initializeUI(hasServerData: boolean): void {
   setupFilterBar();
+  setupPickRandom();
   setupBrowseControls();
   setupStackBar();
   setupStackManagePanel();
@@ -767,7 +768,7 @@ function setupFilterBar(): void {
 
   filterBar.addEventListener("click", (event) => {
     const target = event.target as HTMLElement;
-    if (!target.classList.contains("filter-btn")) {
+    if (!target.classList.contains("filter-btn") || !target.dataset.filter) {
       return;
     }
 
@@ -776,6 +777,42 @@ function setupFilterBar(): void {
       filter: target.dataset.filter as ListenStatus | "all" | "scheduled",
     });
     syncDateListenedOption();
+  });
+}
+
+function setupPickRandom(): void {
+  const btn = document.getElementById("pick-random-btn");
+  if (!(btn instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  btn.addEventListener("click", async () => {
+    if (btn.disabled) return;
+    const originalText = btn.textContent ?? "🎲 Pick One";
+    btn.disabled = true;
+    try {
+      const filters = buildMusicItemFilters("to-listen", appCtx().currentStack);
+      const result = await api.listMusicItems(filters);
+      if (result.items.length === 0) {
+        btn.textContent = "🎲 Nothing yet";
+        setTimeout(() => {
+          btn.textContent = originalText;
+          btn.disabled = false;
+        }, 1500);
+        return;
+      }
+      const picked = result.items[Math.floor(Math.random() * result.items.length)];
+      const link = document.createElement("a");
+      link.href = `/r/${picked.id}`;
+      link.style.display = "none";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } finally {
+      if (btn.textContent === originalText) {
+        btn.disabled = false;
+      }
+    }
   });
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -776,6 +776,20 @@ select.input {
   font-weight: bold;
 }
 
+.filter-btn--action {
+  margin-left: auto;
+  font-weight: bold;
+}
+
+.filter-btn--action:active:not(:disabled) {
+  border-color: var(--chrome-darker) var(--chrome-white) var(--chrome-white) var(--chrome-darker);
+}
+
+.filter-btn--action:disabled {
+  cursor: default;
+  color: var(--chrome-dark);
+}
+
 .browse-tools {
   display: flex;
   align-items: center;
@@ -1228,6 +1242,10 @@ select.input {
     font-size: 10px;
     padding: 0 8px 0 2px;
     flex-shrink: 0;
+  }
+
+  .filter-btn--action {
+    margin-left: 0;
   }
 
   .browse-controls {

--- a/tests/visual/ui.spec.ts
+++ b/tests/visual/ui.spec.ts
@@ -233,6 +233,14 @@ async function mockCoverScanRoutes(
     });
   });
 
+  await page.route("**/api/release/apple-music-lookup/*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ url: null }),
+    });
+  });
+
   await page.route(`**${uploadedArtworkUrl}`, async (route) => {
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary

Three independent changes (branch renamed from `fix-ssr-stack-route-filter` — that name was vestigial from earlier work and no longer reflects what's here):

### 1. `feat(home)`: add "Pick One" button to randomly select a to-listen item — `3e3bde8`

### 2. `test(visual)`: mock Apple Music secondary lookup to stabilise release page snapshot — `f328ff8`

### 3. `fix(scraper)`: detect music links via OG metadata and URL slug — `c6292d8`

`scrapeUnknownUrl` now passes `url` + parsed `og` into `detectMusicRelatedHtml`, which scans `og:title` / `og:description` / `og:site_name` + URL pathname alongside the stripped body. Also adds `vol` to `STRONG_MUSIC_TERMS` (word-boundary regex keeps it from matching "volume" / "evolution").

Catches Shopify product pages where the music signal lives in OG meta or the URL slug rather than the visible body. Reported case: `https://igetrvng.com/products/reflections-vol-3-felicia-atkinson-christina-vantzou-water-poems` was being rejected as non-music because the truncated 250KB body strips to ~3KB of nav + Shopify's worldwide currency picker; the music vocab ("songs", "stream", "vol") lives in OG description and the URL slug.

## Test plan
- [x] Unit suite: 421/421 pass
- [x] `tsc --noEmit` clean
- [x] Music fix verified against reported RVNG URL: `isMusicRelated: true, matchedTerms: ["stream", "songs"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)