### PR TITLE
Add track skip controls and release track list to Apple Music player

### DIFF
--- a/src/lib/components/PlayerWindow.svelte
+++ b/src/lib/components/PlayerWindow.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import { player } from "../player.svelte";
-  import { musickit, togglePlay, seek, authorize } from "../musickit.svelte";
+  import {
+    musickit,
+    togglePlay,
+    seek,
+    authorize,
+    skipNext,
+    skipPrevious,
+    playTrackAt,
+  } from "../musickit.svelte";
 
   let windowEl: HTMLElement | undefined = $state();
 
@@ -134,6 +142,18 @@
         </div>
 
         <div class="am-player__controls">
+          {#if musickit.hasQueue}
+            <button
+              class="am-player__skip"
+              id="apple-music-prev"
+              type="button"
+              aria-label="Previous track"
+              title="Previous track"
+              disabled={!musickit.canSkipPrevious}
+              onclick={() => skipPrevious()}>⏮</button
+            >
+          {/if}
+
           <button
             class="am-player__play"
             id="apple-music-play"
@@ -144,6 +164,18 @@
           >
             {#if musickit.loadingTrack}…{:else if musickit.playing}❚❚{:else}▶{/if}
           </button>
+
+          {#if musickit.hasQueue}
+            <button
+              class="am-player__skip"
+              id="apple-music-next"
+              type="button"
+              aria-label="Next track"
+              title="Next track"
+              disabled={!musickit.canSkipNext}
+              onclick={() => skipNext()}>⏭</button
+            >
+          {/if}
 
           {#if !musickit.authorized}
             <button
@@ -159,6 +191,27 @@
           <div class="am-player__error" role="status">{musickit.error}</div>
         {:else if !musickit.authorized}
           <div class="am-player__hint">Sign in to play the full track.</div>
+        {/if}
+
+        {#if musickit.hasQueue}
+          <ol class="am-player__tracklist" id="apple-music-tracklist">
+            {#each musickit.tracks as track, i (i)}
+              <li>
+                <button
+                  type="button"
+                  class="am-player__track"
+                  class:am-player__track--current={i === musickit.trackIndex}
+                  aria-current={i === musickit.trackIndex ? "true" : undefined}
+                  onclick={() => playTrackAt(i)}
+                >
+                  <span class="am-player__track-num" aria-hidden="true">
+                    {#if i === musickit.trackIndex && musickit.playing}▶{:else}{i + 1}{/if}
+                  </span>
+                  <span class="am-player__track-title">{track.title}</span>
+                </button>
+              </li>
+            {/each}
+          </ol>
         {/if}
       </div>
     {:else if player.src !== null}

--- a/src/lib/musickit.svelte.ts
+++ b/src/lib/musickit.svelte.ts
@@ -26,6 +26,11 @@ interface MusicKitMediaItem {
   artwork?: MusicKitArtwork;
 }
 
+interface MusicKitQueue {
+  items: MusicKitMediaItem[];
+  position: number;
+}
+
 type SetQueueOptions = Partial<Record<AppleMusicKind, string>>;
 
 interface MusicKitInstance {
@@ -34,6 +39,8 @@ interface MusicKitInstance {
   currentPlaybackTime: number;
   currentPlaybackDuration: number;
   nowPlayingItem: MusicKitMediaItem | null;
+  nowPlayingItemIndex: number;
+  queue: MusicKitQueue;
   addEventListener(name: string, handler: (event: unknown) => void): void;
   authorize(): Promise<string>;
   unauthorize(): Promise<void>;
@@ -42,6 +49,9 @@ interface MusicKitInstance {
   pause(): Promise<void>;
   stop(): Promise<void>;
   seekToTime(seconds: number): Promise<void>;
+  skipToNextItem(): Promise<void>;
+  skipToPreviousItem(): Promise<void>;
+  changeToMediaAtIndex(index: number): Promise<void>;
 }
 
 interface MusicKitStatic {
@@ -63,6 +73,12 @@ declare global {
 // ── Reactive state ──────────────────────────────────────────────────────────
 type Availability = "unknown" | "loading" | "ready" | "unavailable";
 
+/** One entry of the current playback queue (an album/playlist's track list). */
+export interface QueueTrack {
+  title: string;
+  artist: string;
+}
+
 interface MusicKitUiState {
   availability: Availability;
   authorized: boolean;
@@ -74,6 +90,8 @@ interface MusicKitUiState {
   artist: string;
   artworkUrl: string | null;
   error: string | null;
+  tracks: QueueTrack[];
+  trackIndex: number;
 }
 
 const ui = $state<MusicKitUiState>({
@@ -87,6 +105,8 @@ const ui = $state<MusicKitUiState>({
   artist: "",
   artworkUrl: null,
   error: null,
+  tracks: [],
+  trackIndex: -1,
 });
 
 let instance: MusicKitInstance | null = null;
@@ -142,6 +162,19 @@ function syncFromInstance(MK: MusicKitStatic): void {
   ui.title = item?.title ?? "";
   ui.artist = item?.artistName ?? "";
   ui.artworkUrl = artworkUrlFor(item);
+  syncQueueFromInstance();
+}
+
+/** Mirror MusicKit's playback queue (the release's track list) into the UI. */
+function syncQueueFromInstance(): void {
+  if (!instance) return;
+  const items = instance.queue?.items ?? [];
+  ui.tracks = items.map((it) => ({ title: it.title ?? "", artist: it.artistName ?? "" }));
+  const idx =
+    typeof instance.nowPlayingItemIndex === "number" && instance.nowPlayingItemIndex >= 0
+      ? instance.nowPlayingItemIndex
+      : (instance.queue?.position ?? -1);
+  ui.trackIndex = idx;
 }
 
 function attachListeners(MK: MusicKitStatic): void {
@@ -150,6 +183,8 @@ function attachListeners(MK: MusicKitStatic): void {
   instance.addEventListener("playbackStateDidChange", sync);
   instance.addEventListener("nowPlayingItemDidChange", sync);
   instance.addEventListener("authorizationStatusDidChange", sync);
+  instance.addEventListener("queueItemsDidChange", () => syncQueueFromInstance());
+  instance.addEventListener("queuePositionDidChange", () => syncQueueFromInstance());
   instance.addEventListener("playbackTimeDidChange", (event) => {
     // The event carries the fresh time; read the instance to stay authoritative.
     void event;
@@ -276,6 +311,36 @@ export async function togglePlay(): Promise<void> {
   }
 }
 
+/** Advance to the next track in the queue (e.g. the next album track). */
+export async function skipNext(): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.skipToNextItem();
+  } catch (err) {
+    console.error("[musickit] skip next failed:", err);
+  }
+}
+
+/** Go back to the previous track in the queue. */
+export async function skipPrevious(): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.skipToPreviousItem();
+  } catch (err) {
+    console.error("[musickit] skip previous failed:", err);
+  }
+}
+
+/** Jump straight to a track by its position in the queue (track-list click). */
+export async function playTrackAt(index: number): Promise<void> {
+  if (!instance) return;
+  try {
+    await instance.changeToMediaAtIndex(index);
+  } catch (err) {
+    console.error("[musickit] change track failed:", err);
+  }
+}
+
 export async function seek(seconds: number): Promise<void> {
   if (!instance) return;
   try {
@@ -295,6 +360,8 @@ export async function stop(): Promise<void> {
   }
   ui.playing = false;
   ui.position = 0;
+  ui.tracks = [];
+  ui.trackIndex = -1;
 }
 
 /** Reactive facade the player UI binds to. */
@@ -328,5 +395,21 @@ export const musickit = {
   },
   get error(): string | null {
     return ui.error;
+  },
+  get tracks(): QueueTrack[] {
+    return ui.tracks;
+  },
+  get trackIndex(): number {
+    return ui.trackIndex;
+  },
+  /** More than one track queued, so skip/track-list controls are meaningful. */
+  get hasQueue(): boolean {
+    return ui.tracks.length > 1;
+  },
+  get canSkipNext(): boolean {
+    return ui.tracks.length > 1 && ui.trackIndex < ui.tracks.length - 1;
+  },
+  get canSkipPrevious(): boolean {
+    return ui.tracks.length > 1 && ui.trackIndex > 0;
   },
 };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2583,6 +2583,29 @@ a:hover {
   opacity: 0.7;
 }
 
+.am-player__skip {
+  width: 32px;
+  height: 28px;
+  font-size: var(--text-sm);
+  background: var(--chrome);
+  border: 2px solid;
+  border-color: var(--bevel-raised);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.am-player__skip:active:not(:disabled) {
+  border-color: var(--bevel-sunken);
+}
+
+.am-player__skip:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
 .am-player__signin {
   flex: 1;
   height: 28px;
@@ -2604,6 +2627,57 @@ a:hover {
 
 .am-player__error {
   color: #d60017;
+}
+
+.am-player__tracklist {
+  list-style: none;
+  margin: 0;
+  padding: 2px;
+  max-height: 168px;
+  overflow-y: auto;
+  border: 2px solid;
+  border-color: var(--bevel-sunken);
+  background: var(--field, #ffffff);
+}
+
+.am-player__track {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: 3px 5px;
+  border: 0;
+  background: transparent;
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.am-player__track:hover {
+  background: var(--title-bar);
+  color: #ffffff;
+}
+
+.am-player__track--current {
+  background: var(--title-bar);
+  color: #ffffff;
+  font-weight: bold;
+}
+
+.am-player__track-num {
+  flex-shrink: 0;
+  width: 1.5em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
+}
+
+.am-player__track-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .player-window--video {


### PR DESCRIPTION
When a full album or playlist is playing through MusicKit, the queue now
carries the release's whole track list. Surface that in the player window:

- Previous / next buttons flanking play/pause, wired to MusicKit's
  skipToPreviousItem / skipToNextItem and disabled at the queue ends.
- A scrollable track list showing every track, highlighting the current
  one, with click-to-jump via changeToMediaAtIndex.

Both only appear when more than one track is queued, so single-song
playback is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017kvu8S1NQheSC5HL9UYxyE