### PR TITLE
Open the database lazily so the SvelteKit build never touches it

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,39 +1,70 @@
 import { Database } from "bun:sqlite";
 import path from "node:path";
-import { drizzle } from "drizzle-orm/bun-sqlite";
+import { drizzle, type BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import * as schema from "./schema";
 
-const dbPath = process.env.DATABASE_PATH ?? "on_the_beach.db";
-const sqlite = new Database(dbPath);
-sqlite.exec("PRAGMA journal_mode = WAL");
-sqlite.exec("PRAGMA foreign_keys = ON");
-export const db = drizzle(sqlite, { schema });
+type AppDatabase = BunSQLiteDatabase<typeof schema>;
 
-// Apply any pending migrations on startup (idempotent). Resolved from the
-// working directory (repo root / container WORKDIR) rather than import.meta
-// so the path survives the SvelteKit server bundle.
-migrate(db, { migrationsFolder: path.resolve(process.cwd(), "drizzle") });
+let instance: AppDatabase | null = null;
 
-// Seed reference data (idempotent — onConflictDoNothing)
-const SEED_SOURCES = [
-  { name: "bandcamp", displayName: "Bandcamp", urlPattern: "bandcamp.com" },
-  { name: "spotify", displayName: "Spotify", urlPattern: "open.spotify.com" },
-  { name: "soundcloud", displayName: "SoundCloud", urlPattern: "soundcloud.com" },
-  { name: "youtube", displayName: "YouTube", urlPattern: "youtube.com" },
-  { name: "apple_music", displayName: "Apple Music", urlPattern: "music.apple.com" },
-  { name: "discogs", displayName: "Discogs", urlPattern: "discogs.com" },
-  { name: "tidal", displayName: "Tidal", urlPattern: "tidal.com" },
-  { name: "deezer", displayName: "Deezer", urlPattern: "deezer.com" },
-  { name: "mixcloud", displayName: "Mixcloud", urlPattern: "mixcloud.com" },
-  { name: "nts", displayName: "NTS Radio", urlPattern: "nts.live" },
-  { name: "pitchfork", displayName: "Pitchfork", urlPattern: "pitchfork.com" },
-  { name: "physical", displayName: "Physical Media", urlPattern: null },
-] as const;
+function openDatabase(): AppDatabase {
+  const dbPath = process.env.DATABASE_PATH ?? "on_the_beach.db";
+  const sqlite = new Database(dbPath);
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  const database = drizzle(sqlite, { schema });
 
-for (const source of SEED_SOURCES) {
-  db.insert(schema.sources)
-    .values(source)
-    .onConflictDoNothing({ target: schema.sources.name })
-    .run();
+  // Apply any pending migrations on first open (idempotent). Resolved from the
+  // working directory (repo root / container WORKDIR) rather than import.meta
+  // so the path survives the SvelteKit server bundle.
+  migrate(database, { migrationsFolder: path.resolve(process.cwd(), "drizzle") });
+
+  // Seed reference data (idempotent — onConflictDoNothing)
+  const SEED_SOURCES = [
+    { name: "bandcamp", displayName: "Bandcamp", urlPattern: "bandcamp.com" },
+    { name: "spotify", displayName: "Spotify", urlPattern: "open.spotify.com" },
+    { name: "soundcloud", displayName: "SoundCloud", urlPattern: "soundcloud.com" },
+    { name: "youtube", displayName: "YouTube", urlPattern: "youtube.com" },
+    { name: "apple_music", displayName: "Apple Music", urlPattern: "music.apple.com" },
+    { name: "discogs", displayName: "Discogs", urlPattern: "discogs.com" },
+    { name: "tidal", displayName: "Tidal", urlPattern: "tidal.com" },
+    { name: "deezer", displayName: "Deezer", urlPattern: "deezer.com" },
+    { name: "mixcloud", displayName: "Mixcloud", urlPattern: "mixcloud.com" },
+    { name: "nts", displayName: "NTS Radio", urlPattern: "nts.live" },
+    { name: "pitchfork", displayName: "Pitchfork", urlPattern: "pitchfork.com" },
+    { name: "physical", displayName: "Physical Media", urlPattern: null },
+  ] as const;
+
+  for (const source of SEED_SOURCES) {
+    database
+      .insert(schema.sources)
+      .values(source)
+      .onConflictDoNothing({ target: schema.sources.name })
+      .run();
+  }
+
+  return database;
 }
+
+function getDatabase(): AppDatabase {
+  if (!instance) {
+    instance = openDatabase();
+  }
+  return instance;
+}
+
+// The database opens lazily on first query rather than at import time.
+// SvelteKit's build imports the server modules while analysing routes (in a
+// worker thread, inside the Docker build container where no database file can
+// be created) — merely importing this module must not touch the filesystem.
+export const db: AppDatabase = new Proxy({} as AppDatabase, {
+  get(_target, prop) {
+    const database = getDatabase();
+    const value = Reflect.get(database as object, prop, database);
+    return typeof value === "function" ? value.bind(database) : value;
+  },
+  has(_target, prop) {
+    return prop in (getDatabase() as object);
+  },
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import { json, type Handle } from "@sveltejs/kit";
+import { building } from "$app/environment";
 import { processReminders } from "../server/reminders";
 import {
   CSRF_COOKIE_NAME,
@@ -9,9 +10,10 @@ import {
 
 // ---------- Reminder cron ----------
 // Run reminder processing on startup and then every hour. Guarded so dev-mode
-// module reloads don't stack intervals.
+// module reloads don't stack intervals, and skipped entirely while SvelteKit
+// builds/analyses the app — the build environment has no database.
 const globalState = globalThis as typeof globalThis & { __otbRemindersStarted?: boolean };
-if (!globalState.__otbRemindersStarted) {
+if (!building && !globalState.__otbRemindersStarted) {
   globalState.__otbRemindersStarted = true;
   processReminders().catch((err) => console.error("[reminders] startup run failed:", err));
   setInterval(


### PR DESCRIPTION
Fixes the Coolify deployment failure: `RUN bun run build` died with `error: unable to open database file`.

## Root cause

During `vite build`, SvelteKit imports the compiled server modules in a worker thread while analysing routes (`writeBundle`). That import chain pulls in `server/db/index.ts`, whose module scope opened the SQLite database, ran migrations, and seeded reference data. The `oven/bun` image runs the Docker build as the non-root `bun` user in a root-owned `/app`, so creating `on_the_beach.db` fails and the build aborts. CI and local builds only survived because their build directories happened to be writable (leaving a stray `.db` file behind).

## Fix

- `server/db/index.ts` now exports a lazy proxy: the database is opened, migrated, and seeded on the **first query** instead of at import time. Importing the module is side-effect free; no call sites change.
- The reminder cron in `src/hooks.server.ts` is skipped while SvelteKit's `building` flag is set, so build-time evaluation of hooks can't trigger a query either.

## Verification

- Reproduced the exact failure mode: `DATABASE_PATH=/nonexistent-dir/x.db bun run build` previously crashed identically to Coolify; it now builds clean and creates no database file.
- Runtime behaviour unchanged: the DB is created/migrated/seeded on the first request; item creation and RSS feeds verified against the built server.
- Unit tests 415/415; e2e 27/30 (the remaining 3 are the sandbox's outbound-network limitation and pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYBMbvheHtJV1YbQF1nbG7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYBMbvheHtJV1YbQF1nbG7)_