### PR TITLE
Apple Music: MusicKit integration for full-track playback

### DIFF
--- a/server/routes/apple-music.ts
+++ b/server/routes/apple-music.ts
@@ -22,10 +22,34 @@ export function createAppleMusicRoutes(): Hono {
   });
 
   routes.get("/token", (c) => {
+    // Distinguish "no credentials set" from "credentials present but the token
+    // couldn't be minted" (usually a malformed private key) so the failure is
+    // diagnosable from the response alone.
+    if (!isAppleMusicConfigured()) {
+      return c.json(
+        {
+          error: "Apple Music is not configured",
+          reason: "missing_credentials",
+          detail:
+            "Set APPLE_MUSIC_TEAM_ID, APPLE_MUSIC_KEY_ID and APPLE_MUSIC_PRIVATE_KEY, then restart the server.",
+        },
+        503,
+      );
+    }
+
     const token = getDeveloperToken();
     if (!token) {
-      return c.json({ error: "Apple Music is not configured" }, 503);
+      return c.json(
+        {
+          error: "Apple Music developer token could not be generated",
+          reason: "token_error",
+          detail:
+            "Credentials are set but signing failed — check that APPLE_MUSIC_PRIVATE_KEY is the full .p8 contents (PKCS#8 PEM).",
+        },
+        503,
+      );
     }
+
     // Small caches are fine — the token lives for months and is not secret.
     c.header("Cache-Control", "private, max-age=3600");
     return c.json({ token, storefront: getStorefront() });

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { apiFetch } from "$lib/api";
   import { musickit, authorize, unauthorize, ensureConfigured } from "$lib/musickit.svelte";
   import type { LookupService } from "../../../server/settings";
@@ -9,12 +10,46 @@
   let activeService = $state(data.activeService);
   let statusMessage = $state("");
 
+  // ── Apple Music configuration status ────────────────────────────────────────
+  // Probe the token endpoint so the page reflects the *live* server state,
+  // including the case where the credentials are set but the developer token
+  // can't be minted (usually a malformed private key) — which the SSR
+  // `configured` flag alone can't distinguish.
+  type AmState = "checking" | "ready" | "missing_credentials" | "token_error";
+  let amState = $state<AmState>("checking");
+  let amDetail = $state("");
+
+  const amReady = $derived(amState === "ready");
+
+  onMount(() => {
+    void refreshAppleMusicStatus();
+  });
+
+  async function refreshAppleMusicStatus(): Promise<void> {
+    amState = "checking";
+    try {
+      const res = await fetch("/api/apple-music/token");
+      if (res.ok) {
+        amState = "ready";
+        amDetail = "";
+        void ensureConfigured();
+        return;
+      }
+      const body = (await res.json().catch(() => ({}))) as { reason?: string; detail?: string };
+      amState = body.reason === "token_error" ? "token_error" : "missing_credentials";
+      amDetail = body.detail ?? "";
+    } catch {
+      amState = "missing_credentials";
+      amDetail = "Couldn't reach the server to check Apple Music status.";
+    }
+  }
+
   // ── Apple Music account authorisation ──────────────────────────────────────
   // The developer token enables catalogue access; playing full tracks needs the
   // listener to authorise their own Apple Music subscription once, here or from
   // the player.
   function connectAppleMusic(): void {
-    if (data.appleMusicConfigured) void ensureConfigured();
+    if (amReady) void ensureConfigured();
   }
 
   async function signInAppleMusic(): Promise<void> {
@@ -86,8 +121,28 @@
     </section>
 
     <section class="settings__section" id="apple-music-settings">
-      <h2 class="settings__heading">Apple Music</h2>
-      {#if data.appleMusicConfigured}
+      <h2 class="settings__heading">
+        Apple Music
+        <span
+          class="settings__badge"
+          class:settings__badge--ok={amReady}
+          class:settings__badge--warn={amState === "token_error"}
+          class:settings__badge--off={amState === "missing_credentials"}
+          id="apple-music-status-badge"
+        >
+          {#if amState === "checking"}
+            Checking…
+          {:else if amReady}
+            Configured ✓
+          {:else if amState === "token_error"}
+            Key error
+          {:else}
+            Not configured
+          {/if}
+        </span>
+      </h2>
+
+      {#if amReady}
         <p class="settings__hint">
           MusicKit is configured (storefront: {data.appleMusicStorefront.toUpperCase()}). Sign in to
           your Apple Music subscription to play full tracks in the player instead of 30-second
@@ -107,13 +162,24 @@
               onclick={signInAppleMusic}
               onmouseenter={connectAppleMusic}>Sign in to Apple Music</button
             >
+            {#if musickit.error}
+              <p class="settings__status" role="status">{musickit.error}</p>
+            {/if}
           {/if}
         </div>
+      {:else if amState === "checking"}
+        <p class="settings__hint">Checking Apple Music configuration…</p>
+      {:else if amState === "token_error"}
+        <p class="settings__hint">
+          Apple Music credentials are set, but the developer token couldn't be generated.
+          {amDetail || "Check that APPLE_MUSIC_PRIVATE_KEY is the full .p8 contents (PKCS#8 PEM)."}
+        </p>
       {:else}
         <p class="settings__hint">
           MusicKit is not configured. Set <code>APPLE_MUSIC_TEAM_ID</code>,
-          <code>APPLE_MUSIC_KEY_ID</code>, and <code>APPLE_MUSIC_PRIVATE_KEY</code> to enable
-          full-track Apple Music playback. Until then, Apple Music links play 30-second previews.
+          <code>APPLE_MUSIC_KEY_ID</code>, and <code>APPLE_MUSIC_PRIVATE_KEY</code> on the server
+          (then restart it) to enable full-track Apple Music playback. Until then, Apple Music links
+          play 30-second previews.
         </p>
       {/if}
     </section>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3416,6 +3416,41 @@ a:hover {
   margin: 0;
   font-family: var(--font-display);
   font-size: var(--text-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings__badge {
+  font-family: var(--font-body);
+  font-size: var(--text-2xs);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border: 1px solid;
+  border-color: var(--bevel-sunken);
+  background: var(--chrome);
+  color: var(--chrome-darker);
+  white-space: nowrap;
+}
+
+.settings__badge--ok {
+  background: #0a7d2c;
+  border-color: #0a7d2c;
+  color: #ffffff;
+}
+
+.settings__badge--warn {
+  background: #b25a00;
+  border-color: #b25a00;
+  color: #ffffff;
+}
+
+.settings__badge--off {
+  background: var(--chrome-dark);
+  border-color: var(--chrome-dark);
+  color: #ffffff;
 }
 
 .settings__hint {


### PR DESCRIPTION
## What & why

Replaces the preview-only Apple Music integration with a proper **MusicKit** setup. Previously, Apple Music links played through the public `embed.music.apple.com` iframe, which only ever streams 30-second previews. Now, with credentials from the Apple Developer Program, the app mints a MusicKit developer token, resolves links via the official Apple Music Catalog API, and plays **full tracks** through a native player once the listener authorises their own Apple Music subscription.

When credentials aren't set, everything degrades gracefully to the previous behaviour (iTunes Search API lookup + preview iframe).

## Server

- **`server/apple-music-token.ts`** — mints an ES256-signed developer-token JWT from `APPLE_MUSIC_TEAM_ID` / `APPLE_MUSIC_KEY_ID` / `APPLE_MUSIC_PRIVATE_KEY`, cached in memory and refreshed a day before expiry. Tolerates `\n`-escaped and armour-stripped private keys.
- **`server/apple-music-catalog.ts`** — resolves links via the Apple Music Catalog API (using the developer token) so stored URLs carry the catalogue ids MusicKit needs; `searchAppleMusic` prefers it and **falls back to the iTunes Search API** when unconfigured or on a miss.
- **`server/routes/apple-music.ts`** — `GET /api/apple-music/config` and `/token`. The token 503 distinguishes missing credentials from a token-minting failure so misconfiguration is diagnosable from the response body.

## Client

- **`src/lib/musickit.svelte.ts`** — loads MusicKit JS v3 on demand, configures it with the developer token, handles authorize/sign-out and `setQueue`+play/seek, and bridges playback state into Svelte runes.
- **`player.svelte.ts` / `PlayerWindow.svelte`** — new `apple_music` player mode with native transport controls (artwork, play/pause, seek bar, now-playing metadata, sign-in prompt). The iframe path (Bandcamp/YouTube/Mixcloud) is unchanged.
- **Release page** — "Listen on Apple Music" streams the full track via MusicKit on desktop and hands off to the native app on touch; preview iframe remains the unconfigured fallback.
- **Settings page** — live status badge (Configured ✓ / Key error / Not configured) plus sign in / sign out.
- **`shared/apple-music.ts`** — parses `music.apple.com` URLs into the `{ kind, id }` MusicKit's `setQueue` needs (album / song / `?i=` deep-link / playlist / music-video).

## Config

New env vars (all optional; all three of the first are required together to enable MusicKit): `APPLE_MUSIC_TEAM_ID`, `APPLE_MUSIC_KEY_ID`, `APPLE_MUSIC_PRIVATE_KEY`, and `APPLE_MUSIC_STOREFRONT` (default `gb`). Documented in `README.md` and `docs/areas/integrations/apple-music.md`.

## Tests

- New unit tests for developer-token minting, catalogue search + iTunes fallback, and catalogue-URL parsing (29 tests).
- Full unit suite green (459 pass), typecheck clean, production build succeeds.

## Notes for reviewers

- The Playwright `persistent-player` e2e can't run in the CI sandbox used here because the Bandcamp scrape returns bot-protected HTML (so `album_id` isn't extracted and the listen button doesn't render) — this is environmental and pre-existing, unrelated to these changes; the iframe player path and all its selectors are preserved.
- Full-track playback requires the MusicKit credentials to be set on the deployment and the listener to sign into their own Apple Music subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018bR59pVZcyhi7XyWpbaxdp)_