### PR TITLE
Clear remind_at when a scheduled reminder fires

### DIFF
--- a/server/reminders.ts
+++ b/server/reminders.ts
@@ -1,4 +1,4 @@
-import { lte, eq, and, inArray } from "drizzle-orm";
+import { lte, eq, and } from "drizzle-orm";
 import { db } from "./db/index";
 import { musicItems } from "./db/schema";
 
@@ -17,6 +17,10 @@ export async function processReminders(): Promise<void> {
     .update(musicItems)
     .set({
       listenStatus: "to-listen",
+      // Clear the reminder now that its date has passed: a release whose
+      // scheduled date is in the past is no longer "scheduled", so drop it out
+      // of the Scheduled filter and let it surface under "To Listen".
+      remindAt: null,
       reminderPending: true,
       updatedAt: now,
       addedToListenAt: now,

--- a/tests/unit/reminders.test.ts
+++ b/tests/unit/reminders.test.ts
@@ -67,6 +67,7 @@ describe("processReminders", () => {
         reminderPending: musicItems.reminderPending,
         addedToListenAt: musicItems.addedToListenAt,
         createdAt: musicItems.createdAt,
+        remindAt: musicItems.remindAt,
       })
       .from(musicItems)
       .where(eq(musicItems.id, inserted.id))
@@ -82,6 +83,45 @@ describe("processReminders", () => {
     // created_at must be untouched so RSS pubDate and original creation time stay correct.
     const created = row?.createdAt instanceof Date ? row.createdAt.getTime() : 0;
     expect(created).toBe(past.getTime());
+  });
+
+  // Once the scheduled date has passed the release is no longer "scheduled":
+  // `remind_at` is cleared so it leaves the Scheduled filter (which selects
+  // remind_at IS NOT NULL) and surfaces under "To Listen" (which excludes
+  // remind_at IS NOT NULL).
+  test("clears remind_at so a fired reminder no longer counts as scheduled", async () => {
+    const { db } = await import("../../server/db/index");
+    const { musicItems } = await import("../../server/db/schema");
+    const { processReminders } = await import("../../server/reminders");
+    const { eq } = await import("drizzle-orm");
+
+    const past = new Date("2020-02-01T00:00:00Z");
+    const dueAt = new Date(Date.now() - 60_000);
+
+    const [inserted] = await db
+      .insert(musicItems)
+      .values({
+        title: "Overdue schedule",
+        normalizedTitle: "overdue schedule",
+        listenStatus: "to-listen",
+        createdAt: past,
+        updatedAt: past,
+        addedToListenAt: past,
+        remindAt: dueAt,
+        reminderPending: false,
+      })
+      .returning({ id: musicItems.id });
+    insertedItemIds.push(inserted.id);
+
+    await processReminders();
+
+    const row = await db
+      .select({ remindAt: musicItems.remindAt })
+      .from(musicItems)
+      .where(eq(musicItems.id, inserted.id))
+      .get();
+
+    expect(row?.remindAt).toBeNull();
   });
 
   test("does not touch items whose reminder is not yet due", async () => {


### PR DESCRIPTION
A release whose scheduled date has passed should no longer be treated as "scheduled". processReminders moved fired items to "to-listen" but left remind_at set, so — because the Scheduled filter selects remind_at IS NOT NULL while the listen-status buckets exclude it — a fired item stayed stuck under "Scheduled" and never appeared under "To Listen".

Clear remind_at as the reminder fires so the item leaves the Scheduled filter and surfaces in the To Listen queue.


Claude-Session: https://claude.ai/code/session_014xm2ysN1yuh2yNFWgmXtg3