### PR TITLE
Apple Music: tolerate mangled private-key formatting

### DIFF
--- a/server/apple-music-token.ts
+++ b/server/apple-music-token.ts
@@ -68,20 +68,33 @@ function base64Url(input: Buffer | string): string {
 }
 
 /**
- * Reconstruct a usable PKCS#8 PEM from the configured private key, tolerating
- * `\n`-escaped newlines and a bare (armour-stripped) base64 body.
+ * Reconstruct a canonical PEM from the configured private key.
+ *
+ * Env vars mangle multi-line PEMs in every direction, so rather than trust the
+ * incoming layout we always strip the armour + all whitespace down to the raw
+ * base64 body and re-wrap it at 64-char lines. This tolerates:
+ *   - `\n`- (and `\r\n`-) escaped newlines,
+ *   - real newlines,
+ *   - a bare (armour-stripped) base64 body, and
+ *   - the header/footer glued to the body when a host collapses newlines
+ *     (e.g. `-----BEGIN PRIVATE KEY-----MIGT…==-----END PRIVATE KEY-----`).
+ *
+ * The BEGIN/END label is preserved when present (Apple `.p8` keys are PKCS#8,
+ * i.e. `PRIVATE KEY`), defaulting to `PRIVATE KEY` for a bare body.
  */
 function normalizePrivateKeyPem(raw: string): string {
-  const withNewlines = raw.replace(/\\n/g, "\n").trim();
+  const unescaped = raw.replace(/\\r/g, "").replace(/\\n/g, "\n").trim();
 
-  if (withNewlines.includes("-----BEGIN")) {
-    return withNewlines;
-  }
+  const labelMatch = unescaped.match(/-----BEGIN ([A-Z0-9 ]+?)-----/);
+  const label = labelMatch ? labelMatch[1].trim() : "PRIVATE KEY";
 
-  // Bare base64 body — wrap it in PKCS#8 PEM armour at 64-char lines.
-  const body = withNewlines.replace(/\s+/g, "");
+  const body = unescaped
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+
   const lines = body.match(/.{1,64}/g) ?? [body];
-  return `-----BEGIN PRIVATE KEY-----\n${lines.join("\n")}\n-----END PRIVATE KEY-----\n`;
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----\n`;
 }
 
 /**

--- a/tests/unit/apple-music-token.test.ts
+++ b/tests/unit/apple-music-token.test.ts
@@ -85,6 +85,19 @@ describe("mintDeveloperToken", () => {
     expect(verify(mintDeveloperToken({ ...credentials, privateKey: bareBody }))).toBe(true);
     expect(verify(mintDeveloperToken({ ...credentials, privateKey: escaped }))).toBe(true);
   });
+
+  test("accepts a key whose newlines were collapsed (armour glued to body)", () => {
+    // What a host does when a multi-line PEM is pasted into a single-line field:
+    // all newlines vanish, gluing the header/footer onto the base64 body.
+    const glued = privatePem.replace(/\n/g, "");
+    expect(glued).toMatch(/-----BEGIN PRIVATE KEY-----[A-Za-z0-9+/=]+-----END PRIVATE KEY-----/);
+    expect(verify(mintDeveloperToken({ ...credentials, privateKey: glued }))).toBe(true);
+  });
+
+  test("accepts a key with real newlines and surrounding whitespace", () => {
+    const padded = `\n  ${privatePem}\n\n`;
+    expect(verify(mintDeveloperToken({ ...credentials, privateKey: padded }))).toBe(true);
+  });
 });
 
 describe("credentials and configuration", () => {


### PR DESCRIPTION
## What & why

Follow-up to the MusicKit integration. The "Key error" status on Settings comes from `mintDeveloperToken` failing to parse `APPLE_MUSIC_PRIVATE_KEY` — almost always because the multi-line `.p8` PEM got mangled going into an env var (newlines collapsed, escaped, or armour stripped).

This makes the key parser tolerant of every common form:
- real newlines,
- `\n`- / `\r\n`-escaped newlines,
- a bare (armour-stripped) base64 body,
- **the header/footer glued onto the body** when a host collapses newlines (e.g. `-----BEGIN PRIVATE KEY-----MIGT…==-----END PRIVATE KEY-----`) — the case the previous code returned untouched and then failed to sign with,
- surrounding whitespace.

Instead of trusting the incoming layout, `normalizePrivateKeyPem` now strips the armour + all whitespace down to the raw base64 body and re-wraps it canonically at 64-char lines, preserving the BEGIN/END label (Apple `.p8` keys are PKCS#8).

## Tests

Adds unit tests for the newline-collapsed/glued-armour case and a whitespace-padded key; full token suite green (8 pass). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018bR59pVZcyhi7XyWpbaxdp)_