### PR TITLE
Merge preview/start-menu into main (conflicts resolved)

### DIFF
--- a/playwright/start-menu.spec.ts
+++ b/playwright/start-menu.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "./fixtures/parallel-test";
+
+test("start menu opens, runs an action, and closes", async ({ page }) => {
+  await page.goto("/");
+
+  const startBtn = page.locator("#taskbar-start");
+  const menu = page.locator("#start-menu");
+
+  await expect(menu).toBeHidden();
+  await startBtn.click();
+  await expect(menu).toBeVisible();
+  await expect(startBtn).toHaveAttribute("aria-expanded", "true");
+  await expect(menu.locator(".start-menu__item")).toHaveCount(5);
+
+  // "Add a release" focuses the add input and closes the menu
+  await menu.locator('[data-start-action="add"]').click();
+  await expect(menu).toBeHidden();
+  await expect(page.locator("#url-input")).toBeFocused();
+
+  // Escape closes a reopened menu
+  await startBtn.click();
+  await expect(menu).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(menu).toBeHidden();
+  await expect(startBtn).toHaveAttribute("aria-expanded", "false");
+
+  // Outside click closes too
+  await startBtn.click();
+  await expect(menu).toBeVisible();
+  await page.locator("h1").click();
+  await expect(menu).toBeHidden();
+});

--- a/src/lib/components/Taskbar.svelte
+++ b/src/lib/components/Taskbar.svelte
@@ -18,6 +18,64 @@
     return () => clearInterval(interval);
   });
 
+  // ── Start menu ──────────────────────────────────────────────────────────────
+  // One canonical, discoverable home for every primary action. The actions
+  // drive main-page controls by id — the same contract the e2e specs use.
+  let startMenuOpen = $state(false);
+
+  function closeStartMenu(): void {
+    startMenuOpen = false;
+  }
+
+  function onStartAction(action: string): void {
+    closeStartMenu();
+
+    switch (action) {
+      case "add": {
+        const input = document.getElementById("url-input");
+        if (input instanceof HTMLInputElement) {
+          input.scrollIntoView({ block: "center" });
+          input.focus();
+        }
+        break;
+      }
+      case "pick": {
+        document.getElementById("pick-random-btn")?.click();
+        break;
+      }
+      case "search": {
+        // Defer past the current click event — document-level outside-click
+        // handlers would close the panel this opens.
+        setTimeout(() => {
+          const toggle = document.getElementById("browse-search-toggle");
+          const search = document.getElementById("browse-search");
+          // On small screens the search input lives behind a toggle; open
+          // the panel first, then focus.
+          if (toggle instanceof HTMLElement && toggle.offsetParent !== null) {
+            if (toggle.getAttribute("aria-expanded") !== "true") {
+              toggle.click();
+            }
+          } else {
+            search?.scrollIntoView({ block: "center" });
+          }
+          if (search instanceof HTMLInputElement) {
+            search.focus();
+          }
+        }, 0);
+        break;
+      }
+      case "stacks": {
+        const manageBtn = document.getElementById("manage-stacks-btn");
+        const panel = document.getElementById("stack-manage");
+        if (manageBtn instanceof HTMLElement && panel instanceof HTMLElement && panel.hidden) {
+          manageBtn.click();
+        }
+        panel?.scrollIntoView({ block: "nearest" });
+        break;
+      }
+    }
+  }
+
   // ── Scheduled-reminders popup ───────────────────────────────────────────────
   // The taskbar clock is the natural place to look for time-things: clicking it
   // lists the next six scheduled releases, soonest first.
@@ -60,6 +118,33 @@
   }
 
   $effect(() => {
+    if (!startMenuOpen) return;
+
+    const onDocumentClick = (event: MouseEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      const menu = document.getElementById("start-menu");
+      const startBtn = document.getElementById("taskbar-start");
+      if (menu?.contains(target) || startBtn?.contains(target)) return;
+      closeStartMenu();
+    };
+
+    const onEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") closeStartMenu();
+    };
+
+    document.addEventListener("keydown", onEscape);
+    // Deferred so the click that opened the menu doesn't immediately close it.
+    const timer = setTimeout(() => document.addEventListener("click", onDocumentClick), 0);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("keydown", onEscape);
+      document.removeEventListener("click", onDocumentClick);
+    };
+  });
+
+  $effect(() => {
     if (!popupOpen) return;
 
     const onDocumentClick = (event: MouseEvent): void => {
@@ -89,7 +174,58 @@
 
 <div id="taskbar">
   {#if showStart}
-    <button id="taskbar-start" class="taskbar__start">🪟 Start</button>
+    <div id="start-menu" class="start-menu" hidden={!startMenuOpen}>
+      <div class="start-menu__banner" aria-hidden="true">On The Beach</div>
+      <div class="start-menu__items" role="menu">
+        <button
+          type="button"
+          class="start-menu__item"
+          role="menuitem"
+          data-start-action="add"
+          onclick={() => onStartAction("add")}
+        >
+          <span class="start-menu__icon" aria-hidden="true">💿</span>Add a release
+        </button>
+        <button
+          type="button"
+          class="start-menu__item"
+          role="menuitem"
+          data-start-action="pick"
+          onclick={() => onStartAction("pick")}
+        >
+          <span class="start-menu__icon" aria-hidden="true">🎲</span>Pick One
+        </button>
+        <button
+          type="button"
+          class="start-menu__item"
+          role="menuitem"
+          data-start-action="search"
+          onclick={() => onStartAction("search")}
+        >
+          <span class="start-menu__icon" aria-hidden="true">🔍</span>Search
+        </button>
+        <button
+          type="button"
+          class="start-menu__item"
+          role="menuitem"
+          data-start-action="stacks"
+          onclick={() => onStartAction("stacks")}
+        >
+          <span class="start-menu__icon" aria-hidden="true">🗂️</span>Manage stacks
+        </button>
+        <div class="start-menu__divider" role="separator"></div>
+        <a class="start-menu__item" role="menuitem" href="/feed/to-listen.rss" onclick={closeStartMenu}>
+          <span class="start-menu__icon" aria-hidden="true">📡</span>RSS feed
+        </a>
+      </div>
+    </div>
+    <button
+      id="taskbar-start"
+      class="taskbar__start"
+      aria-haspopup="menu"
+      aria-expanded={startMenuOpen}
+      onclick={() => (startMenuOpen = !startMenuOpen)}>🪟 Start</button
+    >
   {/if}
   <button
     id="taskbar-np-btn"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2149,9 +2149,88 @@ a:hover {
   font-weight: bold;
   font-size: var(--text-base);
   background: var(--chrome);
-  cursor: default;
+  cursor: pointer;
   padding: 0 8px;
   text-align: left;
+}
+
+#taskbar-start[aria-expanded="true"] {
+  border-color: var(--bevel-sunken);
+  background: var(--chrome-mid);
+}
+
+/* ── Start menu ── */
+.start-menu {
+  position: absolute;
+  bottom: calc(100% + 1px);
+  left: 2px;
+  display: flex;
+  min-width: 220px;
+  background: var(--chrome);
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-raised);
+  box-shadow: var(--shadow-menu);
+}
+
+.start-menu[hidden] {
+  display: none;
+}
+
+.start-menu__banner {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  background: linear-gradient(0deg, var(--win-blue), #0a2a5c);
+  color: #ffffff;
+  font-family: var(--font-display);
+  font-weight: bold;
+  font-size: var(--text-lg);
+  letter-spacing: 0.12em;
+  padding: var(--space-4) var(--space-1);
+  text-align: right;
+  user-select: none;
+}
+
+.start-menu__items {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: var(--space-1);
+}
+
+.start-menu__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  min-height: var(--touch-icon);
+  padding: var(--space-2) var(--space-6) var(--space-2) var(--space-3);
+  border: none;
+  background: transparent;
+  color: #000000;
+  font-family: var(--font-ui);
+  font-size: var(--text-md);
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.start-menu__item:hover,
+.start-menu__item:focus-visible {
+  background: var(--win-blue);
+  color: #ffffff;
+  outline: none;
+}
+
+.start-menu__icon {
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.start-menu__divider {
+  border-top: 1px solid var(--chrome-dark);
+  border-bottom: 1px solid var(--chrome-white);
+  margin: var(--space-1) var(--space-2);
 }
 
 #taskbar-start:active {


### PR DESCRIPTION
Resolves the merge conflict on #209 (`preview/start-menu` → `main`).

## Conflict
One file conflicted: `src/lib/components/Taskbar.svelte`. Two features had landed independently on the same component:

- **`preview/start-menu`** — functional Win95 Start menu (`startMenuOpen`, `onStartAction`, `closeStartMenu` + an outside-click `$effect`).
- **`main`** — scheduled-reminders clock popup (`popupOpen`, `toggleClockPopup`, reminder helpers + its own outside-click `$effect`).

Git tried to interleave the two near-identical `$effect` blocks into one.

## Resolution
Both features are kept in full as **two separate `$effect` blocks** — one closing the Start menu, one closing the clock popup, each keyed to its own state and DOM ids. The already-merged template markup references both feature sets, so dropping either side would break it. `src/styles/main.css` auto-merged cleanly and retains both `start-menu` and `clock-popup` rules.

## Verification
- `bun run typecheck` → 0 errors, 0 warnings (1138 files)
- No conflict markers remain in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFcd3uHucF2GSUnUCbHaCg)_