### PR TITLE
Fix cloud setup script failing on Playwright browser download

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -4,12 +4,14 @@
 # Enter the contents of this file in: Environment settings > Setup script
 set -e
 
-# Install gh CLI (not in the default cloud image)
-apt-get update -qq && apt-get install -y gh
-
 # Install dependencies
 # Note: bun has known proxy compatibility issues in cloud environments, so use npm
 npm install
 
-# Install Playwright browser for E2E tests (chromium only, headless)
-npx playwright install --with-deps chromium || true
+# NOTE: Do not run `npx playwright install` here. The Claude Code web image
+# already ships a prebuilt Chromium at $PLAYWRIGHT_BROWSERS_PATH
+# (/opt/pw-browsers), and downloading the ~177 MB browser from
+# cdn.playwright.dev is killed mid-transfer by the cloud egress proxy, so the
+# install fails on every run. Playwright picks up the preinstalled browser
+# automatically. Likewise, gh is already present in the image, so there is no
+# need to apt-get install it.


### PR DESCRIPTION
The web setup script ran `npx playwright install --with-deps chromium`,
which downloads a ~177 MB Chromium from cdn.playwright.dev. The cloud
egress proxy kills that download mid-transfer, so the step failed on
every run (and the retries wasted minutes). The Claude Code web image
already ships a prebuilt Chromium at $PLAYWRIGHT_BROWSERS_PATH, which
Playwright picks up automatically, so the install step is unnecessary.

Also drop the `apt-get install gh` step since gh is already present in
the image.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0145mzHU52XPA8cn1zawGeFQ