### PR TITLE
Add photo ingest endpoint with OCR-based music recognition

### DIFF
--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -1,7 +1,13 @@
 import { Hono } from "hono";
 import { extractMusicUrls } from "../email-parser";
-import { createMusicItemsFromUrl } from "../music-item-creator";
+import { createMusicItemDirect, createMusicItemsFromUrl } from "../music-item-creator";
 import { isValidUrl } from "../utils";
+import { saveImageFromBase64, validateImageBase64 } from "../uploads";
+import { createScanEnricher } from "../scan-enricher";
+import { extractReleaseInfo, extractReleaseInfoFromWebContext } from "../vision";
+import { getWebContext } from "../google-vision";
+import { lookupRelease } from "../musicbrainz";
+import type { ScanResult } from "../../src/types";
 
 interface EmailEnvelope {
   from: string;
@@ -24,52 +30,118 @@ const providers: Record<string, ProviderAdapter> = {
   }),
 };
 
-export const ingestRoutes = new Hono();
+export type ScanPhotoFn = (base64Image: string) => Promise<ScanResult | null>;
+export type SavePhotoFn = (base64Image: string) => Promise<string>;
 
-ingestRoutes.post("/email", async (c) => {
-  // Check if ingest is configured
-  const apiKey = process.env.INGEST_API_KEY;
-  if (!apiKey) {
-    return c.json({ error: "Ingest not configured" }, 503);
-  }
+export interface IngestRoutesDeps {
+  scanPhoto?: ScanPhotoFn;
+  savePhoto?: SavePhotoFn;
+}
 
-  // Check if ingest is enabled
-  if (process.env.INGEST_ENABLED === "false") {
-    return c.json({ error: "Ingest disabled" }, 503);
-  }
+export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
+  const scanPhoto =
+    deps.scanPhoto ??
+    createScanEnricher(
+      extractReleaseInfo,
+      lookupRelease,
+      getWebContext,
+      extractReleaseInfoFromWebContext,
+    );
+  const savePhoto = deps.savePhoto ?? saveImageFromBase64;
 
-  // Authenticate
-  const auth = c.req.header("Authorization");
-  if (auth !== `Bearer ${apiKey}`) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
+  const routes = new Hono();
 
-  // Select provider adapter
-  const provider = c.req.query("provider") || "generic";
-  const adapter = providers[provider];
-  if (!adapter) {
-    return c.json({ error: `Unknown provider: ${provider}` }, 400);
-  }
+  routes.post("/email", async (c) => {
+    const apiKey = process.env.INGEST_API_KEY;
+    if (!apiKey) {
+      return c.json({ error: "Ingest not configured" }, 503);
+    }
 
-  // Parse body into envelope
-  const body = await c.req.json();
-  const envelope = adapter(body);
+    if (process.env.INGEST_ENABLED === "false") {
+      return c.json({ error: "Ingest disabled" }, 503);
+    }
 
-  // Extract music URLs from email content
-  const urls = extractMusicUrls(
-    { html: envelope.html, text: envelope.text },
-    { includeUnknown: true },
-  );
+    const auth = c.req.header("Authorization");
+    if (auth !== `Bearer ${apiKey}`) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
 
-  // Create items for each URL
-  const items: Array<{ id: number; title: string; url: string }> = [];
-  const skipped: Array<{ url: string; reason: string }> = [];
+    const provider = c.req.query("provider") || "generic";
+    const adapter = providers[provider];
+    if (!adapter) {
+      return c.json({ error: `Unknown provider: ${provider}` }, 400);
+    }
 
-  for (const url of urls) {
+    const body = await c.req.json();
+    const envelope = adapter(body);
+
+    const urls = extractMusicUrls(
+      { html: envelope.html, text: envelope.text },
+      { includeUnknown: true },
+    );
+
+    const items: Array<{ id: number; title: string; url: string }> = [];
+    const skipped: Array<{ url: string; reason: string }> = [];
+
+    for (const url of urls) {
+      try {
+        const results = await createMusicItemsFromUrl(url, {
+          notes: `Via email from ${envelope.from}`,
+        });
+
+        for (const result of results) {
+          if (result.created) {
+            items.push({
+              id: result.item.id,
+              title: result.item.title,
+              url: result.item.primary_url || url,
+            });
+          } else {
+            skipped.push({ url, reason: "duplicate" });
+          }
+        }
+      } catch (err) {
+        console.error(`[api] POST /api/ingest/email failed to create item for ${url}:`, err);
+        skipped.push({ url, reason: "creation_failed" });
+      }
+    }
+
+    return c.json({
+      received: true,
+      items_created: items.length,
+      items_skipped: skipped.length,
+      items,
+      skipped,
+    });
+  });
+
+  routes.post("/link", async (c) => {
+    const apiKey = process.env.INGEST_API_KEY;
+    if (!apiKey) {
+      return c.json({ error: "Ingest not configured" }, 503);
+    }
+
+    if (process.env.INGEST_ENABLED === "false") {
+      return c.json({ error: "Ingest disabled" }, 503);
+    }
+
+    const auth = c.req.header("Authorization");
+    if (auth !== `Bearer ${apiKey}`) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const body = await c.req.json();
+    const url = typeof body?.url === "string" ? body.url.trim() : "";
+
+    if (!url || !isValidUrl(url)) {
+      return c.json({ error: "Missing or invalid url" }, 400);
+    }
+
     try {
-      const results = await createMusicItemsFromUrl(url, {
-        notes: `Via email from ${envelope.from}`,
-      });
+      const results = await createMusicItemsFromUrl(url);
+
+      const items: Array<{ id: number; title: string; url: string }> = [];
+      const skipped: Array<{ url: string; reason: string }> = [];
 
       for (const result of results) {
         if (result.created) {
@@ -82,73 +154,113 @@ ingestRoutes.post("/email", async (c) => {
           skipped.push({ url, reason: "duplicate" });
         }
       }
+
+      return c.json({
+        received: true,
+        items_created: items.length,
+        items_skipped: skipped.length,
+        items,
+        skipped,
+      });
     } catch (err) {
-      console.error(`[api] POST /api/ingest/email failed to create item for ${url}:`, err);
-      skipped.push({ url, reason: "creation_failed" });
+      console.error(`[api] POST /api/ingest/link failed for ${url}:`, err);
+      return c.json({ error: "Failed to create item" }, 422);
     }
-  }
-
-  return c.json({
-    received: true,
-    items_created: items.length,
-    items_skipped: skipped.length,
-    items,
-    skipped,
   });
-});
 
-ingestRoutes.post("/link", async (c) => {
-  // Check if ingest is configured
-  const apiKey = process.env.INGEST_API_KEY;
-  if (!apiKey) {
-    return c.json({ error: "Ingest not configured" }, 503);
-  }
-
-  // Check if ingest is enabled
-  if (process.env.INGEST_ENABLED === "false") {
-    return c.json({ error: "Ingest disabled" }, 503);
-  }
-
-  // Authenticate
-  const auth = c.req.header("Authorization");
-  if (auth !== `Bearer ${apiKey}`) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
-
-  const body = await c.req.json();
-  const url = typeof body?.url === "string" ? body.url.trim() : "";
-
-  if (!url || !isValidUrl(url)) {
-    return c.json({ error: "Missing or invalid url" }, 400);
-  }
-
-  try {
-    const results = await createMusicItemsFromUrl(url);
-
-    const items: Array<{ id: number; title: string; url: string }> = [];
-    const skipped: Array<{ url: string; reason: string }> = [];
-
-    for (const result of results) {
-      if (result.created) {
-        items.push({
-          id: result.item.id,
-          title: result.item.title,
-          url: result.item.primary_url || url,
-        });
-      } else {
-        skipped.push({ url, reason: "duplicate" });
-      }
+  routes.post("/photo", async (c) => {
+    const apiKey = process.env.INGEST_API_KEY;
+    if (!apiKey) {
+      return c.json({ error: "Ingest not configured" }, 503);
     }
 
-    return c.json({
-      received: true,
-      items_created: items.length,
-      items_skipped: skipped.length,
-      items,
-      skipped,
-    });
-  } catch (err) {
-    console.error(`[api] POST /api/ingest/link failed for ${url}:`, err);
-    return c.json({ error: "Failed to create item" }, 422);
-  }
-});
+    if (process.env.INGEST_ENABLED === "false") {
+      return c.json({ error: "Ingest disabled" }, 503);
+    }
+
+    const auth = c.req.header("Authorization");
+    if (auth !== `Bearer ${apiKey}`) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err) {
+      console.error("[api] POST /api/ingest/photo invalid JSON:", err);
+      return c.json({ error: "Invalid JSON payload" }, 400);
+    }
+
+    if (!body || typeof body !== "object") {
+      return c.json({ error: "Invalid JSON payload" }, 400);
+    }
+
+    const { imageBase64, notes, from } = body as Record<string, unknown>;
+    const validation = validateImageBase64(imageBase64);
+    if (!validation.ok) {
+      return c.json({ error: validation.error }, 400);
+    }
+
+    let artworkUrl: string;
+    try {
+      artworkUrl = await savePhoto(validation.value);
+    } catch (err) {
+      console.error("[api] POST /api/ingest/photo failed to save image:", err);
+      return c.json({ error: "Failed to save image" }, 500);
+    }
+
+    let scan: ScanResult | null = null;
+    try {
+      scan = await scanPhoto(validation.value);
+    } catch (err) {
+      console.error("[api] POST /api/ingest/photo scan failed:", err);
+    }
+
+    const noteParts: string[] = [];
+    if (typeof notes === "string" && notes.trim()) noteParts.push(notes.trim());
+    if (typeof from === "string" && from.trim()) noteParts.push(`Via photo from ${from.trim()}`);
+
+    try {
+      const result = await createMusicItemDirect({
+        title: scan?.title ?? undefined,
+        artistName: scan?.artist ?? undefined,
+        artworkUrl,
+        year: scan?.year ?? undefined,
+        label: scan?.label ?? undefined,
+        country: scan?.country ?? undefined,
+        catalogueNumber: scan?.catalogueNumber ?? undefined,
+        musicbrainzReleaseId: scan?.musicbrainzReleaseId ?? undefined,
+        musicbrainzArtistId: scan?.musicbrainzArtistId ?? undefined,
+        notes: noteParts.length ? noteParts.join(" — ") : undefined,
+      });
+
+      return c.json({
+        received: true,
+        items_created: 1,
+        items_skipped: 0,
+        items: [
+          {
+            id: result.item.id,
+            title: result.item.title,
+            artworkUrl,
+          },
+        ],
+        scan: scan
+          ? {
+              artist: scan.artist,
+              title: scan.title,
+              artistConfidence: scan.artistConfidence,
+              titleConfidence: scan.titleConfidence,
+            }
+          : null,
+      });
+    } catch (err) {
+      console.error("[api] POST /api/ingest/photo failed to create item:", err);
+      return c.json({ error: "Failed to create item", artworkUrl }, 422);
+    }
+  });
+
+  return routes;
+}
+
+export const ingestRoutes = createIngestRoutes();

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -183,19 +183,47 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch (err) {
-      console.error("[api] POST /api/ingest/photo invalid JSON:", err);
-      return c.json({ error: "Invalid JSON payload" }, 400);
+    let imageBase64: unknown;
+    let notes: unknown;
+    let from: unknown;
+
+    const contentType = c.req.header("Content-Type") ?? "";
+
+    if (contentType.includes("multipart/form-data")) {
+      // iPhone Shortcuts and other clients send the photo as a file field.
+      let form: Record<string, string | File>;
+      try {
+        form = (await c.req.parseBody()) as Record<string, string | File>;
+      } catch (err) {
+        console.error("[api] POST /api/ingest/photo invalid form data:", err);
+        return c.json({ error: "Invalid form data" }, 400);
+      }
+
+      const file = form.photo ?? form.image ?? form.file;
+      if (!(file instanceof File)) {
+        return c.json({ error: "photo file is required" }, 400);
+      }
+
+      const buffer = Buffer.from(await file.arrayBuffer());
+      imageBase64 = buffer.toString("base64");
+      notes = form.notes;
+      from = form.from;
+    } else {
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch (err) {
+        console.error("[api] POST /api/ingest/photo invalid JSON:", err);
+        return c.json({ error: "Invalid JSON payload" }, 400);
+      }
+
+      if (!body || typeof body !== "object") {
+        return c.json({ error: "Invalid JSON payload" }, 400);
+      }
+
+      ({ imageBase64, notes, from } = body as Record<string, unknown>);
     }
 
-    if (!body || typeof body !== "object") {
-      return c.json({ error: "Invalid JSON payload" }, 400);
-    }
-
-    const { imageBase64, notes, from } = body as Record<string, unknown>;
     const validation = validateImageBase64(imageBase64);
     if (!validation.ok) {
       return c.json({ error: validation.error }, 400);

--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -1,6 +1,4 @@
 import { Hono } from "hono";
-import { mkdir, writeFile } from "node:fs/promises";
-import path from "node:path";
 import { eq, and } from "drizzle-orm";
 import { extractReleaseInfo, extractReleaseInfoFromWebContext } from "../vision";
 import { getWebContext } from "../google-vision";
@@ -9,41 +7,15 @@ import { fetchAndSaveCoverArt } from "../cover-art-archive";
 import { createScanEnricher } from "../scan-enricher";
 import type { ScanResult } from "../../src/types";
 import type { MusicBrainzFields } from "../musicbrainz";
-import { getUploadsDir, toUploadsPublicPath } from "../uploads";
+import { saveImageFromBase64, validateImageBase64 } from "../uploads";
 import { searchAppleMusic } from "../scraper";
 import { parseUrl } from "../utils";
 import { db } from "../db/index";
 import { musicItems, musicLinks, sources, artists } from "../db/schema";
 import { recognizeAudio, isAcrCloudConfigured } from "../acrcloud";
 
-const MAX_IMAGE_BASE64_LENGTH = 2_000_000;
-const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-
 interface ScanRequestBody {
   imageBase64?: unknown;
-}
-
-function validateImageBase64(
-  value: unknown,
-): { ok: true; value: string } | { ok: false; error: string } {
-  if (typeof value !== "string") {
-    return { ok: false, error: "imageBase64 must be a string" };
-  }
-
-  const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    return { ok: false, error: "imageBase64 is required" };
-  }
-
-  if (trimmed.length > MAX_IMAGE_BASE64_LENGTH) {
-    return { ok: false, error: "imageBase64 is too large" };
-  }
-
-  if (!BASE64_PATTERN.test(trimmed)) {
-    return { ok: false, error: "imageBase64 must be valid base64" };
-  }
-
-  return { ok: true, value: trimmed };
 }
 
 export type ExtractReleaseInfoFn = (base64Image: string) => Promise<ScanResult | null>;
@@ -147,18 +119,6 @@ async function defaultSaveAppleMusicLink(itemId: number, url: string): Promise<v
   }
 }
 
-async function saveReleaseImage(base64Image: string): Promise<string> {
-  const uploadsDir = getUploadsDir();
-  await mkdir(uploadsDir, { recursive: true });
-
-  const filename = `${crypto.randomUUID()}.jpg`;
-  const filePath = path.join(uploadsDir, filename);
-  const imageBytes = Buffer.from(base64Image, "base64");
-  await writeFile(filePath, imageBytes);
-
-  return toUploadsPublicPath(filename);
-}
-
 export function createReleaseRoutes(
   scanReleaseCover: ExtractReleaseInfoFn = createScanEnricher(
     extractReleaseInfo,
@@ -166,7 +126,7 @@ export function createReleaseRoutes(
     getWebContext,
     extractReleaseInfoFromWebContext,
   ),
-  saveImage: SaveReleaseImageFn = saveReleaseImage,
+  saveImage: SaveReleaseImageFn = saveImageFromBase64,
   lookupReleaseFn: LookupReleaseFn = lookupRelease,
   fetchCoverArtFn: FetchCoverArtFn = fetchAndSaveCoverArt,
   searchAppleMusicFn: SearchAppleMusicFn = searchAppleMusic,

--- a/server/uploads.ts
+++ b/server/uploads.ts
@@ -1,7 +1,10 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const DEFAULT_UPLOADS_DIR = "uploads";
 const UPLOADS_ROUTE_PREFIX = "/uploads";
+const MAX_IMAGE_BASE64_LENGTH = 2_000_000;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 export function getUploadsDir(): string {
   const configuredDir = process.env.UPLOADS_DIR?.trim();
@@ -25,4 +28,39 @@ export function rewriteUploadsRequestPath(requestPath: string): string {
   }
 
   return requestPath.slice(UPLOADS_ROUTE_PREFIX.length) || "/";
+}
+
+export type ValidateImageBase64Result = { ok: true; value: string } | { ok: false; error: string };
+
+export function validateImageBase64(value: unknown): ValidateImageBase64Result {
+  if (typeof value !== "string") {
+    return { ok: false, error: "imageBase64 must be a string" };
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: "imageBase64 is required" };
+  }
+
+  if (trimmed.length > MAX_IMAGE_BASE64_LENGTH) {
+    return { ok: false, error: "imageBase64 is too large" };
+  }
+
+  if (!BASE64_PATTERN.test(trimmed)) {
+    return { ok: false, error: "imageBase64 must be valid base64" };
+  }
+
+  return { ok: true, value: trimmed };
+}
+
+export async function saveImageFromBase64(base64Image: string): Promise<string> {
+  const uploadsDir = getUploadsDir();
+  await mkdir(uploadsDir, { recursive: true });
+
+  const filename = `${crypto.randomUUID()}.jpg`;
+  const filePath = path.join(uploadsDir, filename);
+  const imageBytes = Buffer.from(base64Image, "base64");
+  await writeFile(filePath, imageBytes);
+
+  return toUploadsPublicPath(filename);
 }

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -655,4 +655,63 @@ describe("POST /api/ingest/photo", () => {
     expect(body.error).toBe("Failed to create item");
     expect(body.artworkUrl).toBe("/uploads/abc.jpg");
   });
+
+  it("accepts multipart/form-data with a photo file", async () => {
+    mockScan.mockResolvedValue({
+      artist: "Aphex Twin",
+      title: "Selected Ambient Works 85-92",
+      artistConfidence: 0.99,
+      titleConfidence: 0.97,
+    });
+    mockCreateDirect.mockResolvedValue({
+      item: { id: 5, title: "Selected Ambient Works 85-92" },
+      created: true,
+    });
+
+    const imageBytes = new Uint8Array([1, 2, 3, 4]);
+    const expectedBase64 = Buffer.from(imageBytes).toString("base64");
+
+    const form = new FormData();
+    form.append("photo", new File([imageBytes], "cover.jpg", { type: "image/jpeg" }));
+    form.append("notes", "Record shop find");
+    form.append("from", "iphone");
+
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/ingest/photo", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret" },
+      body: form,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items_created).toBe(1);
+    expect(body.items[0].id).toBe(5);
+    expect(mockSaveImage).toHaveBeenCalledWith(expectedBase64);
+    expect(mockScan).toHaveBeenCalledWith(expectedBase64);
+    expect(mockCreateDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Selected Ambient Works 85-92",
+        artistName: "Aphex Twin",
+        notes: "Record shop find — Via photo from iphone",
+      }),
+    );
+  });
+
+  it("returns 400 when multipart upload has no photo file", async () => {
+    const form = new FormData();
+    form.append("notes", "missing the file");
+
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/ingest/photo", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret" },
+      body: form,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("photo");
+    expect(mockSaveImage).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { Hono } from "hono";
 
 const mockCreateMany = mock();
+const mockCreateDirect = mock();
+const mockSaveImage = mock();
+const mockScan = mock();
 
 // Mock the entire music-item-creator module before importing any route.
 // All named exports must be present: bun's mock.module() persists across
@@ -10,7 +13,7 @@ const mockCreateMany = mock();
 mock.module("../../server/music-item-creator", () => ({
   createMusicItemsFromUrl: mockCreateMany,
   createMusicItemFromUrl: mock(),
-  createMusicItemDirect: mock(),
+  createMusicItemDirect: mockCreateDirect,
   fetchFullItem: mock(),
   fullItemSelect: mock(),
   getOrCreateArtist: mock(),
@@ -18,12 +21,12 @@ mock.module("../../server/music-item-creator", () => ({
   AmbiguousLinkSelectionError: class AmbiguousLinkSelectionError extends Error {},
 }));
 
-// Import after mock is set up
-const { ingestRoutes } = await import("../../server/routes/ingest");
+// Import after mocks are set up
+const { createIngestRoutes } = await import("../../server/routes/ingest");
 
 function makeApp() {
   const app = new Hono();
-  app.route("/api/ingest", ingestRoutes);
+  app.route("/api/ingest", createIngestRoutes({ scanPhoto: mockScan, savePhoto: mockSaveImage }));
   return app;
 }
 
@@ -395,5 +398,261 @@ describe("POST /api/ingest/email", () => {
     const body = await res.json();
     expect(body.items_created).toBe(2);
     expect(body.items).toHaveLength(2);
+  });
+});
+
+function makePhotoRequest(
+  app: Hono,
+  body: Record<string, unknown>,
+  opts?: { apiKey?: string; raw?: string },
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts?.apiKey) {
+    headers.Authorization = `Bearer ${opts.apiKey}`;
+  }
+
+  return app.request("http://localhost/api/ingest/photo", {
+    method: "POST",
+    headers,
+    body: opts?.raw ?? JSON.stringify(body),
+  });
+}
+
+describe("POST /api/ingest/photo", () => {
+  const originalEnv = { ...process.env };
+  const validBase64 = "YWJjZA==";
+
+  beforeEach(() => {
+    process.env.INGEST_API_KEY = "test-secret";
+    delete process.env.INGEST_ENABLED;
+    mockCreateDirect.mockReset();
+    mockSaveImage.mockReset();
+    mockSaveImage.mockResolvedValue("/uploads/abc.jpg");
+    mockScan.mockReset();
+    mockScan.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns 503 when INGEST_API_KEY is not set", async () => {
+    delete process.env.INGEST_API_KEY;
+    const app = makeApp();
+    const res = await makePhotoRequest(app, { imageBase64: validBase64 }, { apiKey: "anything" });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Ingest not configured");
+  });
+
+  it("returns 503 when INGEST_ENABLED is false", async () => {
+    process.env.INGEST_ENABLED = "false";
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Ingest disabled");
+  });
+
+  it("returns 401 when no Authorization header is provided", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(app, { imageBase64: validBase64 });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong API key is provided", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(app, { imageBase64: validBase64 }, { apiKey: "wrong-key" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when imageBase64 is missing", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(app, {}, { apiKey: "test-secret" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("imageBase64");
+    expect(mockSaveImage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid base64", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: "not!!base64" },
+      { apiKey: "test-secret" },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("base64");
+    expect(mockSaveImage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(app, {}, { apiKey: "test-secret", raw: "{not-json" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON payload");
+  });
+
+  it("creates an item using scanned metadata when scan succeeds", async () => {
+    mockScan.mockResolvedValue({
+      artist: "Boards of Canada",
+      title: "Geogaddi",
+      artistConfidence: 0.95,
+      titleConfidence: 0.92,
+      year: 2002,
+      label: "Warp",
+      country: "GB",
+      catalogueNumber: "WARP101",
+    });
+    mockCreateDirect.mockResolvedValue({
+      item: { id: 42, title: "Geogaddi" },
+      created: true,
+    });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.received).toBe(true);
+    expect(body.items_created).toBe(1);
+    expect(body.items[0]).toEqual({
+      id: 42,
+      title: "Geogaddi",
+      artworkUrl: "/uploads/abc.jpg",
+    });
+    expect(body.scan).toEqual({
+      artist: "Boards of Canada",
+      title: "Geogaddi",
+      artistConfidence: 0.95,
+      titleConfidence: 0.92,
+    });
+
+    expect(mockSaveImage).toHaveBeenCalledWith(validBase64);
+    expect(mockScan).toHaveBeenCalledWith(validBase64);
+    expect(mockCreateDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Geogaddi",
+        artistName: "Boards of Canada",
+        artworkUrl: "/uploads/abc.jpg",
+        year: 2002,
+        label: "Warp",
+        country: "GB",
+        catalogueNumber: "WARP101",
+      }),
+    );
+  });
+
+  it("creates an item even when scan returns null", async () => {
+    mockScan.mockResolvedValue(null);
+    mockCreateDirect.mockResolvedValue({
+      item: { id: 7, title: "Untitled" },
+      created: true,
+    });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items_created).toBe(1);
+    expect(body.items[0].id).toBe(7);
+    expect(body.scan).toBeNull();
+    expect(mockCreateDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artworkUrl: "/uploads/abc.jpg",
+      }),
+    );
+  });
+
+  it("still creates an item when scan throws", async () => {
+    mockScan.mockRejectedValue(new Error("vision API down"));
+    mockCreateDirect.mockResolvedValue({
+      item: { id: 9, title: "Untitled" },
+      created: true,
+    });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items_created).toBe(1);
+    expect(body.scan).toBeNull();
+  });
+
+  it("includes notes and from in the created item's notes", async () => {
+    mockScan.mockResolvedValue(null);
+    mockCreateDirect.mockResolvedValue({
+      item: { id: 1, title: "Untitled" },
+      created: true,
+    });
+
+    const app = makeApp();
+    await makePhotoRequest(
+      app,
+      { imageBase64: validBase64, notes: "Record shop find", from: "phone" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(mockCreateDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notes: "Record shop find — Via photo from phone",
+      }),
+    );
+  });
+
+  it("returns 500 when image save fails", async () => {
+    mockSaveImage.mockRejectedValue(new Error("disk full"));
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to save image");
+    expect(mockCreateDirect).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when item creation fails", async () => {
+    mockScan.mockResolvedValue(null);
+    mockCreateDirect.mockRejectedValue(new Error("DB error"));
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to create item");
+    expect(body.artworkUrl).toBe("/uploads/abc.jpg");
   });
 });


### PR DESCRIPTION
## Summary
This PR adds a new `/api/ingest/photo` endpoint that allows users to submit album cover photos for automatic music metadata extraction and item creation. The endpoint uses OCR/vision APIs to scan album artwork and extract artist, title, and other release information.

## Key Changes

- **New photo ingest endpoint** (`POST /api/ingest/photo`): Accepts album cover images via JSON (base64) or multipart form data, automatically extracts metadata using vision APIs, and creates music items with the scanned information
- **Refactored ingest routes**: Converted `ingestRoutes` from a singleton to a factory function `createIngestRoutes(deps)` to support dependency injection for testing and customization
- **Extracted upload utilities**: Moved image validation and saving logic from `release.ts` to a new `uploads.ts` module (`validateImageBase64` and `saveImageFromBase64`) for reuse across endpoints
- **Vision API integration**: The photo endpoint leverages existing scan enrichment infrastructure (`createScanEnricher`) to extract release metadata including artist, title, year, label, country, and catalogue number
- **Flexible input handling**: Supports both JSON payloads with base64-encoded images and multipart form data (for iPhone Shortcuts and similar clients)
- **Graceful degradation**: Creates items even if vision API scanning fails, allowing manual metadata entry as fallback
- **Comprehensive test coverage**: Added 15+ test cases covering authentication, validation, success paths, error handling, and both JSON and multipart request formats

## Notable Implementation Details

- The endpoint validates base64 input before processing and returns appropriate HTTP status codes (400 for validation, 500 for save failures, 422 for item creation failures)
- Metadata from vision scanning is passed to `createMusicItemDirect` for direct item creation without URL-based lookups
- Notes and source information ("from" field) are combined into a single notes field with " — " separator
- The response includes both created item details and scan confidence scores when available
- Multipart form data supports multiple field names for the photo (`photo`, `image`, or `file`) for compatibility with different clients

https://claude.ai/code/session_0125XLyDKvDALSxtn9ssMoPc