### PR TITLE
fix: show release suggestion when marking listened on the release page

### DIFF
--- a/playwright/suggestion-on-listened.spec.ts
+++ b/playwright/suggestion-on-listened.spec.ts
@@ -1,0 +1,56 @@
+// playwright/suggestion-on-listened.spec.ts
+import { expect, test } from "./fixtures/parallel-test";
+
+test.beforeEach(async ({ request }) => {
+  await request.post("/api/__test__/reset");
+});
+
+test("suggestion modal appears when a release is marked listened on the release page", async ({
+  page,
+  request,
+}) => {
+  // Create a to-listen release.
+  const res = await request.post("/api/music-items", {
+    data: { title: "Amber", artistName: "Autechre", listenStatus: "to-listen", year: 1994 },
+  });
+  const item = await res.json();
+
+  await page.goto(`/r/${item.id}`);
+  await expect(page.locator("#status-select")).toBeVisible();
+
+  // Mock the PATCH status update to return a pending suggestion, mirroring what
+  // the server returns once a background MusicBrainz lookup has stored one.
+  await page.route(`**/api/music-items/${item.id}`, async (route) => {
+    if (route.request().method() !== "PATCH") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        item: { ...item, listen_status: "listened" },
+        suggestion: {
+          id: 999,
+          sourceItemId: item.id,
+          title: "Tri Repetae",
+          artistName: "Autechre",
+          itemType: "album",
+          year: 1995,
+          musicbrainzReleaseId: null,
+          status: "pending",
+          createdAt: new Date().toISOString(),
+        },
+      }),
+    });
+  });
+
+  // Change status to Listened.
+  await page.locator("#status-select").selectOption("listened");
+
+  // The suggestion picker modal should surface the suggested release.
+  const modal = page.locator("#suggestion-picker-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  await expect(modal).toContainText("Tri Repetae");
+  await expect(modal).toContainText("Autechre");
+});

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -3,9 +3,11 @@
   import { onMount } from "svelte";
   import type { PageData } from "../../routes/r/[id]/$types";
   import type { ListenEmbed } from "../../routes/r/[id]/+page.server";
+  import type { ItemSuggestion, ListenStatus } from "../../types";
   import { api, apiFetch } from "../api";
   import { player } from "../player.svelte";
   import StarRating from "./StarRating.svelte";
+  import SuggestionPickerModal from "./SuggestionPickerModal.svelte";
 
   // The page wraps this component in {#key item.id}, so all state below is
   // (re)initialised per release — the same lifecycle as the old full-page SSR.
@@ -63,12 +65,17 @@
     remindAtValue = "";
   }
 
+  // ── Suggestion picker ──────────────────────────────────────────────────────
+  let suggestion = $state<ItemSuggestion | null>(null);
+  let suggestionSourceId = $state<number | null>(null);
+
   async function onStatusChange(event: Event): Promise<void> {
     const newStatus = (event.currentTarget as HTMLSelectElement).value;
     if (newStatus === "scheduled") return;
     const wasScheduled = currentRemindAt !== null;
+    let result: Awaited<ReturnType<typeof api.updateListenStatus>>;
     try {
-      await api.updateMusicItem(item.id, { listenStatus: newStatus as "to-listen" | "listened" });
+      result = await api.updateListenStatus(item.id, newStatus as ListenStatus);
     } catch {
       alert("Failed to update status.");
       return;
@@ -76,6 +83,10 @@
     currentListenStatus = newStatus;
     if (wasScheduled) {
       await clearReminder();
+    }
+    if (newStatus === "listened" && result?.suggestion) {
+      suggestion = result.suggestion;
+      suggestionSourceId = item.id;
     }
   }
 
@@ -624,3 +635,13 @@
     </div>
   </div>
 </main>
+
+<SuggestionPickerModal
+  {suggestion}
+  sourceItemId={suggestionSourceId}
+  onAccepted={() => {}}
+  onClosed={() => {
+    suggestion = null;
+    suggestionSourceId = null;
+  }}
+/>


### PR DESCRIPTION
The suggestion picker modal was only wired into the main list view. On the release detail page, onStatusChange called api.updateMusicItem, which discards the suggestion returned by the PATCH and never mounted the modal — so marking a release listened from its own page never suggested a follow-up release.

Switch the release page to api.updateListenStatus, mount SuggestionPickerModal, and surface any pending suggestion returned when the status becomes listened, mirroring the main-page flow. Add an e2e test covering the release-page path.


Claude-Session: https://claude.ai/code/session_01HcDvLD1F1o4XRfKDyA4wj4