### PR TITLE
Preview: Pick One rolls the dice visibly before landing

### DIFF
--- a/playwright/pick-one.spec.ts
+++ b/playwright/pick-one.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "./fixtures/parallel-test";
+
+test("pick one rolls and lands on a release page", async ({ page, request }) => {
+  for (const n of [1, 2, 3]) {
+    const res = await request.post("/api/music-items", {
+      data: { title: `Roll Candidate ${n}`, artistName: "Lady Luck" },
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+
+  await page.goto("/");
+  await page.locator('[data-filter="to-listen"]').click();
+  await expect(page.locator(".music-card").first()).toBeVisible();
+
+  await page.locator("#pick-random-btn").click();
+  await page.waitForURL(/\/r\/\d+/, { timeout: 10_000 });
+  await expect(page.getByText(/Roll Candidate \d/).first()).toBeVisible();
+});

--- a/src/lib/components/BrowseControls.svelte
+++ b/src/lib/components/BrowseControls.svelte
@@ -90,6 +90,7 @@
   async function pickRandom(): Promise<void> {
     if (randomBtnDisabled) return;
     randomBtnDisabled = true;
+    randomBtnText = "🎲 Rolling…";
     try {
       const picked = await onPickRandom();
       if (!picked) {
@@ -98,6 +99,8 @@
           randomBtnText = "🎲 Pick One";
           randomBtnDisabled = false;
         }, 1500);
+      } else {
+        randomBtnText = "🎲 Pick One";
       }
     } finally {
       if (randomBtnText === "🎲 Pick One") {

--- a/src/lib/components/MainPage.svelte
+++ b/src/lib/components/MainPage.svelte
@@ -216,6 +216,43 @@
     app.send({ type: "STACK_DELETED", stackId });
   }
 
+  /**
+   * Slot-machine sweep across the visible cards before Pick One settles on the
+   * winner. Skipped for reduced motion, tiny lists, or when the picked item
+   * isn't rendered in the current view.
+   */
+  async function rouletteToCard(targetId: number): Promise<void> {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    const cards = [...document.querySelectorAll<HTMLElement>(".music-card")];
+    const target = document.querySelector<HTMLElement>(`.music-card[data-item-id="${targetId}"]`);
+    if (cards.length < 2 || !target) {
+      return;
+    }
+
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+    const clear = () => {
+      for (const card of cards) card.classList.remove("music-card--roulette");
+    };
+
+    const steps = Math.min(8, cards.length + 3);
+    for (let i = 0; i < steps; i++) {
+      clear();
+      const card = cards[Math.floor(Math.random() * cards.length)];
+      card.classList.add("music-card--roulette");
+      card.scrollIntoView({ block: "nearest" });
+      await wait(55 + i * 16);
+    }
+
+    clear();
+    target.classList.add("music-card--roulette");
+    target.scrollIntoView({ block: "nearest" });
+    await wait(320);
+    target.classList.remove("music-card--roulette");
+  }
+
   async function pickRandom(): Promise<{ id: number } | null> {
     const filters = buildMusicItemFilters("to-listen", ctx.currentStack);
     const result = await api.listMusicItems(filters);
@@ -223,6 +260,7 @@
       return null;
     }
     const picked = result.items[Math.floor(Math.random() * result.items.length)];
+    await rouletteToCard(picked.id);
     await goto(`/r/${picked.id}`);
     return picked;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1471,6 +1471,16 @@ select.input {
   justify-content: center;
 }
 
+.music-card.music-card--roulette {
+  background: var(--win-blue);
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.music-card--roulette .music-card__title,
+.music-card--roulette .music-card__artist {
+  color: #ffffff;
+}
+
 .music-card__menu-panel {
   position: absolute;
   top: calc(100% + 4px);


### PR DESCRIPTION
**Preview experiment** — independently deployable and mergeable.

Pick One performs before it lands: the button reads "Rolling…" while a brief slot-machine sweep lights random visible cards in selection blue, settles on the winner for a beat, then opens its release page. Skipped under `prefers-reduced-motion`, for tiny lists, or when the picked item isn't rendered in the current view.

Once Coolify **Preview Deployments** are enabled (see `PREVIEWS.md`), this PR gets its own preview URL; set `PREVIEW_SEED=1` so there's a queue to roll across. Shared commits dedupe across `preview/*` merges.

https://claude.ai/code/session_01Gfetuacbxt4EeDHo5px3yP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gfetuacbxt4EeDHo5px3yP)_