### PR TITLE
Add MusicKit integration for full-track Apple Music playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,21 @@ Open http://localhost:3000.
 
 ## Environment Variables
 
-| Variable             | Required | Default                | Description                                                                 |
-| -------------------- | -------- | ---------------------- | --------------------------------------------------------------------------- |
-| `DATABASE_PATH`      | No       | `on_the_beach.db`      | Path to the SQLite database file                                            |
-| `PORT`               | No       | `3000`                 | HTTP server port                                                            |
-| `UPLOADS_DIR`        | No       | `uploads`              | Directory for uploaded cover images                                         |
-| `MISTRAL_API_KEY`    | No       | —                      | Enables AI cover scanning and unsupported music-link extraction             |
-| `MISTRAL_LINK_MODEL` | No       | `mistral-small-latest` | Model for unsupported music-link extraction via chat completions.           |
-| `MISTRAL_SCAN_MODEL` | No       | `mistral-ocr-latest`   | Model for cover scanning. Non-OCR models use chat-completions mode.         |
-| `INGEST_API_KEY`     | No       | —                      | Secret token for the HTTP email ingest webhook. Required to enable it.      |
-| `INGEST_ENABLED`     | No       | `true`                 | Set to `false` to disable the HTTP ingest endpoint without removing the key |
-| `ORIGIN`             | Prod     | —                      | Public origin of the deployment (e.g. `https://otb.example.com`). Used to derive request URLs, the CSRF origin check, and cookie security flags. |
+| Variable                  | Required | Default                | Description                                                                                                                                      |
+| ------------------------- | -------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DATABASE_PATH`           | No       | `on_the_beach.db`      | Path to the SQLite database file                                                                                                                 |
+| `PORT`                    | No       | `3000`                 | HTTP server port                                                                                                                                 |
+| `UPLOADS_DIR`             | No       | `uploads`              | Directory for uploaded cover images                                                                                                              |
+| `MISTRAL_API_KEY`         | No       | —                      | Enables AI cover scanning and unsupported music-link extraction                                                                                  |
+| `MISTRAL_LINK_MODEL`      | No       | `mistral-small-latest` | Model for unsupported music-link extraction via chat completions.                                                                                |
+| `MISTRAL_SCAN_MODEL`      | No       | `mistral-ocr-latest`   | Model for cover scanning. Non-OCR models use chat-completions mode.                                                                              |
+| `INGEST_API_KEY`          | No       | —                      | Secret token for the HTTP email ingest webhook. Required to enable it.                                                                           |
+| `INGEST_ENABLED`          | No       | `true`                 | Set to `false` to disable the HTTP ingest endpoint without removing the key                                                                      |
+| `ORIGIN`                  | Prod     | —                      | Public origin of the deployment (e.g. `https://otb.example.com`). Used to derive request URLs, the CSRF origin check, and cookie security flags. |
+| `APPLE_MUSIC_TEAM_ID`     | No       | —                      | Apple Developer Team ID. Enables MusicKit full-track playback and catalogue search (all three `APPLE_MUSIC_*` vars required).                    |
+| `APPLE_MUSIC_KEY_ID`      | No       | —                      | MusicKit key identifier for the `.p8` auth key.                                                                                                  |
+| `APPLE_MUSIC_PRIVATE_KEY` | No       | —                      | Contents of the MusicKit `AuthKey_XXXX.p8` (PKCS#8 PEM; `\n`-escaped newlines accepted).                                                         |
+| `APPLE_MUSIC_STOREFRONT`  | No       | `gb`                   | Two-letter storefront code used for Apple Music catalogue search.                                                                                |
 
 ## Scripts
 

--- a/docs/areas/integrations/apple-music.md
+++ b/docs/areas/integrations/apple-music.md
@@ -1,0 +1,71 @@
+# Apple Music (MusicKit) integration
+
+On The Beach integrates Apple Music in two layers:
+
+1. **Catalogue lookup (server)** — resolving a release to its Apple Music page,
+   stored as a secondary listen link.
+2. **Full-track playback (browser)** — streaming the whole track in the app's
+   player via Apple's MusicKit JS, rather than the 30-second preview the public
+   `embed.music.apple.com` iframe offers.
+
+Both layers are enabled by the same MusicKit credentials. When they are absent,
+the app degrades gracefully: catalogue lookup falls back to the open iTunes
+Search API, and playback falls back to the preview iframe.
+
+## Configuration
+
+Create a **MusicKit key** in the Apple Developer portal (Certificates,
+Identifiers & Profiles → Keys → enable _MusicKit_) and download the
+`AuthKey_XXXXXXXXXX.p8`. Then set:
+
+| Variable                  | What it is                                       |
+| ------------------------- | ------------------------------------------------ |
+| `APPLE_MUSIC_TEAM_ID`     | Your 10-char Apple Developer Team ID (JWT `iss`) |
+| `APPLE_MUSIC_KEY_ID`      | The MusicKit key's Key ID (JWT header `kid`)     |
+| `APPLE_MUSIC_PRIVATE_KEY` | The `.p8` file contents (PKCS#8 PEM)             |
+| `APPLE_MUSIC_STOREFRONT`  | Optional storefront code, default `gb`           |
+
+`APPLE_MUSIC_PRIVATE_KEY` accepts the PEM with real newlines or with `\n`
+escapes (for hosting UIs that can't hold multi-line values), and tolerates the
+PEM armour being stripped.
+
+## Developer token
+
+`server/apple-music-token.ts` mints an ES256-signed JWT (the _developer token_)
+from the credentials, caches it in memory, and refreshes it a day before
+expiry. The token is deliberately safe to hand to the browser — it grants only
+team-scoped catalogue access and expires. It is served from:
+
+- `GET /api/apple-music/config` → `{ configured, storefront }`
+- `GET /api/apple-music/token` → `{ token, storefront }` (503 when unconfigured)
+
+## Catalogue lookup
+
+`searchAppleMusic` (in `server/scraper.ts`) first tries the Apple Music Catalog
+API (`server/apple-music-catalog.ts`) using the developer token, then falls back
+to the iTunes Search API. Both return a `music.apple.com` URL; the catalogue API
+path yields URLs that carry the catalogue ids MusicKit needs for playback.
+
+The lookup is wired into the shared secondary-link enrichment
+(`server/secondary-link-enrichment.ts`), so nothing else changes about when or
+how Apple Music links are attached to items.
+
+## Browser playback
+
+- `src/lib/musickit.svelte.ts` loads MusicKit JS v3 on demand, configures it
+  with the developer token, and exposes a small reactive facade (availability,
+  authorised, playing, position/duration, now-playing metadata) plus
+  `authorize`, `playResource`, `togglePlay`, `seek`, and `stop`.
+- `shared/apple-music.ts` parses a stored `music.apple.com` URL into the
+  `{ kind, id }` MusicKit's `setQueue` needs (`album` / `song` / `playlist` /
+  `musicVideo`), including `?i=` track deep-links.
+- `src/lib/player.svelte.ts` gains an `apple_music` mode alongside the existing
+  iframe mode; `PlayerWindow.svelte` renders native transport controls (artwork,
+  play/pause, seek bar, and a "Sign in to Apple Music" prompt) for that mode.
+- The release page's "Listen on Apple Music" button starts MusicKit playback on
+  desktop; on touch devices it hands off to the native Apple Music app/site, as
+  the other listen buttons do.
+
+Playing a full track requires the listener to authorise their own Apple Music
+subscription once (from the player or the Settings page). Without a
+subscription, MusicKit still plays previews.

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,6 +3,7 @@ import { musicItemRoutes } from "./routes/music-items";
 import { stackRoutes } from "./routes/stacks";
 import { ingestRoutes } from "./routes/ingest";
 import { releaseRoutes } from "./routes/release";
+import { appleMusicRoutes } from "./routes/apple-music";
 import { settingsRoutes } from "./routes/settings";
 import { rssRoutes } from "./routes/rss";
 
@@ -22,6 +23,7 @@ apiApp.route("/api/music-items", musicItemRoutes);
 apiApp.route("/api/stacks", stackRoutes);
 apiApp.route("/api/ingest", ingestRoutes);
 apiApp.route("/api/release", releaseRoutes);
+apiApp.route("/api/apple-music", appleMusicRoutes);
 apiApp.route("/api/settings", settingsRoutes);
 apiApp.route("/feed", rssRoutes);
 

--- a/server/apple-music-catalog.ts
+++ b/server/apple-music-catalog.ts
@@ -1,0 +1,131 @@
+import { getDeveloperToken, getStorefront, isAppleMusicConfigured } from "./apple-music-token";
+
+// ---------------------------------------------------------------------------
+// Apple Music Catalog API search
+//
+// When MusicKit is configured we resolve secondary Apple Music links through
+// the official catalogue search (api.music.apple.com) rather than the legacy
+// iTunes Search API. It returns first-class catalogue URLs (and, crucially, the
+// catalogue ids the browser MusicKit SDK needs to stream full tracks). Callers
+// fall back to the iTunes search when this returns null / when unconfigured.
+// ---------------------------------------------------------------------------
+
+const API_BASE = "https://api.music.apple.com/v1/catalog";
+
+function normalizeForMatch(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\w\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+interface CatalogResource {
+  attributes?: {
+    name?: unknown;
+    artistName?: unknown;
+    url?: unknown;
+  };
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Search the Apple Music catalogue for a release by title and artist, returning
+ * the best-matching catalogue URL, or null when unconfigured, on error, or when
+ * nothing matches confidently. Mirrors the three-pass matching used for the
+ * iTunes search (exact title+artist, compatible title+artist, artist-only).
+ */
+export async function searchAppleMusicCatalog(
+  title: string,
+  artist: string | null,
+  timeoutMs = 8000,
+): Promise<string | null> {
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
+  if (!isAppleMusicConfigured()) return null;
+
+  const token = getDeveloperToken();
+  if (!token) return null;
+
+  try {
+    const term = [artist, title].filter(Boolean).join(" ");
+    const params = new URLSearchParams({
+      term,
+      types: "albums,songs",
+      limit: "10",
+    });
+    const searchUrl = `${API_BASE}/${getStorefront()}/search?${params.toString()}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(searchUrl, {
+      signal: controller.signal,
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    });
+
+    clearTimeout(timer);
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      results?: {
+        albums?: { data?: CatalogResource[] };
+        songs?: { data?: CatalogResource[] };
+      };
+    };
+
+    // Prefer album matches over individual tracks — a release maps to an album.
+    const candidates: CatalogResource[] = [
+      ...(data.results?.albums?.data ?? []),
+      ...(data.results?.songs?.data ?? []),
+    ];
+    if (candidates.length === 0) return null;
+
+    const normalizedTitle = normalizeForMatch(title);
+    const normalizedArtist = artist ? normalizeForMatch(artist) : null;
+
+    function artistMatches(resultArtist: string | undefined): boolean {
+      if (!normalizedArtist || !resultArtist) return true;
+      return normalizeForMatch(resultArtist) === normalizedArtist;
+    }
+
+    function titlesCompatible(resultTitle: string): boolean {
+      const rn = normalizeForMatch(resultTitle);
+      return (
+        rn === normalizedTitle || rn.startsWith(normalizedTitle) || normalizedTitle.startsWith(rn)
+      );
+    }
+
+    // Pass 1: exact title + artist.
+    for (const c of candidates) {
+      const name = getString(c.attributes?.name);
+      if (!name || normalizeForMatch(name) !== normalizedTitle) continue;
+      if (!artistMatches(getString(c.attributes?.artistName))) continue;
+      const url = getString(c.attributes?.url);
+      if (url) return url;
+    }
+
+    // Pass 2: compatible title (prefix either way) + artist.
+    for (const c of candidates) {
+      const name = getString(c.attributes?.name);
+      if (!name || !titlesCompatible(name)) continue;
+      if (!artistMatches(getString(c.attributes?.artistName))) continue;
+      const url = getString(c.attributes?.url);
+      if (url) return url;
+    }
+
+    // Pass 3: first artist-matching result (the query is already specific).
+    for (const c of candidates) {
+      if (!artistMatches(getString(c.attributes?.artistName))) continue;
+      const url = getString(c.attributes?.url);
+      if (url) return url;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/server/apple-music-token.ts
+++ b/server/apple-music-token.ts
@@ -1,0 +1,143 @@
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Apple MusicKit developer token
+//
+// MusicKit (both the JS SDK in the browser and the Apple Music API on the
+// server) authenticates with a *developer token*: a short-ish-lived ES256 JWT
+// signed with a MusicKit private key issued from the Apple Developer Program.
+// It is deliberately safe to hand to the browser — it grants only catalogue
+// access scoped to our team, never a user's library, and expires.
+//
+// Configuration (all three required to enable Apple Music):
+//   APPLE_MUSIC_TEAM_ID      10-char Apple Developer Team ID  (JWT `iss`)
+//   APPLE_MUSIC_KEY_ID       10-char MusicKit key identifier  (JWT header `kid`)
+//   APPLE_MUSIC_PRIVATE_KEY  contents of the AuthKey_XXXX.p8   (ES256 PKCS#8 PEM)
+//
+// The private key is a PEM PKCS#8 block. Because env vars can't hold literal
+// newlines in most hosting UIs, we accept the key with `\n` escapes and/or with
+// the PEM armour stripped, and reconstruct a valid PEM before signing.
+// ---------------------------------------------------------------------------
+
+/** Maximum lifetime Apple permits for a developer token is 6 months. */
+const MAX_TOKEN_LIFETIME_SECONDS = 60 * 60 * 24 * 180;
+/** We mint tokens that live for ~150 days and refresh a day before expiry. */
+const TOKEN_LIFETIME_SECONDS = 60 * 60 * 24 * 150;
+const REFRESH_MARGIN_SECONDS = 60 * 60 * 24;
+
+interface CachedToken {
+  token: string;
+  /** Unix seconds at which the cached token should be considered stale. */
+  expiresAt: number;
+}
+
+let cache: CachedToken | null = null;
+
+export interface AppleMusicCredentials {
+  teamId: string;
+  keyId: string;
+  privateKey: string;
+}
+
+/** Read the three env vars, returning null unless all are present. */
+export function readAppleMusicCredentials(): AppleMusicCredentials | null {
+  const teamId = process.env.APPLE_MUSIC_TEAM_ID?.trim();
+  const keyId = process.env.APPLE_MUSIC_KEY_ID?.trim();
+  const privateKey = process.env.APPLE_MUSIC_PRIVATE_KEY;
+
+  if (!teamId || !keyId || !privateKey || !privateKey.trim()) {
+    return null;
+  }
+
+  return { teamId, keyId, privateKey };
+}
+
+/** Whether Apple Music (MusicKit) is configured for this deployment. */
+export function isAppleMusicConfigured(): boolean {
+  return readAppleMusicCredentials() !== null;
+}
+
+/** The Apple Music storefront to query (ISO country code). Defaults to `gb`. */
+export function getStorefront(): string {
+  const raw = process.env.APPLE_MUSIC_STOREFRONT?.trim().toLowerCase();
+  return raw && /^[a-z]{2}$/.test(raw) ? raw : "gb";
+}
+
+function base64Url(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+/**
+ * Reconstruct a usable PKCS#8 PEM from the configured private key, tolerating
+ * `\n`-escaped newlines and a bare (armour-stripped) base64 body.
+ */
+function normalizePrivateKeyPem(raw: string): string {
+  const withNewlines = raw.replace(/\\n/g, "\n").trim();
+
+  if (withNewlines.includes("-----BEGIN")) {
+    return withNewlines;
+  }
+
+  // Bare base64 body — wrap it in PKCS#8 PEM armour at 64-char lines.
+  const body = withNewlines.replace(/\s+/g, "");
+  const lines = body.match(/.{1,64}/g) ?? [body];
+  return `-----BEGIN PRIVATE KEY-----\n${lines.join("\n")}\n-----END PRIVATE KEY-----\n`;
+}
+
+/**
+ * Mint a fresh MusicKit developer token. Exported for testing; production code
+ * should call {@link getDeveloperToken}, which caches.
+ */
+export function mintDeveloperToken(
+  credentials: AppleMusicCredentials,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+  lifetimeSeconds: number = TOKEN_LIFETIME_SECONDS,
+): string {
+  const lifetime = Math.min(lifetimeSeconds, MAX_TOKEN_LIFETIME_SECONDS);
+
+  const header = { alg: "ES256", kid: credentials.keyId, typ: "JWT" };
+  const payload = {
+    iss: credentials.teamId,
+    iat: nowSeconds,
+    exp: nowSeconds + lifetime,
+  };
+
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(payload))}`;
+
+  // ES256 for JWT requires the raw (IEEE P1363) r||s signature, not DER.
+  const signature = crypto.sign("SHA256", Buffer.from(signingInput), {
+    key: normalizePrivateKeyPem(credentials.privateKey),
+    dsaEncoding: "ieee-p1363",
+  });
+
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+/**
+ * Return a valid developer token, minting and caching a new one when none is
+ * cached or the cached token is within the refresh margin of expiry. Returns
+ * null when Apple Music is not configured.
+ */
+export function getDeveloperToken(): string | null {
+  const credentials = readAppleMusicCredentials();
+  if (!credentials) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (cache && cache.expiresAt - REFRESH_MARGIN_SECONDS > now) {
+    return cache.token;
+  }
+
+  try {
+    const token = mintDeveloperToken(credentials, now);
+    cache = { token, expiresAt: now + TOKEN_LIFETIME_SECONDS };
+    return token;
+  } catch (err) {
+    console.error("[apple-music] failed to mint developer token:", err);
+    return null;
+  }
+}
+
+/** Clear the cached token. Exported for tests. */
+export function resetDeveloperTokenCache(): void {
+  cache = null;
+}

--- a/server/routes/apple-music.ts
+++ b/server/routes/apple-music.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+import { getDeveloperToken, getStorefront, isAppleMusicConfigured } from "../apple-music-token";
+
+/**
+ * Endpoints backing the browser MusicKit integration.
+ *
+ *   GET /api/apple-music/config → whether MusicKit is available + storefront
+ *   GET /api/apple-music/token  → a developer token for MusicKit.configure()
+ *
+ * The developer token is designed to be handed to the browser: it grants only
+ * team-scoped catalogue access and expires. It carries no user authority — the
+ * user authorises their own Apple Music account separately, client-side.
+ */
+export function createAppleMusicRoutes(): Hono {
+  const routes = new Hono();
+
+  routes.get("/config", (c) => {
+    return c.json({
+      configured: isAppleMusicConfigured(),
+      storefront: getStorefront(),
+    });
+  });
+
+  routes.get("/token", (c) => {
+    const token = getDeveloperToken();
+    if (!token) {
+      return c.json({ error: "Apple Music is not configured" }, 503);
+    }
+    // Small caches are fine — the token lives for months and is not secret.
+    c.header("Cache-Control", "private, max-age=3600");
+    return c.json({ token, storefront: getStorefront() });
+  });
+
+  return routes;
+}
+
+export const appleMusicRoutes = createAppleMusicRoutes();

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -4,6 +4,7 @@ import {
   type ExtractedReleaseCandidate,
 } from "./link-extractor";
 import { fetchDiscogsRelease } from "./discogs";
+import { searchAppleMusicCatalog } from "./apple-music-catalog";
 
 export interface OgData {
   ogTitle?: string;
@@ -1138,8 +1139,27 @@ function normalizeForMatch(s: string): string {
 }
 
 /**
- * Search Apple Music (iTunes Search API) for a release by title and artist.
- * Returns the Apple Music URL for the best matching result, or null if not found.
+ * Search Apple Music for a release by title and artist, returning the best
+ * matching catalogue URL, or null if not found.
+ *
+ * Prefers the official Apple Music Catalog API (api.music.apple.com) when
+ * MusicKit is configured — those URLs carry the catalogue ids the browser SDK
+ * needs to stream full tracks — and falls back to the open iTunes Search API
+ * when unconfigured or when the catalogue search comes up empty.
+ */
+export async function searchAppleMusic(
+  title: string,
+  artist: string | null,
+  timeoutMs = 8000,
+): Promise<string | null> {
+  const catalogUrl = await searchAppleMusicCatalog(title, artist, timeoutMs);
+  if (catalogUrl) return catalogUrl;
+  return searchAppleMusicViaItunes(title, artist, timeoutMs);
+}
+
+/**
+ * Search Apple Music via the open iTunes Search API. Returns the Apple Music
+ * URL for the best matching result, or null if not found.
  *
  * Matching strategy (in order):
  *  1. Exact title + artist match
@@ -1147,7 +1167,7 @@ function normalizeForMatch(s: string): string {
  *     Wikipedia-style disambiguators like "Foo (1981 album)" vs "Foo")
  *  3. First result whose artist matches (search query is already specific)
  */
-export async function searchAppleMusic(
+export async function searchAppleMusicViaItunes(
   title: string,
   artist: string | null,
   timeoutMs = 8000,

--- a/shared/apple-music.ts
+++ b/shared/apple-music.ts
@@ -1,0 +1,70 @@
+// Parsing of Apple Music catalogue URLs into the ids MusicKit needs to build a
+// playback queue. Shared by the server (deriving playback descriptors at SSR
+// time) and the client (resolving links fetched after load).
+
+/** The `MusicKit.setQueue` option key for a catalogue resource. */
+export type AppleMusicKind = "album" | "song" | "playlist" | "musicVideo";
+
+export interface AppleMusicResource {
+  kind: AppleMusicKind;
+  /** Catalogue id, e.g. "1440846597" for albums/songs or "pl.u-…" for playlists. */
+  id: string;
+}
+
+/**
+ * Parse a `music.apple.com` catalogue URL into the resource MusicKit can play.
+ *
+ * Handles the common shapes:
+ *   /album/{slug}/{id}            → album
+ *   /album/{slug}/{id}?i={songId} → song   (track deep-link within an album)
+ *   /song/{slug}/{id}             → song
+ *   /playlist/{slug}/{pl.id}      → playlist
+ *   /music-video/{slug}/{id}      → musicVideo
+ *
+ * The storefront segment (e.g. `/gb/`) is optional. Returns null for anything
+ * that isn't a recognisable, playable catalogue resource.
+ */
+export function parseAppleMusicCatalogUrl(rawUrl: string): AppleMusicResource | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (!url.hostname.toLowerCase().endsWith("music.apple.com")) return null;
+
+  // A `?i=` param always denotes a specific track, whatever the path type.
+  const trackParam = url.searchParams.get("i");
+  if (trackParam && /^\d+$/.test(trackParam)) {
+    return { kind: "song", id: trackParam };
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  // Drop a leading two-letter storefront segment when present.
+  if (segments[0] && /^[a-z]{2}$/i.test(segments[0])) {
+    segments.shift();
+  }
+
+  const type = segments[0];
+  const id = segments[segments.length - 1];
+  if (!type || !id) return null;
+
+  switch (type) {
+    case "album":
+      return /^\d+$/.test(id) ? { kind: "album", id } : null;
+    case "song":
+      return /^\d+$/.test(id) ? { kind: "song", id } : null;
+    case "music-video":
+      return /^\d+$/.test(id) ? { kind: "musicVideo", id } : null;
+    case "playlist":
+      return id.startsWith("pl.") ? { kind: "playlist", id } : null;
+    default:
+      return null;
+  }
+}
+
+/** Whether a URL is a playable Apple Music catalogue resource. */
+export function isPlayableAppleMusicUrl(url: string): boolean {
+  return parseAppleMusicCatalogUrl(url) !== null;
+}

--- a/src/lib/components/PlayerWindow.svelte
+++ b/src/lib/components/PlayerWindow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { player } from "../player.svelte";
+  import { musickit, togglePlay, seek, authorize } from "../musickit.svelte";
 
   let windowEl: HTMLElement | undefined = $state();
 
@@ -38,6 +39,25 @@
       windowEl.style.removeProperty("bottom");
       windowEl.style.removeProperty("right");
     }
+  }
+
+  // ── Apple Music (MusicKit) transport ──────────────────────────────────────
+  // Prefer MusicKit's own now-playing metadata once it resolves, falling back
+  // to the label the caller supplied when starting playback.
+  const amTitle = $derived(musickit.title || player.label);
+  const amArtist = $derived(musickit.title ? musickit.artist : "");
+
+  function formatTime(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
+    const total = Math.floor(seconds);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+  }
+
+  function onSeek(e: Event): void {
+    const value = Number((e.currentTarget as HTMLInputElement).value);
+    void seek(value);
   }
 </script>
 
@@ -78,7 +98,70 @@
     </div>
   </div>
   <div class="player-window__body" id="player-body">
-    {#if player.src !== null}
+    {#if player.isAppleMusic}
+      <div class="am-player" id="apple-music-player">
+        <div class="am-player__top">
+          <div class="am-player__artwork" aria-hidden="true">
+            {#if musickit.artworkUrl}
+              <img src={musickit.artworkUrl} alt="" />
+            {:else}
+              <span class="am-player__artwork-placeholder">♫</span>
+            {/if}
+          </div>
+          <div class="am-player__meta">
+            <div class="am-player__badge">Apple Music</div>
+            <div class="am-player__title" title={amTitle}>{amTitle}</div>
+            {#if amArtist}
+              <div class="am-player__artist" title={amArtist}>{amArtist}</div>
+            {/if}
+          </div>
+        </div>
+
+        <div class="am-player__scrubber">
+          <span class="am-player__time">{formatTime(musickit.position)}</span>
+          <input
+            class="am-player__range"
+            type="range"
+            min="0"
+            max={Math.max(1, Math.floor(musickit.duration))}
+            value={Math.floor(musickit.position)}
+            step="1"
+            aria-label="Seek"
+            disabled={musickit.duration <= 0}
+            oninput={onSeek}
+          />
+          <span class="am-player__time">{formatTime(musickit.duration)}</span>
+        </div>
+
+        <div class="am-player__controls">
+          <button
+            class="am-player__play"
+            id="apple-music-play"
+            type="button"
+            aria-label={musickit.playing ? "Pause" : "Play"}
+            disabled={musickit.loadingTrack}
+            onclick={() => togglePlay()}
+          >
+            {#if musickit.loadingTrack}…{:else if musickit.playing}❚❚{:else}▶{/if}
+          </button>
+
+          {#if !musickit.authorized}
+            <button
+              class="am-player__signin"
+              id="apple-music-signin"
+              type="button"
+              onclick={() => authorize()}>Sign in to Apple Music</button
+            >
+          {/if}
+        </div>
+
+        {#if musickit.error}
+          <div class="am-player__error" role="status">{musickit.error}</div>
+        {:else if !musickit.authorized}
+          <div class="am-player__hint">Sign in to play the full track.</div>
+        {/if}
+      </div>
+    {:else if player.src !== null}
       {#if player.playerType === "video"}
         <iframe
           src={player.src}

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -2,8 +2,9 @@
   import { goto } from "$app/navigation";
   import { onMount } from "svelte";
   import type { PageData } from "../../routes/r/[id]/$types";
-  import type { ListenEmbed } from "../../routes/r/[id]/+page.server";
+  import type { AppleMusicListen, ListenEmbed } from "../../routes/r/[id]/+page.server";
   import type { ItemSuggestion, ListenStatus } from "../../types";
+  import { parseAppleMusicCatalogUrl } from "../../../shared/apple-music";
   import { api, apiFetch } from "../api";
   import { player } from "../player.svelte";
   import StarRating from "./StarRating.svelte";
@@ -96,6 +97,43 @@
       window.open(embed.href, "_blank", "noopener,noreferrer");
     } else {
       player.load(embed.src, item.title, item.artist_name ?? "", embed.playerType);
+    }
+  }
+
+  // Full-track Apple Music playback (MusicKit) when configured, else the preview
+  // iframe. On touch devices, hand off to the native Apple Music app/site — the
+  // same behaviour the other listen buttons use for coarse pointers.
+  function listenAppleMusic(listenTarget: AppleMusicListen): void {
+    const coarse = window.matchMedia("(pointer: coarse)").matches;
+    if (listenTarget.mode === "musickit" && listenTarget.resource && !coarse) {
+      player.loadAppleMusic(
+        listenTarget.resource.kind,
+        listenTarget.resource.id,
+        item.title,
+        item.artist_name ?? "",
+      );
+      return;
+    }
+    if (coarse) {
+      window.open(listenTarget.href, "_blank", "noopener,noreferrer");
+      return;
+    }
+    // Unconfigured (preview) fallback.
+    if (listenTarget.src) {
+      player.load(listenTarget.src, item.title, item.artist_name ?? "", "audio");
+    } else {
+      window.open(listenTarget.href, "_blank", "noopener,noreferrer");
+    }
+  }
+
+  // Play a client-discovered Apple Music secondary link (the on-view lookup)
+  // through MusicKit when it resolves to a playable catalogue resource.
+  function listenLookupAppleMusic(url: string): void {
+    const resource = parseAppleMusicCatalogUrl(url);
+    if (resource && !window.matchMedia("(pointer: coarse)").matches) {
+      player.loadAppleMusic(resource.kind, resource.id, item.title, item.artist_name ?? "");
+    } else {
+      window.open(url, "_blank", "noopener,noreferrer");
     }
   }
 
@@ -266,6 +304,10 @@
   // request when the active service's link is already shown.
   let lookupLink = $state<{ url: string; label: string } | null>(null);
 
+  const lookupIsPlayableAppleMusic = $derived(
+    !!lookupLink && data.appleMusicConfigured && parseAppleMusicCatalogUrl(lookupLink.url) !== null,
+  );
+
   onMount(() => {
     api
       .listStacks()
@@ -383,14 +425,15 @@
               onclick={() => listen(data.youtubeEmbed!)}>▶ Watch</button
             >
           {/if}
-          {#if data.appleMusicEmbed}
+          {#if data.appleMusicListen}
             <button
-              class="release-page__listen-btn"
-              data-src={data.appleMusicEmbed.src}
+              class="release-page__listen-btn release-page__listen-btn--apple"
+              data-am-mode={data.appleMusicListen.mode}
               data-title={item.title}
               data-artist={item.artist_name ?? ""}
-              data-href={data.appleMusicEmbed.href}
-              onclick={() => listen(data.appleMusicEmbed!)}>▶ Listen</button
+              data-href={data.appleMusicListen.href}
+              onclick={() => listenAppleMusic(data.appleMusicListen!)}
+              >▶ Listen on Apple Music</button
             >
           {/if}
           {#if data.mixcloudWidgetSrc}
@@ -403,7 +446,14 @@
             ></iframe>
           {/if}
           <div id="secondary-links">
-            {#if lookupLink}
+            {#if lookupLink && lookupIsPlayableAppleMusic}
+              <button
+                class="release-page__listen-btn release-page__listen-btn--apple"
+                data-am-mode="musickit"
+                onclick={() => listenLookupAppleMusic(lookupLink!.url)}
+                >▶ Listen on Apple Music</button
+              >
+            {:else if lookupLink}
               <a
                 class="release-page__source-link"
                 href={lookupLink.url}

--- a/src/lib/musickit.svelte.ts
+++ b/src/lib/musickit.svelte.ts
@@ -1,0 +1,332 @@
+/**
+ * Browser MusicKit controller.
+ *
+ * Loads Apple's MusicKit JS (v3) on demand, configures it with a developer
+ * token minted server-side, and exposes a small reactive facade the player UI
+ * binds to. Unlike the old `embed.music.apple.com` iframe — which only ever
+ * plays 30-second previews — MusicKit streams full tracks once the listener has
+ * authorised their own Apple Music subscription.
+ *
+ * All playback state lives at module scope so it survives SvelteKit client-side
+ * navigation, mirroring `player.svelte.ts`.
+ */
+import type { AppleMusicKind } from "../../shared/apple-music";
+
+const MUSICKIT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit.js";
+
+// ── Minimal MusicKit typings (no official @types package) ───────────────────
+interface MusicKitArtwork {
+  url?: string;
+}
+
+interface MusicKitMediaItem {
+  title?: string;
+  artistName?: string;
+  albumName?: string;
+  artwork?: MusicKitArtwork;
+}
+
+type SetQueueOptions = Partial<Record<AppleMusicKind, string>>;
+
+interface MusicKitInstance {
+  isAuthorized: boolean;
+  playbackState: number;
+  currentPlaybackTime: number;
+  currentPlaybackDuration: number;
+  nowPlayingItem: MusicKitMediaItem | null;
+  addEventListener(name: string, handler: (event: unknown) => void): void;
+  authorize(): Promise<string>;
+  unauthorize(): Promise<void>;
+  setQueue(options: SetQueueOptions): Promise<unknown>;
+  play(): Promise<void>;
+  pause(): Promise<void>;
+  stop(): Promise<void>;
+  seekToTime(seconds: number): Promise<void>;
+}
+
+interface MusicKitStatic {
+  configure(config: {
+    developerToken: string;
+    app: { name: string; build: string };
+  }): Promise<MusicKitInstance>;
+  getInstance(): MusicKitInstance | undefined;
+  PlaybackStates: Record<string, number>;
+  formatArtworkURL?(artwork: MusicKitArtwork, height: number, width: number): string;
+}
+
+declare global {
+  interface Window {
+    MusicKit?: MusicKitStatic;
+  }
+}
+
+// ── Reactive state ──────────────────────────────────────────────────────────
+type Availability = "unknown" | "loading" | "ready" | "unavailable";
+
+interface MusicKitUiState {
+  availability: Availability;
+  authorized: boolean;
+  playing: boolean;
+  loadingTrack: boolean;
+  position: number;
+  duration: number;
+  title: string;
+  artist: string;
+  artworkUrl: string | null;
+  error: string | null;
+}
+
+const ui = $state<MusicKitUiState>({
+  availability: "unknown",
+  authorized: false,
+  playing: false,
+  loadingTrack: false,
+  position: 0,
+  duration: 0,
+  title: "",
+  artist: "",
+  artworkUrl: null,
+  error: null,
+});
+
+let instance: MusicKitInstance | null = null;
+let configurePromise: Promise<MusicKitInstance | null> | null = null;
+
+function scriptEl(): HTMLScriptElement | null {
+  return document.querySelector<HTMLScriptElement>(`script[src="${MUSICKIT_SRC}"]`);
+}
+
+/** Inject the MusicKit JS script once and resolve when the global is ready. */
+function loadScript(): Promise<MusicKitStatic | null> {
+  return new Promise((resolve) => {
+    if (window.MusicKit) {
+      resolve(window.MusicKit);
+      return;
+    }
+
+    const onLoaded = (): void => resolve(window.MusicKit ?? null);
+
+    const existing = scriptEl();
+    if (existing) {
+      document.addEventListener("musickitloaded", onLoaded, { once: true });
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = MUSICKIT_SRC;
+    script.async = true;
+    document.addEventListener("musickitloaded", onLoaded, { once: true });
+    script.addEventListener("error", () => resolve(null), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+function artworkUrlFor(item: MusicKitMediaItem | null): string | null {
+  const template = item?.artwork?.url;
+  if (!template) return null;
+  return template.replace(/\{w\}/g, "240").replace(/\{h\}/g, "240").replace(/\{f\}/g, "jpg");
+}
+
+function isPlayingState(state: number, MK: MusicKitStatic): boolean {
+  const playing = MK.PlaybackStates?.playing;
+  return typeof playing === "number" ? state === playing : state === 2;
+}
+
+function syncFromInstance(MK: MusicKitStatic): void {
+  if (!instance) return;
+  ui.authorized = instance.isAuthorized;
+  ui.playing = isPlayingState(instance.playbackState, MK);
+  ui.position = instance.currentPlaybackTime || 0;
+  ui.duration = instance.currentPlaybackDuration || 0;
+  const item = instance.nowPlayingItem;
+  ui.title = item?.title ?? "";
+  ui.artist = item?.artistName ?? "";
+  ui.artworkUrl = artworkUrlFor(item);
+}
+
+function attachListeners(MK: MusicKitStatic): void {
+  if (!instance) return;
+  const sync = (): void => syncFromInstance(MK);
+  instance.addEventListener("playbackStateDidChange", sync);
+  instance.addEventListener("nowPlayingItemDidChange", sync);
+  instance.addEventListener("authorizationStatusDidChange", sync);
+  instance.addEventListener("playbackTimeDidChange", (event) => {
+    // The event carries the fresh time; read the instance to stay authoritative.
+    void event;
+    if (!instance) return;
+    ui.position = instance.currentPlaybackTime || 0;
+    ui.duration = instance.currentPlaybackDuration || ui.duration;
+  });
+}
+
+/**
+ * Load and configure MusicKit, memoised. Resolves to the configured instance,
+ * or null when Apple Music isn't configured / the SDK can't load. Safe to call
+ * repeatedly.
+ */
+export function ensureConfigured(): Promise<MusicKitInstance | null> {
+  if (configurePromise) return configurePromise;
+
+  configurePromise = (async () => {
+    ui.availability = "loading";
+    ui.error = null;
+    try {
+      const res = await fetch("/api/apple-music/token");
+      if (!res.ok) {
+        ui.availability = "unavailable";
+        return null;
+      }
+      const { token } = (await res.json()) as { token?: string };
+      if (!token) {
+        ui.availability = "unavailable";
+        return null;
+      }
+
+      const MK = await loadScript();
+      if (!MK) {
+        ui.availability = "unavailable";
+        ui.error = "Couldn't load Apple Music.";
+        return null;
+      }
+
+      instance =
+        MK.getInstance() ??
+        (await MK.configure({
+          developerToken: token,
+          app: { name: "On The Beach", build: "1.0.0" },
+        }));
+
+      attachListeners(MK);
+      syncFromInstance(MK);
+      ui.availability = "ready";
+      return instance;
+    } catch (err) {
+      console.error("[musickit] configuration failed:", err);
+      ui.availability = "unavailable";
+      ui.error = "Apple Music is unavailable.";
+      // Let a later call retry rather than caching the failure forever.
+      configurePromise = null;
+      return null;
+    }
+  })();
+
+  return configurePromise;
+}
+
+/** Prompt the listener to sign in to their Apple Music account. */
+export async function authorize(): Promise<boolean> {
+  const mk = await ensureConfigured();
+  if (!mk) return false;
+  try {
+    await mk.authorize();
+    ui.authorized = mk.isAuthorized;
+    return mk.isAuthorized;
+  } catch (err) {
+    console.error("[musickit] authorize failed:", err);
+    return false;
+  }
+}
+
+/** Sign the listener out of Apple Music for this app. */
+export async function unauthorize(): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.unauthorize();
+    ui.authorized = false;
+  } catch (err) {
+    console.error("[musickit] unauthorize failed:", err);
+  }
+}
+
+/** Queue and play a catalogue resource (full playback for subscribers). */
+export async function playResource(kind: AppleMusicKind, id: string): Promise<void> {
+  const mk = await ensureConfigured();
+  if (!mk) return;
+
+  ui.loadingTrack = true;
+  ui.error = null;
+  try {
+    if (!mk.isAuthorized) {
+      const ok = await authorize();
+      if (!ok) {
+        ui.error = "Sign in to Apple Music to play the full track.";
+        return;
+      }
+    }
+    await mk.setQueue({ [kind]: id } as SetQueueOptions);
+    await mk.play();
+  } catch (err) {
+    console.error("[musickit] playback failed:", err);
+    ui.error = "Playback failed.";
+  } finally {
+    ui.loadingTrack = false;
+  }
+}
+
+export async function togglePlay(): Promise<void> {
+  if (!instance) return;
+  try {
+    if (ui.playing) {
+      await instance.pause();
+    } else {
+      await instance.play();
+    }
+  } catch (err) {
+    console.error("[musickit] toggle play failed:", err);
+  }
+}
+
+export async function seek(seconds: number): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.seekToTime(seconds);
+    ui.position = seconds;
+  } catch (err) {
+    console.error("[musickit] seek failed:", err);
+  }
+}
+
+export async function stop(): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.stop();
+  } catch (err) {
+    console.error("[musickit] stop failed:", err);
+  }
+  ui.playing = false;
+  ui.position = 0;
+}
+
+/** Reactive facade the player UI binds to. */
+export const musickit = {
+  get availability(): Availability {
+    return ui.availability;
+  },
+  get authorized(): boolean {
+    return ui.authorized;
+  },
+  get playing(): boolean {
+    return ui.playing;
+  },
+  get loadingTrack(): boolean {
+    return ui.loadingTrack;
+  },
+  get position(): number {
+    return ui.position;
+  },
+  get duration(): number {
+    return ui.duration;
+  },
+  get title(): string {
+    return ui.title;
+  },
+  get artist(): string {
+    return ui.artist;
+  },
+  get artworkUrl(): string | null {
+    return ui.artworkUrl;
+  },
+  get error(): string | null {
+    return ui.error;
+  },
+};

--- a/src/lib/player.svelte.ts
+++ b/src/lib/player.svelte.ts
@@ -3,26 +3,45 @@
  * page that starts playback. Lives at module scope on the client so playback
  * survives SvelteKit client-side navigation (the player window itself is
  * rendered by the root layout, which never unmounts).
+ *
+ * Two playback modes:
+ *  - "iframe": Bandcamp / YouTube / Mixcloud (and the Apple Music preview
+ *    embed used as a fallback) render an <iframe> from `src`.
+ *  - "apple_music": full-track playback driven by MusicKit (see musickit.svelte.ts).
  */
+import type { AppleMusicKind } from "../../shared/apple-music";
+import { playResource, stop as stopMusicKit } from "./musickit.svelte";
+
 export type PlayerType = "audio" | "video";
+export type PlayerMode = "iframe" | "apple_music";
+
+interface AppleMusicTarget {
+  kind: AppleMusicKind;
+  id: string;
+}
 
 interface PlayerState {
+  mode: PlayerMode;
   src: string | null;
+  apple: AppleMusicTarget | null;
   label: string;
   playerType: PlayerType;
-  isAppleMusic: boolean;
   minimized: boolean;
 }
 
 const state = $state<PlayerState>({
+  mode: "iframe",
   src: null,
+  apple: null,
   label: "",
   playerType: "audio",
-  isAppleMusic: false,
   minimized: false,
 });
 
 export const player = {
+  get mode() {
+    return state.mode;
+  },
   get src() {
     return state.src;
   },
@@ -33,31 +52,48 @@ export const player = {
     return state.playerType;
   },
   get isAppleMusic() {
-    return state.isAppleMusic;
+    return state.mode === "apple_music";
   },
   get minimized() {
     return state.minimized;
   },
   get active() {
-    return state.src !== null;
+    return state.mode === "apple_music" ? state.apple !== null : state.src !== null;
   },
   get windowVisible() {
-    return state.src !== null && !state.minimized;
+    return this.active && !state.minimized;
   },
 
+  /** Play an iframe-embedded source (Bandcamp, YouTube, Mixcloud, AM preview). */
   load(src: string, title: string, artist: string, playerType: PlayerType = "audio"): void {
+    state.mode = "iframe";
     state.src = src;
+    state.apple = null;
     state.label = artist ? `${artist} — ${title}` : title;
     state.playerType = playerType;
-    state.isAppleMusic = playerType !== "video" && src.includes("embed.music.apple.com");
     state.minimized = false;
   },
 
-  stop(): void {
+  /** Play a full Apple Music catalogue resource via MusicKit. */
+  loadAppleMusic(kind: AppleMusicKind, id: string, title: string, artist: string): void {
+    state.mode = "apple_music";
     state.src = null;
+    state.apple = { kind, id };
+    state.label = artist ? `${artist} — ${title}` : title;
+    state.playerType = "audio";
+    state.minimized = false;
+    void playResource(kind, id);
+  },
+
+  stop(): void {
+    if (state.mode === "apple_music") {
+      void stopMusicKit();
+    }
+    state.mode = "iframe";
+    state.src = null;
+    state.apple = null;
     state.label = "";
     state.playerType = "audio";
-    state.isAppleMusic = false;
     state.minimized = false;
   },
 

--- a/src/routes/r/[id]/+page.server.ts
+++ b/src/routes/r/[id]/+page.server.ts
@@ -2,11 +2,13 @@ import { error } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { fetchFullItem } from "../../../../server/music-item-creator";
 import { getLookupService } from "../../../../server/settings";
+import { isAppleMusicConfigured } from "../../../../server/apple-music-token";
 import {
   parseUrl,
   extractYouTubeVideoId,
   extractYouTubePlaylistId,
 } from "../../../../server/utils";
+import { parseAppleMusicCatalogUrl, type AppleMusicResource } from "../../../../shared/apple-music";
 import type { MusicItemFull } from "../../../types";
 
 const SOURCE_DISPLAY_NAMES: Record<string, string> = {
@@ -82,19 +84,61 @@ function bandcampEmbed(item: MusicItemFull): ListenEmbed | null {
   };
 }
 
-function appleMusicEmbed(item: MusicItemFull): ListenEmbed | null {
-  if (!item.primary_url?.includes("music.apple.com")) return null;
-  try {
-    const parsed = new URL(item.primary_url);
-    if (!parsed.hostname.endsWith("music.apple.com")) return null;
-    return {
-      src: `https://embed.music.apple.com${parsed.pathname}`,
-      href: item.primary_url,
-      playerType: "audio",
-    };
-  } catch {
-    return null;
+/**
+ * How to listen to a release on Apple Music.
+ *  - "musickit": full-track playback via the browser MusicKit SDK, using the
+ *    catalogue id parsed from the stored URL. Requires MusicKit configured.
+ *  - "preview": the legacy `embed.music.apple.com` iframe (30-second previews),
+ *    kept as a fallback when MusicKit isn't configured.
+ */
+export interface AppleMusicListen {
+  mode: "musickit" | "preview";
+  resource: AppleMusicResource | null;
+  src: string | null;
+  href: string;
+}
+
+/** The first Apple Music URL on the item (primary link preferred). */
+function appleMusicUrlForItem(item: MusicItemFull): { url: string; isPrimary: boolean } | null {
+  if (item.primary_url?.includes("music.apple.com")) {
+    return { url: item.primary_url, isPrimary: true };
   }
+  const link = item.links.find(
+    (l) => !l.is_primary && (l.source_name === "apple_music" || l.url.includes("music.apple.com")),
+  );
+  return link ? { url: link.url, isPrimary: false } : null;
+}
+
+function appleMusicListen(item: MusicItemFull, configured: boolean): AppleMusicListen | null {
+  const found = appleMusicUrlForItem(item);
+  if (!found) return null;
+
+  if (configured) {
+    const resource = parseAppleMusicCatalogUrl(found.url);
+    if (resource) {
+      return { mode: "musickit", resource, src: null, href: found.url };
+    }
+  }
+
+  // Preview fallback, only for a primary Apple Music link (unchanged behaviour
+  // for unconfigured deployments — secondary AM links stay plain links).
+  if (found.isPrimary) {
+    try {
+      const parsed = new URL(found.url);
+      if (parsed.hostname.endsWith("music.apple.com")) {
+        return {
+          mode: "preview",
+          resource: null,
+          src: `https://embed.music.apple.com${parsed.pathname}`,
+          href: found.url,
+        };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 function mixcloudWidgetSrc(item: MusicItemFull): string | null {
@@ -133,6 +177,8 @@ export const load: PageServerLoad = async ({ params }) => {
         }
       : null;
 
+  const appleMusicConfigured = isAppleMusicConfigured();
+
   return {
     item,
     backdropUrl: safeArtworkUrl(item.artwork_url ?? ""),
@@ -140,7 +186,8 @@ export const load: PageServerLoad = async ({ params }) => {
     sourceLink,
     youtubeEmbed: youTubeEmbed(item),
     bandcampEmbed: bandcampEmbed(item),
-    appleMusicEmbed: appleMusicEmbed(item),
+    appleMusicListen: appleMusicListen(item, appleMusicConfigured),
+    appleMusicConfigured,
     mixcloudWidgetSrc: mixcloudWidgetSrc(item),
     lookupService: await getLookupService(),
   };

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from "./$types";
 import { getLookupService, LOOKUP_SERVICES } from "../../../server/settings";
 import { LOOKUP_SERVICE_CONFIG } from "../../../server/secondary-link-enrichment";
+import { isAppleMusicConfigured, getStorefront } from "../../../server/apple-music-token";
 
 export const load: PageServerLoad = async () => {
   return {
@@ -9,5 +10,7 @@ export const load: PageServerLoad = async () => {
       value: service,
       displayName: LOOKUP_SERVICE_CONFIG[service].displayName,
     })),
+    appleMusicConfigured: isAppleMusicConfigured(),
+    appleMusicStorefront: getStorefront(),
   };
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { apiFetch } from "$lib/api";
+  import { musickit, authorize, unauthorize, ensureConfigured } from "$lib/musickit.svelte";
   import type { LookupService } from "../../../server/settings";
 
   let { data } = $props();
@@ -7,6 +8,22 @@
   // svelte-ignore state_referenced_locally
   let activeService = $state(data.activeService);
   let statusMessage = $state("");
+
+  // ── Apple Music account authorisation ──────────────────────────────────────
+  // The developer token enables catalogue access; playing full tracks needs the
+  // listener to authorise their own Apple Music subscription once, here or from
+  // the player.
+  function connectAppleMusic(): void {
+    if (data.appleMusicConfigured) void ensureConfigured();
+  }
+
+  async function signInAppleMusic(): Promise<void> {
+    await authorize();
+  }
+
+  async function signOutAppleMusic(): Promise<void> {
+    await unauthorize();
+  }
 
   async function onServiceChange(service: LookupService): Promise<void> {
     activeService = service;
@@ -66,6 +83,39 @@
       <p id="settings-status" class="settings__status" role="status" aria-live="polite">
         {statusMessage}
       </p>
+    </section>
+
+    <section class="settings__section" id="apple-music-settings">
+      <h2 class="settings__heading">Apple Music</h2>
+      {#if data.appleMusicConfigured}
+        <p class="settings__hint">
+          MusicKit is configured (storefront: {data.appleMusicStorefront.toUpperCase()}). Sign in to
+          your Apple Music subscription to play full tracks in the player instead of 30-second
+          previews.
+        </p>
+        <div class="settings__options">
+          {#if musickit.authorized}
+            <p class="settings__status" role="status">Signed in to Apple Music.</p>
+            <button type="button" class="btn" id="apple-music-signout" onclick={signOutAppleMusic}
+              >Sign out</button
+            >
+          {:else}
+            <button
+              type="button"
+              class="btn btn--primary"
+              id="apple-music-connect"
+              onclick={signInAppleMusic}
+              onmouseenter={connectAppleMusic}>Sign in to Apple Music</button
+            >
+          {/if}
+        </div>
+      {:else}
+        <p class="settings__hint">
+          MusicKit is not configured. Set <code>APPLE_MUSIC_TEAM_ID</code>,
+          <code>APPLE_MUSIC_KEY_ID</code>, and <code>APPLE_MUSIC_PRIVATE_KEY</code> to enable
+          full-track Apple Music playback. Until then, Apple Music links play 30-second previews.
+        </p>
+      {/if}
     </section>
   </div>
 </main>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2458,7 +2458,152 @@ a:hover {
 }
 
 .player-window--apple-music {
-  height: 472px;
+  height: auto;
+  min-height: 0;
+  resize: none;
+}
+
+/* ─── Apple Music (MusicKit) native transport ───────────────────────────── */
+
+.am-player {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  line-height: normal;
+  background: var(--chrome);
+}
+
+.am-player__top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.am-player__artwork {
+  width: 64px;
+  height: 64px;
+  flex-shrink: 0;
+  border: 2px solid;
+  border-color: var(--bevel-sunken);
+  background: #000000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.am-player__artwork img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.am-player__artwork-placeholder {
+  font-size: var(--text-xl);
+  color: #ffffff;
+}
+
+.am-player__meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.am-player__badge {
+  display: inline-block;
+  font-size: var(--text-2xs);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #d60017;
+  margin-bottom: var(--space-1);
+}
+
+.am-player__title {
+  font-weight: bold;
+  font-size: var(--text-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.am-player__artist {
+  font-size: var(--text-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.am-player__scrubber {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.am-player__time {
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  min-width: 2.5em;
+  text-align: center;
+}
+
+.am-player__range {
+  flex: 1;
+  min-width: 0;
+}
+
+.am-player__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.am-player__play {
+  width: 40px;
+  height: 28px;
+  font-size: var(--text-base);
+  background: var(--chrome);
+  border: 2px solid;
+  border-color: var(--bevel-raised);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.am-player__play:active {
+  border-color: var(--bevel-sunken);
+}
+
+.am-player__play:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.am-player__signin {
+  flex: 1;
+  height: 28px;
+  font-size: var(--text-sm);
+  background: var(--chrome);
+  border: 2px solid;
+  border-color: var(--bevel-raised);
+  cursor: pointer;
+}
+
+.am-player__signin:active {
+  border-color: var(--bevel-sunken);
+}
+
+.am-player__hint,
+.am-player__error {
+  font-size: var(--text-2xs);
+}
+
+.am-player__error {
+  color: #d60017;
 }
 
 .player-window--video {

--- a/tests/unit/apple-music-catalog.test.ts
+++ b/tests/unit/apple-music-catalog.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import crypto from "node:crypto";
+import { searchAppleMusicCatalog } from "../../server/apple-music-catalog";
+import { searchAppleMusic } from "../../server/scraper";
+import { resetDeveloperTokenCache } from "../../server/apple-music-token";
+
+const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+const privatePem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+function configure(): void {
+  process.env.APPLE_MUSIC_TEAM_ID = "TEAM123456";
+  process.env.APPLE_MUSIC_KEY_ID = "KEY7654321";
+  process.env.APPLE_MUSIC_PRIVATE_KEY = privatePem;
+  process.env.APPLE_MUSIC_STOREFRONT = "gb";
+  resetDeveloperTokenCache();
+}
+
+function unconfigure(): void {
+  delete process.env.APPLE_MUSIC_TEAM_ID;
+  delete process.env.APPLE_MUSIC_KEY_ID;
+  delete process.env.APPLE_MUSIC_PRIVATE_KEY;
+  delete process.env.APPLE_MUSIC_STOREFRONT;
+  delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+  resetDeveloperTokenCache();
+}
+
+interface CatalogItem {
+  name: string;
+  artistName: string;
+  url: string;
+}
+
+function catalogResponse(albums: CatalogItem[], songs: CatalogItem[] = []): Response {
+  const toData = (items: CatalogItem[]) => ({
+    data: items.map((attributes) => ({ attributes })),
+  });
+  return new Response(
+    JSON.stringify({ results: { albums: toData(albums), songs: toData(songs) } }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("searchAppleMusicCatalog", () => {
+  beforeEach(unconfigure);
+  afterEach(() => {
+    unconfigure();
+    mock.restore();
+  });
+
+  test("returns null when Apple Music is not configured (no fetch)", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch");
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns null under OTB_DISABLE_EXTERNAL_LOOKUPS even when configured", async () => {
+    configure();
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+    const fetchSpy = spyOn(globalThis, "fetch");
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("queries the catalogue with a bearer token and returns an exact match", async () => {
+    configure();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Blue Lines",
+          artistName: "Massive Attack",
+          url: "https://music.apple.com/gb/album/blue-lines/123",
+        },
+      ]),
+    );
+
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/123");
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("https://api.music.apple.com/v1/catalog/gb/search");
+    const auth = (init.headers as Record<string, string>).Authorization;
+    expect(auth).toMatch(/^Bearer .+/);
+  });
+
+  test("matches a Wikipedia-style disambiguated title", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Michael Nyman",
+          artistName: "Michael Nyman",
+          url: "https://music.apple.com/gb/album/michael-nyman/456",
+        },
+      ]),
+    );
+    const result = await searchAppleMusicCatalog("Michael Nyman (1981 album)", "Michael Nyman");
+    expect(result).toBe("https://music.apple.com/gb/album/michael-nyman/456");
+  });
+
+  test("prefers albums over songs", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse(
+        [
+          {
+            name: "Discovery",
+            artistName: "Daft Punk",
+            url: "https://music.apple.com/gb/album/discovery/1",
+          },
+        ],
+        [
+          {
+            name: "Discovery",
+            artistName: "Daft Punk",
+            url: "https://music.apple.com/gb/song/x/2",
+          },
+        ],
+      ),
+    );
+    const result = await searchAppleMusicCatalog("Discovery", "Daft Punk");
+    expect(result).toBe("https://music.apple.com/gb/album/discovery/1");
+  });
+
+  test("returns null when nothing matches the artist", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Blue Lines",
+          artistName: "Someone Else",
+          url: "https://music.apple.com/gb/album/blue-lines/999",
+        },
+      ]),
+    );
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    // Pass 3 falls back to the first artist-matching result; there is none here,
+    // and the title matches but the artist does not, so passes 1/2 also skip it.
+    expect(result).toBeNull();
+  });
+
+  test("returns null on an empty catalogue result", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(catalogResponse([], []));
+    const result = await searchAppleMusicCatalog("Nothing", "Nobody");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the API responds non-OK", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when fetch rejects", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network"));
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toBeNull();
+  });
+});
+
+describe("searchAppleMusic orchestration", () => {
+  beforeEach(unconfigure);
+  afterEach(() => {
+    unconfigure();
+    mock.restore();
+  });
+
+  test("prefers the catalogue API over iTunes when configured", async () => {
+    configure();
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Blue Lines",
+          artistName: "Massive Attack",
+          url: "https://music.apple.com/gb/album/blue-lines/from-catalog",
+        },
+      ]),
+    );
+
+    const result = await searchAppleMusic("Blue Lines", "Massive Attack");
+    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/from-catalog");
+    // Only the catalogue endpoint was hit — no iTunes fallback fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain("api.music.apple.com");
+  });
+
+  test("falls back to the iTunes search when the catalogue finds nothing", async () => {
+    configure();
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(catalogResponse([], []))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            results: [
+              {
+                collectionName: "Blue Lines",
+                artistName: "Massive Attack",
+                collectionViewUrl: "https://music.apple.com/gb/album/blue-lines/from-itunes",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const result = await searchAppleMusic("Blue Lines", "Massive Attack");
+    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/from-itunes");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1]?.[0]).toContain("itunes.apple.com");
+  });
+});

--- a/tests/unit/apple-music-token.test.ts
+++ b/tests/unit/apple-music-token.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import {
+  getDeveloperToken,
+  getStorefront,
+  isAppleMusicConfigured,
+  mintDeveloperToken,
+  readAppleMusicCredentials,
+  resetDeveloperTokenCache,
+  type AppleMusicCredentials,
+} from "../../server/apple-music-token";
+
+// A throwaway EC P-256 key pair for signing/verifying test tokens.
+const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+const privatePem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+const publicPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+
+const TEAM_ID = "TEAM123456";
+const KEY_ID = "KEY7654321";
+
+const credentials: AppleMusicCredentials = {
+  teamId: TEAM_ID,
+  keyId: KEY_ID,
+  privateKey: privatePem,
+};
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+function verify(token: string): boolean {
+  const [header, payload, signature] = token.split(".");
+  return crypto.verify(
+    "SHA256",
+    Buffer.from(`${header}.${payload}`),
+    { key: publicPem, dsaEncoding: "ieee-p1363" },
+    Buffer.from(signature, "base64url"),
+  );
+}
+
+const ENV_KEYS = [
+  "APPLE_MUSIC_TEAM_ID",
+  "APPLE_MUSIC_KEY_ID",
+  "APPLE_MUSIC_PRIVATE_KEY",
+  "APPLE_MUSIC_STOREFRONT",
+];
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+describe("mintDeveloperToken", () => {
+  test("produces a verifiable ES256 JWT with the expected claims", () => {
+    const now = 1_700_000_000;
+    const token = mintDeveloperToken(credentials, now);
+
+    const [headerB64, payloadB64] = token.split(".");
+    expect(token.split(".")).toHaveLength(3);
+
+    const header = decodeSegment(headerB64);
+    expect(header).toMatchObject({ alg: "ES256", kid: KEY_ID, typ: "JWT" });
+
+    const payload = decodeSegment(payloadB64);
+    expect(payload.iss).toBe(TEAM_ID);
+    expect(payload.iat).toBe(now);
+    expect(payload.exp).toBeGreaterThan(now);
+
+    expect(verify(token)).toBe(true);
+  });
+
+  test("caps the token lifetime at Apple's 6-month maximum", () => {
+    const now = 1_700_000_000;
+    const token = mintDeveloperToken(credentials, now, 60 * 60 * 24 * 400);
+    const payload = decodeSegment(token.split(".")[1]);
+    expect((payload.exp as number) - now).toBeLessThanOrEqual(60 * 60 * 24 * 180);
+  });
+
+  test("accepts a private key with escaped newlines and stripped armour", () => {
+    const bareBody = privatePem
+      .replace(/-----BEGIN PRIVATE KEY-----/, "")
+      .replace(/-----END PRIVATE KEY-----/, "")
+      .replace(/\s+/g, "");
+    const escaped = privatePem.replace(/\n/g, "\\n");
+
+    expect(verify(mintDeveloperToken({ ...credentials, privateKey: bareBody }))).toBe(true);
+    expect(verify(mintDeveloperToken({ ...credentials, privateKey: escaped }))).toBe(true);
+  });
+});
+
+describe("credentials and configuration", () => {
+  beforeEach(() => {
+    clearEnv();
+    resetDeveloperTokenCache();
+  });
+  afterEach(clearEnv);
+
+  test("isAppleMusicConfigured requires all three vars", () => {
+    expect(isAppleMusicConfigured()).toBe(false);
+    process.env.APPLE_MUSIC_TEAM_ID = TEAM_ID;
+    process.env.APPLE_MUSIC_KEY_ID = KEY_ID;
+    expect(isAppleMusicConfigured()).toBe(false);
+    process.env.APPLE_MUSIC_PRIVATE_KEY = privatePem;
+    expect(isAppleMusicConfigured()).toBe(true);
+    expect(readAppleMusicCredentials()).not.toBeNull();
+  });
+
+  test("getStorefront defaults to gb and honours a valid override", () => {
+    expect(getStorefront()).toBe("gb");
+    process.env.APPLE_MUSIC_STOREFRONT = "US";
+    expect(getStorefront()).toBe("us");
+    process.env.APPLE_MUSIC_STOREFRONT = "invalid";
+    expect(getStorefront()).toBe("gb");
+  });
+
+  test("getDeveloperToken returns null when unconfigured and a token when configured", () => {
+    expect(getDeveloperToken()).toBeNull();
+
+    process.env.APPLE_MUSIC_TEAM_ID = TEAM_ID;
+    process.env.APPLE_MUSIC_KEY_ID = KEY_ID;
+    process.env.APPLE_MUSIC_PRIVATE_KEY = privatePem;
+
+    const token = getDeveloperToken();
+    expect(token).not.toBeNull();
+    expect(verify(token as string)).toBe(true);
+    // Cached: a second call returns the same token instance.
+    expect(getDeveloperToken()).toBe(token);
+  });
+});

--- a/tests/unit/apple-music-url.test.ts
+++ b/tests/unit/apple-music-url.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { parseAppleMusicCatalogUrl, isPlayableAppleMusicUrl } from "../../shared/apple-music";
+
+describe("parseAppleMusicCatalogUrl", () => {
+  test("parses an album URL with a storefront", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/gb/album/blue-lines/123")).toEqual({
+      kind: "album",
+      id: "123",
+    });
+  });
+
+  test("parses an album URL without a storefront", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/album/boc/789")).toEqual({
+      kind: "album",
+      id: "789",
+    });
+  });
+
+  test("treats an album ?i= deep-link as a song", () => {
+    expect(
+      parseAppleMusicCatalogUrl("https://music.apple.com/gb/album/blue-lines/123?i=456"),
+    ).toEqual({ kind: "song", id: "456" });
+  });
+
+  test("parses a song URL", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/us/song/foo/789")).toEqual({
+      kind: "song",
+      id: "789",
+    });
+  });
+
+  test("parses a playlist URL", () => {
+    expect(
+      parseAppleMusicCatalogUrl("https://music.apple.com/gb/playlist/foo/pl.u-abc123"),
+    ).toEqual({ kind: "playlist", id: "pl.u-abc123" });
+  });
+
+  test("parses a music-video URL", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/gb/music-video/foo/555")).toEqual({
+      kind: "musicVideo",
+      id: "555",
+    });
+  });
+
+  test("rejects a non-Apple-Music host", () => {
+    expect(parseAppleMusicCatalogUrl("https://open.spotify.com/album/x")).toBeNull();
+  });
+
+  test("rejects a non-playable Apple Music path (artist)", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/gb/artist/foo/111")).toBeNull();
+  });
+
+  test("rejects a playlist without a pl. id", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/gb/playlist/foo/12345")).toBeNull();
+  });
+
+  test("rejects an album with a non-numeric id", () => {
+    expect(parseAppleMusicCatalogUrl("https://music.apple.com/gb/album/foo/not-an-id")).toBeNull();
+  });
+
+  test("rejects malformed input", () => {
+    expect(parseAppleMusicCatalogUrl("not a url")).toBeNull();
+  });
+
+  test("isPlayableAppleMusicUrl reflects parseability", () => {
+    expect(isPlayableAppleMusicUrl("https://music.apple.com/gb/album/blue-lines/123")).toBe(true);
+    expect(isPlayableAppleMusicUrl("https://example.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
Replace the preview-only Apple Music integration with a proper MusicKit
setup that streams full tracks and is integrated into the app's player.

Server:
- Mint an ES256 developer token (JWT) from APPLE_MUSIC_TEAM_ID/KEY_ID/
  PRIVATE_KEY, cached and auto-refreshed (server/apple-music-token.ts).
- Serve it and a config flag from /api/apple-music/{token,config}.
- Resolve secondary Apple Music links via the Apple Music Catalog API
  when configured, falling back to the iTunes Search API otherwise
  (server/apple-music-catalog.ts, wired into searchAppleMusic).

Client:
- MusicKit controller that loads the v3 SDK on demand, configures it with
  the developer token, authorises the listener's subscription, and exposes
  a reactive facade (musickit.svelte.ts).
- Player gains an apple_music mode alongside the iframe mode; PlayerWindow
  renders native transport controls (artwork, play/pause, seek bar,
  now-playing metadata, sign-in prompt) instead of the preview iframe.
- Release page plays the full track through MusicKit when configured
  (desktop), handing off to the native app on touch; preview iframe stays
  as the unconfigured fallback.
- Settings page shows MusicKit status and a sign in / sign out control.

shared/apple-music.ts parses music.apple.com URLs into the ids MusicKit
needs. Adds unit tests for token minting, catalogue search + fallback, and
URL parsing; documents the integration and the new env vars.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018bR59pVZcyhi7XyWpbaxdp