### PR TITLE
Pick One button, music link detection, visual test stability

### DIFF
--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -39,6 +39,7 @@ const STRONG_MUSIC_TERMS = [
   "tracks",
   "single",
   "vinyl",
+  "vol",
   "discography",
   "ep",
   "lp",
@@ -68,6 +69,11 @@ export class UnsupportedMusicLinkError extends Error {
 export interface MusicSignalResult {
   isMusicRelated: boolean;
   matchedTerms: string[];
+}
+
+export interface MusicSignalContext {
+  url?: string;
+  og?: OgData;
 }
 
 export function parseOgTags(html: string): OgData {
@@ -136,8 +142,24 @@ function stripHtmlForAnalysis(html: string): string {
   ).trim();
 }
 
-export function detectMusicRelatedHtml(html: string): MusicSignalResult {
-  const text = stripHtmlForAnalysis(html).toLowerCase();
+function buildMusicSignalText(html: string, { url, og }: MusicSignalContext): string {
+  const parts = [stripHtmlForAnalysis(html)];
+  if (og?.ogTitle) parts.push(og.ogTitle);
+  if (og?.ogDescription) parts.push(og.ogDescription);
+  if (og?.ogSiteName) parts.push(og.ogSiteName);
+  if (og?.title) parts.push(og.title);
+  if (url) {
+    const pathname = new URL(url).pathname;
+    parts.push(decodeURIComponent(pathname).replace(/[-_/]+/g, " "));
+  }
+  return parts.join(" ");
+}
+
+export function detectMusicRelatedHtml(
+  html: string,
+  context: MusicSignalContext = {},
+): MusicSignalResult {
+  const text = buildMusicSignalText(html, context).toLowerCase();
   const matchedTerms = new Set<string>();
 
   for (const term of STRONG_MUSIC_TERMS) {
@@ -176,7 +198,7 @@ function buildUnknownPageSnippet(url: string, html: string): string {
 }
 
 async function scrapeUnknownUrl(url: string, html: string, og: OgData): Promise<ScrapedMetadata> {
-  const signal = detectMusicRelatedHtml(html);
+  const signal = detectMusicRelatedHtml(html, { url, og });
   if (!signal.isMusicRelated) {
     throw new UnsupportedMusicLinkError("Link does not appear to be music-related");
   }

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -427,6 +427,42 @@ describe("detectMusicRelatedHtml", () => {
 
     expect(result.isMusicRelated).toBe(false);
   });
+
+  test("uses OG metadata when visible body is chrome-only (Shopify product page)", () => {
+    // Shopify-style page where the truncated body is dominated by nav + currency picker,
+    // but og:description carries the music signal. Mirrors what scrapeUnknownUrl passes in.
+    const html = `<html><body>
+      <nav>Shop Artists News Events About</nav>
+      <p>United States USD $ Germany EUR €</p>
+    </body></html>`;
+    const result = detectMusicRelatedHtml(html, {
+      url: "https://igetrvng.com/products/reflections-vol-3-water-poems",
+      og: {
+        ogTitle: "Reflections Vol. 3: Water Poems",
+        ogDescription: "dreamlike songs and soundscapes flow into a unified stream",
+        ogSiteName: "RVNG Intl.",
+      },
+    });
+    expect(result.isMusicRelated).toBe(true);
+    expect(result.matchedTerms).toEqual(expect.arrayContaining(["songs", "stream"]));
+  });
+
+  test("uses URL path slug as a music signal", () => {
+    const html = `<html><body><p>welcome</p></body></html>`;
+    const result = detectMusicRelatedHtml(html, {
+      url: "https://example.com/album/some-record-2024",
+    });
+    expect(result.isMusicRelated).toBe(true);
+    expect(result.matchedTerms).toContain("album");
+  });
+
+  test("still rejects non-music pages even with url+og context", () => {
+    const result = detectMusicRelatedHtml(`<html><body><h1>Spring sale</h1></body></html>`, {
+      url: "https://example.com/sale/spring",
+      og: { ogTitle: "Spring Sale", ogDescription: "Big discounts on bags and shoes." },
+    });
+    expect(result.isMusicRelated).toBe(false);
+  });
 });
 
 describe("scrapeUrl", () => {


### PR DESCRIPTION
Replaces #202 (closed by branch rename — `fix-ssr-stack-route-filter` was a vestigial name from earlier work that didn't reflect what's actually here).

## Summary

Three independent changes:

### 1. `feat(home)`: add "Pick One" button to randomly select a to-listen item — `3e3bde8`

### 2. `test(visual)`: mock Apple Music secondary lookup to stabilise release page snapshot — `f328ff8`

### 3. `fix(scraper)`: detect music links via OG metadata and URL slug — `c6292d8`

`scrapeUnknownUrl` now passes `url` + parsed `og` into `detectMusicRelatedHtml`, which scans `og:title` / `og:description` / `og:site_name` + URL pathname alongside the stripped body. Also adds `vol` to `STRONG_MUSIC_TERMS` (word-boundary regex keeps it from matching "volume" / "evolution").

Catches Shopify product pages where the music signal lives in OG meta or the URL slug rather than the visible body. Reported case: `https://igetrvng.com/products/reflections-vol-3-felicia-atkinson-christina-vantzou-water-poems` was being rejected as non-music because the truncated 250KB body strips to ~3KB of nav + Shopify's worldwide currency picker; the music vocab ("songs", "stream", "vol") lives in OG description and the URL slug.

## Test plan
- [x] Unit suite: 421/421 pass
- [x] `tsc --noEmit` clean
- [x] Music fix verified against reported RVNG URL: `isMusicRelated: true, matchedTerms: ["stream", "songs"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)