### PR TITLE
Select a stack when clicking its name, not just the checkbox

### DIFF
--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -649,13 +649,23 @@
           </div>
           <div id="stack-picker-list" class="release-page__edit-stacks-list">
             {#each visibleStacks as stack (stack.id)}
-              <label class="stack-dropdown__item">
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+              <label
+                class="stack-dropdown__item"
+                onclick={(event) => {
+                  // Toggle explicitly so clicking the name text works as
+                  // reliably as clicking the box — native <label>→checkbox
+                  // click forwarding dropped text clicks in some browsers.
+                  event.preventDefault();
+                  toggleStack(stack.id, !assignedIds.has(stack.id));
+                }}
+              >
                 <input
                   type="checkbox"
                   class="stack-dropdown__checkbox"
                   data-sid={stack.id}
                   checked={assignedIds.has(stack.id)}
-                  onchange={(e) => toggleStack(stack.id, e.currentTarget.checked)}
                 />
                 {stack.name}
               </label>

--- a/src/lib/components/StackDropdown.svelte
+++ b/src/lib/components/StackDropdown.svelte
@@ -104,13 +104,28 @@
   </div>
   <div class="stack-dropdown__list">
     {#each visibleStacks as stack (stack.id)}
-      <label class="stack-dropdown__item">
+      <!-- Keyboard access is preserved: the nested checkbox is focusable and
+           Space fires a click that bubbles to this handler. -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <label
+        class="stack-dropdown__item"
+        onclick={(event) => {
+          // Toggle explicitly so clicking anywhere on the row — the name text,
+          // the padding, or the box — reliably flips the assignment exactly
+          // once. Relying on the browser's native <label>→checkbox forwarding
+          // dropped text clicks in some browsers (e.g. Safari), so the box
+          // was the only thing that worked. preventDefault stops the native
+          // toggle; the checkbox stays a controlled reflection of state.
+          event.preventDefault();
+          onToggle(stack.id, !selectedStackIds.has(stack.id));
+        }}
+      >
         <input
           type="checkbox"
           class="stack-dropdown__checkbox"
           data-stack-id={stack.id}
           checked={selectedStackIds.has(stack.id)}
-          onchange={(e) => onToggle(stack.id, e.currentTarget.checked)}
         />
         {stack.name}
       </label>


### PR DESCRIPTION
The stack-assignment lists (the card "+" dropdown and the release page
Stacks section) wrapped each checkbox and name in a <label> and relied on
the browser's native label→checkbox click forwarding. That forwarding
dropped clicks on the name text in some browsers (e.g. Safari): the row
highlighted as if it registered, but the assignment never persisted, so
only clicking the tiny checkbox actually worked.

Handle the toggle explicitly on the row instead. A click anywhere — the
name text, the padding, or the box — calls preventDefault (stopping the
native toggle) and flips the assignment exactly once. The checkbox becomes
a controlled reflection of state. Keyboard access is preserved: the nested
checkbox stays focusable and Space fires a click that bubbles to the
handler.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LzH5dhiRmzgPPrwejpGbK9