### PR TITLE
Backfill Apple Music links in the background at add time

### DIFF
--- a/docs/areas/integrations/scanning-and-enrichment.md
+++ b/docs/areas/integrations/scanning-and-enrichment.md
@@ -19,6 +19,12 @@
 - Cover Art Archive fetches can save richer artwork when a MusicBrainz release ID is found.
 - Apple Music links can be backfilled for playable releases.
 
+## Apple Music backfill
+
+- `server/apple-music-backfill.ts` holds the shared backfill logic. `backfillAppleMusicLink` looks up a release on the iTunes Search API and saves a confident match as a secondary Apple Music link. It is idempotent: it skips releases whose primary link is already Apple Music and leaves any existing Apple Music link untouched.
+- When a non-Apple-Music item is added (via the API, email/link ingest, or photo ingest) `scheduleAppleMusicBackfill` runs the lookup in the background, so a playable Apple Music link is usually ready before the release page is opened.
+- `POST /api/release/apple-music-lookup/:id` exposes the same logic on demand and is still used as a lazy fallback from the release page for older items.
+
 ## Frontend tie-in
 
 `src/ui/state/add-form-machine.ts` runs upload and scan in parallel, then uses MusicBrainz lookup as a non-fatal enrichment step before final item creation.

--- a/server/apple-music-backfill.ts
+++ b/server/apple-music-backfill.ts
@@ -1,0 +1,170 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "./db/index";
+import { musicItems, musicLinks, sources, artists } from "./db/schema";
+import { parseUrl } from "./utils";
+import { searchAppleMusic } from "./scraper";
+
+export interface ItemInfoForLookup {
+  title: string;
+  artistName: string | null;
+  primarySource: string | null;
+  primaryUrl: string | null;
+}
+
+export type FetchItemForLookupFn = (id: number) => Promise<ItemInfoForLookup | null>;
+export type GetExistingAppleMusicLinkFn = (itemId: number) => Promise<string | null>;
+export type SaveAppleMusicLinkFn = (itemId: number, url: string) => Promise<void>;
+export type SearchAppleMusicFn = (title: string, artist: string | null) => Promise<string | null>;
+
+export interface AppleMusicBackfillDeps {
+  fetchItem: FetchItemForLookupFn;
+  getExistingLink: GetExistingAppleMusicLinkFn;
+  saveLink: SaveAppleMusicLinkFn;
+  search: SearchAppleMusicFn;
+}
+
+export type BackfillResult =
+  // The item id did not resolve to a release.
+  | { status: "item_missing" }
+  // The primary link is already an Apple Music link — nothing to do.
+  | { status: "skipped" }
+  // An Apple Music secondary link already exists.
+  | { status: "existing"; url: string }
+  // A matching Apple Music link was found and saved.
+  | { status: "added"; url: string }
+  // No confident Apple Music match was found.
+  | { status: "not_found" };
+
+export const PLAYABLE_SOURCES = new Set([
+  "bandcamp",
+  "spotify",
+  "soundcloud",
+  "youtube",
+  "apple_music",
+  "tidal",
+  "deezer",
+  "mixcloud",
+]);
+
+async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup | null> {
+  const rows = await db
+    .select({
+      title: musicItems.title,
+      artistName: artists.name,
+      primarySource: sources.name,
+      primaryUrl: musicLinks.url,
+    })
+    .from(musicItems)
+    .leftJoin(artists, eq(musicItems.artistId, artists.id))
+    .leftJoin(
+      musicLinks,
+      and(eq(musicLinks.musicItemId, musicItems.id), eq(musicLinks.isPrimary, true)),
+    )
+    .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
+    .where(eq(musicItems.id, id))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return null;
+
+  return {
+    title: row.title,
+    artistName: row.artistName ?? null,
+    primarySource: row.primarySource ?? null,
+    primaryUrl: row.primaryUrl ?? null,
+  };
+}
+
+async function defaultGetExistingAppleMusicLink(itemId: number): Promise<string | null> {
+  const rows = await db
+    .select({ url: musicLinks.url })
+    .from(musicLinks)
+    .innerJoin(sources, eq(musicLinks.sourceId, sources.id))
+    .where(and(eq(musicLinks.musicItemId, itemId), eq(sources.name, "apple_music")))
+    .limit(1);
+
+  return rows[0]?.url ?? null;
+}
+
+async function defaultSaveAppleMusicLink(itemId: number, url: string): Promise<void> {
+  const sourceRows = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(eq(sources.name, "apple_music"))
+    .limit(1);
+
+  const sourceId = sourceRows[0]?.id ?? null;
+
+  try {
+    await db.insert(musicLinks).values({
+      musicItemId: itemId,
+      sourceId,
+      url,
+      isPrimary: false,
+      metadata: null,
+    });
+  } catch {
+    // Likely a unique constraint violation — link already exists
+  }
+}
+
+export const defaultAppleMusicBackfillDeps: AppleMusicBackfillDeps = {
+  fetchItem: defaultFetchItemForLookup,
+  getExistingLink: defaultGetExistingAppleMusicLink,
+  saveLink: defaultSaveAppleMusicLink,
+  search: searchAppleMusic,
+};
+
+function isAppleMusicUrl(url: string | null): boolean {
+  if (!url) return false;
+  return parseUrl(url).source === "apple_music" || url.includes("music.apple.com");
+}
+
+/**
+ * Find a good Apple Music match for a release and save it as a secondary link.
+ *
+ * Idempotent and safe to run in the background: it skips releases whose
+ * primary link is already Apple Music, returns any pre-existing Apple Music
+ * secondary link untouched, and only saves a link when the iTunes Search API
+ * returns a confident title + artist match.
+ */
+export async function backfillAppleMusicLink(
+  itemId: number,
+  deps: AppleMusicBackfillDeps = defaultAppleMusicBackfillDeps,
+): Promise<BackfillResult> {
+  const item = await deps.fetchItem(itemId);
+  if (!item) {
+    return { status: "item_missing" };
+  }
+
+  if (isAppleMusicUrl(item.primaryUrl)) {
+    return { status: "skipped" };
+  }
+
+  const existing = await deps.getExistingLink(itemId);
+  if (existing) {
+    return { status: "existing", url: existing };
+  }
+
+  const appleMusicUrl = await deps.search(item.title, item.artistName);
+  if (!appleMusicUrl) {
+    return { status: "not_found" };
+  }
+
+  await deps.saveLink(itemId, appleMusicUrl);
+  return { status: "added", url: appleMusicUrl };
+}
+
+/**
+ * Fire-and-forget wrapper around {@link backfillAppleMusicLink} for use right
+ * after an item is created. Never throws — failures are logged and swallowed
+ * so they can't disrupt the request that scheduled them.
+ */
+export function scheduleAppleMusicBackfill(
+  itemId: number,
+  deps: AppleMusicBackfillDeps = defaultAppleMusicBackfillDeps,
+): void {
+  void backfillAppleMusicLink(itemId, deps).catch((err) => {
+    console.error("[apple-music] background backfill failed for item", itemId, err);
+  });
+}

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { extractMusicUrls } from "../email-parser";
 import { createMusicItemDirect, createMusicItemsFromUrl } from "../music-item-creator";
+import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
 import { isValidUrl } from "../utils";
 import { saveImageFromBase64, validateImageBase64 } from "../uploads";
 import { createScanEnricher } from "../scan-enricher";
@@ -91,6 +92,7 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
 
         for (const result of results) {
           if (result.created) {
+            scheduleAppleMusicBackfill(result.item.id);
             items.push({
               id: result.item.id,
               title: result.item.title,
@@ -145,6 +147,7 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
 
       for (const result of results) {
         if (result.created) {
+          scheduleAppleMusicBackfill(result.item.id);
           items.push({
             id: result.item.id,
             title: result.item.title,
@@ -261,6 +264,8 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
         musicbrainzArtistId: scan?.musicbrainzArtistId ?? undefined,
         notes: noteParts.length ? noteParts.join(" — ") : undefined,
       });
+
+      scheduleAppleMusicBackfill(result.item.id);
 
       return c.json({
         received: true,

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -25,6 +25,7 @@ import {
 import { hydrateItemStacks } from "../hydrate-item-stacks";
 import { UnsupportedMusicLinkError } from "../scraper";
 import { fetchAndStoreSuggestion } from "../suggestions";
+import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
 import type {
   CreateMusicItemInput,
   UpdateMusicItemInput,
@@ -366,6 +367,12 @@ musicItemRoutes.post("/", async (c) => {
         year: result.item.year,
         musicbrainz_artist_id: result.item.musicbrainz_artist_id,
       });
+    }
+    // Newly added non-Apple-Music releases get an Apple Music link backfilled in
+    // the background, so a playable secondary link is ready by the time the
+    // release page is opened. No-ops if the primary link is already Apple Music.
+    if (result.created) {
+      scheduleAppleMusicBackfill(result.item.id);
     }
     return c.json(result.item, 201);
   } catch (err) {

--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { eq, and } from "drizzle-orm";
 import { extractReleaseInfo, extractReleaseInfoFromWebContext } from "../vision";
 import { getWebContext } from "../google-vision";
 import { lookupRelease } from "../musicbrainz";
@@ -8,11 +7,28 @@ import { createScanEnricher } from "../scan-enricher";
 import type { ScanResult } from "../../src/types";
 import type { MusicBrainzFields } from "../musicbrainz";
 import { saveImageFromBase64, validateImageBase64 } from "../uploads";
-import { searchAppleMusic } from "../scraper";
-import { parseUrl } from "../utils";
 import { db } from "../db/index";
-import { musicItems, musicLinks, sources, artists } from "../db/schema";
+import { sources } from "../db/schema";
 import { recognizeAudio, isAcrCloudConfigured } from "../acrcloud";
+import {
+  backfillAppleMusicLink,
+  defaultAppleMusicBackfillDeps,
+  PLAYABLE_SOURCES,
+  type ItemInfoForLookup,
+  type FetchItemForLookupFn,
+  type GetExistingAppleMusicLinkFn,
+  type SaveAppleMusicLinkFn,
+  type SearchAppleMusicFn,
+} from "../apple-music-backfill";
+
+export { PLAYABLE_SOURCES };
+export type {
+  ItemInfoForLookup,
+  FetchItemForLookupFn,
+  GetExistingAppleMusicLinkFn,
+  SaveAppleMusicLinkFn,
+  SearchAppleMusicFn,
+};
 
 interface ScanRequestBody {
   imageBase64?: unknown;
@@ -31,94 +47,6 @@ export type FetchCoverArtFn = (
   saveImage: SaveReleaseImageFn,
 ) => Promise<string | null>;
 
-export type SearchAppleMusicFn = (title: string, artist: string | null) => Promise<string | null>;
-
-export interface ItemInfoForLookup {
-  title: string;
-  artistName: string | null;
-  primarySource: string | null;
-  primaryUrl: string | null;
-}
-
-export type FetchItemForLookupFn = (id: number) => Promise<ItemInfoForLookup | null>;
-
-export type SaveAppleMusicLinkFn = (itemId: number, url: string) => Promise<void>;
-
-export type GetExistingAppleMusicLinkFn = (itemId: number) => Promise<string | null>;
-
-export const PLAYABLE_SOURCES = new Set([
-  "bandcamp",
-  "spotify",
-  "soundcloud",
-  "youtube",
-  "apple_music",
-  "tidal",
-  "deezer",
-  "mixcloud",
-]);
-
-async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup | null> {
-  const rows = await db
-    .select({
-      title: musicItems.title,
-      artistName: artists.name,
-      primarySource: sources.name,
-      primaryUrl: musicLinks.url,
-    })
-    .from(musicItems)
-    .leftJoin(artists, eq(musicItems.artistId, artists.id))
-    .leftJoin(
-      musicLinks,
-      and(eq(musicLinks.musicItemId, musicItems.id), eq(musicLinks.isPrimary, true)),
-    )
-    .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
-    .where(eq(musicItems.id, id))
-    .limit(1);
-
-  const row = rows[0];
-  if (!row) return null;
-
-  return {
-    title: row.title,
-    artistName: row.artistName ?? null,
-    primarySource: row.primarySource ?? null,
-    primaryUrl: row.primaryUrl ?? null,
-  };
-}
-
-async function defaultGetExistingAppleMusicLink(itemId: number): Promise<string | null> {
-  const rows = await db
-    .select({ url: musicLinks.url })
-    .from(musicLinks)
-    .innerJoin(sources, eq(musicLinks.sourceId, sources.id))
-    .where(and(eq(musicLinks.musicItemId, itemId), eq(sources.name, "apple_music")))
-    .limit(1);
-
-  return rows[0]?.url ?? null;
-}
-
-async function defaultSaveAppleMusicLink(itemId: number, url: string): Promise<void> {
-  const sourceRows = await db
-    .select({ id: sources.id })
-    .from(sources)
-    .where(eq(sources.name, "apple_music"))
-    .limit(1);
-
-  const sourceId = sourceRows[0]?.id ?? null;
-
-  try {
-    await db.insert(musicLinks).values({
-      musicItemId: itemId,
-      sourceId,
-      url,
-      isPrimary: false,
-      metadata: null,
-    });
-  } catch {
-    // Likely a unique constraint violation — link already exists
-  }
-}
-
 export function createReleaseRoutes(
   scanReleaseCover: ExtractReleaseInfoFn = createScanEnricher(
     extractReleaseInfo,
@@ -129,10 +57,10 @@ export function createReleaseRoutes(
   saveImage: SaveReleaseImageFn = saveImageFromBase64,
   lookupReleaseFn: LookupReleaseFn = lookupRelease,
   fetchCoverArtFn: FetchCoverArtFn = fetchAndSaveCoverArt,
-  searchAppleMusicFn: SearchAppleMusicFn = searchAppleMusic,
-  fetchItemForLookupFn: FetchItemForLookupFn = defaultFetchItemForLookup,
-  getExistingAppleMusicLinkFn: GetExistingAppleMusicLinkFn = defaultGetExistingAppleMusicLink,
-  saveAppleMusicLinkFn: SaveAppleMusicLinkFn = defaultSaveAppleMusicLink,
+  searchAppleMusicFn: SearchAppleMusicFn = defaultAppleMusicBackfillDeps.search,
+  fetchItemForLookupFn: FetchItemForLookupFn = defaultAppleMusicBackfillDeps.fetchItem,
+  getExistingAppleMusicLinkFn: GetExistingAppleMusicLinkFn = defaultAppleMusicBackfillDeps.getExistingLink,
+  saveAppleMusicLinkFn: SaveAppleMusicLinkFn = defaultAppleMusicBackfillDeps.saveLink,
 ): Hono {
   const routes = new Hono();
 
@@ -241,32 +169,24 @@ export function createReleaseRoutes(
       return c.json({ error: "Invalid ID" }, 400);
     }
 
-    const item = await fetchItemForLookupFn(id);
-    if (!item) {
-      return c.json({ error: "Not found" }, 404);
+    const result = await backfillAppleMusicLink(id, {
+      fetchItem: fetchItemForLookupFn,
+      getExistingLink: getExistingAppleMusicLinkFn,
+      saveLink: saveAppleMusicLinkFn,
+      search: searchAppleMusicFn,
+    });
+
+    switch (result.status) {
+      case "item_missing":
+        return c.json({ error: "Not found" }, 404);
+      case "skipped":
+        return c.json({ skipped: true }, 200);
+      case "existing":
+      case "added":
+        return c.json({ url: result.url }, 200);
+      case "not_found":
+        return c.json({ url: null }, 200);
     }
-
-    if (
-      item.primaryUrl &&
-      (parseUrl(item.primaryUrl).source === "apple_music" ||
-        item.primaryUrl.includes("music.apple.com"))
-    ) {
-      return c.json({ skipped: true }, 200);
-    }
-
-    const existing = await getExistingAppleMusicLinkFn(id);
-    if (existing) {
-      return c.json({ url: existing }, 200);
-    }
-
-    const appleMusicUrl = await searchAppleMusicFn(item.title, item.artistName);
-    if (!appleMusicUrl) {
-      return c.json({ url: null }, 200);
-    }
-
-    await saveAppleMusicLinkFn(id, appleMusicUrl);
-
-    return c.json({ url: appleMusicUrl }, 200);
   });
 
   routes.post("/recognize", async (c) => {

--- a/tests/unit/apple-music-backfill.test.ts
+++ b/tests/unit/apple-music-backfill.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  backfillAppleMusicLink,
+  type AppleMusicBackfillDeps,
+} from "../../server/apple-music-backfill";
+
+const mockFetchItem = mock();
+const mockGetExistingLink = mock();
+const mockSaveLink = mock();
+const mockSearch = mock();
+
+const deps: AppleMusicBackfillDeps = {
+  fetchItem: mockFetchItem,
+  getExistingLink: mockGetExistingLink,
+  saveLink: mockSaveLink,
+  search: mockSearch,
+};
+
+describe("backfillAppleMusicLink", () => {
+  beforeEach(() => {
+    mockFetchItem.mockReset();
+    mockGetExistingLink.mockReset();
+    mockSaveLink.mockReset();
+    mockSearch.mockReset();
+    mockGetExistingLink.mockResolvedValue(null);
+    mockSaveLink.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue(null);
+  });
+
+  test("returns item_missing when the item does not resolve", async () => {
+    mockFetchItem.mockResolvedValue(null);
+
+    const result = await backfillAppleMusicLink(99, deps);
+
+    expect(result).toEqual({ status: "item_missing" });
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("skips when the primary link is already an Apple Music URL", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "The Band (Remastered)",
+      artistName: "The Band",
+      primarySource: null,
+      primaryUrl: "https://music.apple.com/es/album/the-band-remastered/1440846597",
+    });
+
+    const result = await backfillAppleMusicLink(1, deps);
+
+    expect(result).toEqual({ status: "skipped" });
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockSaveLink).not.toHaveBeenCalled();
+  });
+
+  test("returns the existing Apple Music link without searching", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "Blue Lines",
+      artistName: "Massive Attack",
+      primarySource: "bandcamp",
+      primaryUrl: "https://massiveattack.bandcamp.com/album/blue-lines",
+    });
+    mockGetExistingLink.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/123");
+
+    const result = await backfillAppleMusicLink(1, deps);
+
+    expect(result).toEqual({
+      status: "existing",
+      url: "https://music.apple.com/gb/album/blue-lines/123",
+    });
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("searches and saves a matching Apple Music link", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "Blue Lines",
+      artistName: "Massive Attack",
+      primarySource: "discogs",
+      primaryUrl: "https://www.discogs.com/release/1",
+    });
+    mockSearch.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/456");
+
+    const result = await backfillAppleMusicLink(7, deps);
+
+    expect(result).toEqual({
+      status: "added",
+      url: "https://music.apple.com/gb/album/blue-lines/456",
+    });
+    expect(mockSearch).toHaveBeenCalledWith("Blue Lines", "Massive Attack");
+    expect(mockSaveLink).toHaveBeenCalledWith(7, "https://music.apple.com/gb/album/blue-lines/456");
+  });
+
+  test("returns not_found when the search yields no match", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "Obscure Album",
+      artistName: "Unknown Artist",
+      primarySource: null,
+      primaryUrl: null,
+    });
+    mockSearch.mockResolvedValue(null);
+
+    const result = await backfillAppleMusicLink(2, deps);
+
+    expect(result).toEqual({ status: "not_found" });
+    expect(mockSaveLink).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
When a non-Apple-Music release is added, search the iTunes Search API in
the background and attach a confident Apple Music match as a secondary
link, so a playable link is ready before the release page is opened.

Extract the existing lazy /apple-music-lookup logic into a reusable
server/apple-music-backfill module (backfillAppleMusicLink +
scheduleAppleMusicBackfill), reuse it from the release route, and fire
it fire-and-forget from the music-item and ingest creation paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017xXsCAksQcaXa8nUDWP739