### PR TITLE
Preview: taskbar clock opens scheduled-reminders popup

### DIFF
--- a/playwright/clock-reminders.spec.ts
+++ b/playwright/clock-reminders.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "./fixtures/parallel-test";
+
+test("clock popup lists upcoming scheduled reminders", async ({ page, request }) => {
+  const created = await request.post("/api/music-items", {
+    data: { title: "Reminder Target", artistName: "Clockwork Artist" },
+  });
+  expect(created.ok()).toBeTruthy();
+  const item = await created.json();
+
+  const reminder = await request.put(`/api/music-items/${item.id}/reminder`, {
+    data: { remindAt: "2031-01-15T09:00:00Z" },
+  });
+  expect(reminder.ok()).toBeTruthy();
+
+  await page.goto("/");
+  const clock = page.locator("#taskbar-clock");
+  const popup = page.locator("#clock-popup");
+
+  await expect(popup).toBeHidden();
+  await clock.click();
+  await expect(popup).toBeVisible();
+  await expect(clock).toHaveAttribute("aria-expanded", "true");
+
+  const row = popup.locator(".clock-popup__item", { hasText: "Reminder Target" });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("Clockwork Artist");
+  await expect(row).toContainText("15 Jan");
+
+  // Row links to the release page
+  await expect(row).toHaveAttribute("href", `/r/${item.id}`);
+
+  // Escape closes
+  await page.keyboard.press("Escape");
+  await expect(popup).toBeHidden();
+  await expect(clock).toHaveAttribute("aria-expanded", "false");
+});

--- a/src/lib/components/Taskbar.svelte
+++ b/src/lib/components/Taskbar.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import type { MusicItemFull } from "../../types";
+  import { api } from "../api";
   import { player } from "../player.svelte";
 
   let { showStart = true, showClock = true }: { showStart?: boolean; showClock?: boolean } =
@@ -14,6 +16,74 @@
     tick();
     const interval = setInterval(tick, 10_000);
     return () => clearInterval(interval);
+  });
+
+  // ── Scheduled-reminders popup ───────────────────────────────────────────────
+  // The taskbar clock is the natural place to look for time-things: clicking it
+  // lists the next six scheduled releases, soonest first.
+  let popupOpen = $state(false);
+  let remindersLoading = $state(false);
+  let upcoming = $state<MusicItemFull[]>([]);
+
+  async function toggleClockPopup(): Promise<void> {
+    popupOpen = !popupOpen;
+    if (!popupOpen) return;
+
+    remindersLoading = true;
+    try {
+      const result = await api.listMusicItems({ hasReminder: true });
+      upcoming = result.items
+        .filter((item) => item.remind_at)
+        .sort((a, b) => (a.remind_at! < b.remind_at! ? -1 : 1))
+        .slice(0, 6);
+    } catch {
+      upcoming = [];
+    } finally {
+      remindersLoading = false;
+    }
+  }
+
+  function reminderDate(item: MusicItemFull): string {
+    return new Date(item.remind_at!).toLocaleDateString("en-GB", {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+    });
+  }
+
+  function isDue(item: MusicItemFull): boolean {
+    return new Date(item.remind_at!).getTime() <= Date.now();
+  }
+
+  function reminderLabel(item: MusicItemFull): string {
+    return `${item.artist_name ? `${item.artist_name} — ` : ""}${item.title}`;
+  }
+
+  $effect(() => {
+    if (!popupOpen) return;
+
+    const onDocumentClick = (event: MouseEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      const popup = document.getElementById("clock-popup");
+      const clockBtn = document.getElementById("taskbar-clock");
+      if (popup?.contains(target) || clockBtn?.contains(target)) return;
+      popupOpen = false;
+    };
+
+    const onEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") popupOpen = false;
+    };
+
+    document.addEventListener("keydown", onEscape);
+    // Deferred so the click that opened the popup doesn't immediately close it.
+    const timer = setTimeout(() => document.addEventListener("click", onDocumentClick), 0);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("keydown", onEscape);
+      document.removeEventListener("click", onDocumentClick);
+    };
   });
 </script>
 
@@ -32,6 +102,37 @@
     <span id="taskbar-np-label">{player.active ? player.label : ""}</span>
   </button>
   {#if showClock}
-    <span id="taskbar-clock" class="taskbar__clock">{clock}</span>
+    <div id="clock-popup" class="clock-popup" hidden={!popupOpen}>
+      <div class="clock-popup__title">📅 Scheduled reminders</div>
+      <div id="clock-popup-list" class="clock-popup__list">
+        {#if remindersLoading}
+          <div class="clock-popup__empty">Loading…</div>
+        {:else if upcoming.length === 0}
+          <div class="clock-popup__empty">
+            No reminders scheduled. Set one from a release page.
+          </div>
+        {:else}
+          {#each upcoming as item (item.id)}
+            <a
+              class="clock-popup__item"
+              class:clock-popup__item--due={isDue(item)}
+              href="/r/{item.id}"
+              onclick={() => (popupOpen = false)}
+            >
+              <span class="clock-popup__date">{isDue(item) ? "⏰ " : ""}{reminderDate(item)}</span>
+              <span class="clock-popup__label">{reminderLabel(item)}</span>
+            </a>
+          {/each}
+        {/if}
+      </div>
+    </div>
+    <button
+      id="taskbar-clock"
+      class="taskbar__clock"
+      aria-haspopup="true"
+      aria-expanded={popupOpen}
+      title="Scheduled reminders"
+      onclick={toggleClockPopup}>{clock}</button
+    >
   {/if}
 </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1534,6 +1534,10 @@ select.input {
     width: 44px;
     height: 44px;
   }
+
+  .clock-popup .clock-popup__item {
+    min-height: 36px;
+  }
 }
 
 .music-card__menu-toggle {
@@ -2188,6 +2192,83 @@ a:hover {
   padding: 0 8px;
   display: flex;
   align-items: center;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.taskbar__clock[aria-expanded="true"] {
+  background: var(--chrome-mid);
+}
+
+/* ── Clock popup: upcoming scheduled reminders ── */
+.clock-popup {
+  position: absolute;
+  bottom: calc(100% + 1px);
+  right: 2px;
+  min-width: 250px;
+  max-width: min(92vw, 320px);
+  background: var(--chrome);
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-raised);
+  box-shadow: var(--shadow-menu);
+  padding: var(--space-1);
+}
+
+.clock-popup__title {
+  background: linear-gradient(90deg, var(--win-blue), #0a2a5c);
+  color: #ffffff;
+  font-weight: bold;
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  margin-bottom: var(--space-1);
+}
+
+.clock-popup__item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  width: 100%;
+  min-height: var(--control-h-sm);
+  padding: var(--space-2) var(--space-3);
+  color: #000000;
+  font-size: var(--text-base);
+  text-decoration: none;
+}
+
+.clock-popup__item:hover,
+.clock-popup__item:focus-visible {
+  background: var(--win-blue);
+  color: #ffffff;
+  outline: none;
+}
+
+.clock-popup__date {
+  font-weight: bold;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.clock-popup__item--due .clock-popup__date {
+  color: var(--led-red, #c0392b);
+}
+
+.clock-popup__item--due:hover .clock-popup__date,
+.clock-popup__item--due:focus-visible .clock-popup__date {
+  color: #ffd3cc;
+}
+
+.clock-popup__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clock-popup__empty {
+  padding: var(--space-3);
+  font-size: var(--text-base);
+  color: var(--chrome-dark);
 }
 
 /* ═══════════════════════════════════════════════════


### PR DESCRIPTION
**Preview experiment** — independently deployable and mergeable.

Clicking the taskbar clock opens a Win95 popup listing the next six scheduled reminders, soonest first — overdue entries red with an alarm mark, each row linking to its release page. Surfaces data that previously hid behind the Scheduled filter, in the place you'd naturally look for time-things. Includes the coarse-pointer row sizing for tablets.

Once Coolify **Preview Deployments** are enabled (see `PREVIEWS.md`), this PR gets its own preview URL; `PREVIEW_SEED=1` seeds one overdue and one upcoming reminder so the popup demos itself. Shared commits dedupe across `preview/*` merges.

https://claude.ai/code/session_01Gfetuacbxt4EeDHo5px3yP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gfetuacbxt4EeDHo5px3yP)_