### PR TITLE
Fix iPad list scrolling: touch-friendly scrollbar and drag handle

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1512,7 +1512,9 @@ function setupMusicListReorder(): void {
     },
   });
 
-  musicListReorderMediaQuery = window.matchMedia("(max-width: 520px)");
+  // Use a drag handle on narrow screens and on touch devices (e.g. iPad), so a
+  // swipe anywhere on a card scrolls the list instead of starting a reorder.
+  musicListReorderMediaQuery = window.matchMedia("(max-width: 520px), (pointer: coarse)");
   musicListReorderMediaQuery.addEventListener("change", handleMusicListReorderMediaChange);
   syncMusicListReorderMode();
 }
@@ -1617,19 +1619,22 @@ function setupCustomListScrollbar(): void {
     button.addEventListener("click", () => {
       scrollByStep(delta);
     });
-    button.addEventListener("mousedown", () => {
+    // Pointer events cover both mouse and touch, so press-and-hold repeat
+    // scrolling works on iPad as well as desktop.
+    button.addEventListener("pointerdown", () => {
       startRepeatScroll(delta);
     });
-    button.addEventListener("mouseup", stopRepeatScroll);
-    button.addEventListener("mouseleave", stopRepeatScroll);
+    button.addEventListener("pointerup", stopRepeatScroll);
+    button.addEventListener("pointercancel", stopRepeatScroll);
+    button.addEventListener("pointerleave", stopRepeatScroll);
   };
 
   bindScrollButton(upButton, -40);
   bindScrollButton(downButton, 40);
-  document.addEventListener("mouseup", stopRepeatScroll);
+  document.addEventListener("pointerup", stopRepeatScroll);
   window.addEventListener("blur", stopRepeatScroll);
 
-  track.addEventListener("mousedown", (event) => {
+  track.addEventListener("pointerdown", (event) => {
     if (event.target === thumb) {
       return;
     }
@@ -1643,7 +1648,7 @@ function setupCustomListScrollbar(): void {
     list.scrollBy({ top: direction * Math.max(80, list.clientHeight * 0.8), behavior: "auto" });
   });
 
-  const onDragMove = (event: MouseEvent): void => {
+  const onDragMove = (event: PointerEvent): void => {
     if (!listThumbDrag || !musicListEl || !musicListTrackEl || !musicListThumbEl) {
       return;
     }
@@ -1670,19 +1675,23 @@ function setupCustomListScrollbar(): void {
 
   const onDragEnd = (): void => {
     listThumbDrag = null;
-    document.removeEventListener("mousemove", onDragMove);
+    document.removeEventListener("pointermove", onDragMove);
   };
 
-  thumb.addEventListener("mousedown", (event) => {
+  thumb.addEventListener("pointerdown", (event) => {
     event.preventDefault();
+    if (event.pointerId !== undefined && typeof thumb.setPointerCapture === "function") {
+      thumb.setPointerCapture(event.pointerId);
+    }
     const trackRect = track.getBoundingClientRect();
     const thumbRect = thumb.getBoundingClientRect();
     listThumbDrag = {
       startY: event.clientY,
       startTop: thumbRect.top - trackRect.top,
     };
-    document.addEventListener("mousemove", onDragMove);
-    document.addEventListener("mouseup", onDragEnd, { once: true });
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
   });
 
   list.addEventListener("scroll", () => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -956,6 +956,9 @@ select.input {
   grid-template-rows: 19px minmax(0, 1fr) 19px;
   background: #d4d4d4;
   border-left: 1px solid #7b7b7b;
+  /* Let the scrollbar handle its own touch gestures (thumb drag / track tap)
+     instead of the browser treating them as page scrolls. */
+  touch-action: none;
 }
 
 .music-scrollbar__button {
@@ -1429,6 +1432,14 @@ select.input {
 
 .music-card__reorder-handle:active {
   cursor: grabbing;
+}
+
+/* On touch devices (e.g. iPad) expose the reorder handle so dragging the handle
+   reorders, while a swipe on the rest of the card scrolls the list. */
+@media (pointer: coarse) {
+  .music-card .music-card__reorder-handle {
+    display: inline-flex;
+  }
 }
 
 .music-card__menu-toggle {


### PR DESCRIPTION
On iPad the list view was hard to scroll for two reasons:

1. Drag-and-drop hijacked scroll. The reorder handle was only used below
   520px, so iPad (>=768px) made the whole card draggable and any swipe
   started a reorder. Now a drag handle is used on coarse-pointer (touch)
   devices too, so swipes anywhere else on a card scroll the list.

2. The custom scrollbar only listened for mouse events, so the thumb
   couldn't be dragged and the track/buttons couldn't be tapped on touch.
   Switched the thumb drag, track tap and button press-and-hold to pointer
   events (with pointer capture) and set touch-action: none on the
   scrollbar so the browser doesn't steal the gesture.