### PR TITLE
iOS build CI: cover Mac Catalyst, target iOS 26

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Inject Share Extension target
         run: ruby scripts/add-share-extension.rb
 
-      - name: Build App + Share Extension
+      - name: Build App + Share Extension (iOS Simulator)
         # Building the App scheme also builds the embedded ShareExtension target,
         # so ShareViewController.swift is genuinely compiled. No signing needed
         # for a simulator build.
@@ -97,6 +97,21 @@ jobs:
             -scheme App \
             -sdk iphonesimulator \
             -destination 'generic/platform=iOS Simulator' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Build App + Share Extension (Mac Catalyst)
+        # The extension reaches the macOS share menu only if both it and the app
+        # build for Mac Catalyst; the script enables it on both targets. Catalyst
+        # exercises a distinct code path (notably the Pods' own Catalyst support,
+        # a documented failure mode), so it's worth its own build. Reuses the
+        # already-generated project + Pods, so it's mostly incremental compile.
+        run: |
+          xcodebuild \
+            -workspace ios/App/App.xcworkspace \
+            -scheme App \
+            -destination 'platform=macOS,variant=Mac Catalyst' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             build

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -107,11 +107,17 @@ jobs:
         # exercises a distinct code path (notably the Pods' own Catalyst support,
         # a documented failure mode), so it's worth its own build. Reuses the
         # already-generated project + Pods, so it's mostly incremental compile.
+        #
+        # Use a *generic* Catalyst destination, not "My Mac": the runner's macOS
+        # (15.x) is older than the iOS-26-era Xcode's minimum for a runnable "My
+        # Mac", so a concrete destination fails with "Xcode doesn't support My
+        # Mac's macOS …". A generic destination is build-only — it never resolves
+        # to My Mac — so it compiles for Catalyst regardless of the host OS.
         run: |
           xcodebuild \
             -workspace ios/App/App.xcworkspace \
             -scheme App \
-            -destination 'platform=macOS,variant=Mac Catalyst' \
+            -destination 'generic/platform=macOS,variant=Mac Catalyst' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             build

--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -180,18 +180,17 @@ Mac Catalyst runs the **same** `App` and `ShareExtension` targets as a native Ma
 app, so the compose form and ingest logic are shared with iOS — there is no
 separate macOS code to write or keep in sync.
 
-1. Select the project ▸ **App** target ▸ **General ▸ Supported Destinations** ▸
-   **＋** ▸ add **Mac (Mac Catalyst)**. (On older Xcode this is a **Mac**
-   checkbox under *Deployment Info*.)
-2. Do the same for the **ShareExtension** target — the extension must itself
-   support the Mac destination to appear in the macOS share menu. Both targets'
-   iOS Deployment Target of 13.0 maps to macOS 10.15+; Xcode sets the macOS
-   deployment automatically.
-3. **Signing & Capabilities** for each target: pick the same team you used for
+`scripts/add-share-extension.rb` already enables Mac Catalyst
+(`SUPPORTS_MACCATALYST`) on **both** the App and ShareExtension targets — the
+extension only reaches the macOS share menu if both build for Catalyst. Xcode
+derives the macOS deployment target from the iOS floor (26.0) automatically, so
+there's nothing to toggle in the IDE. That leaves only:
+
+1. **Signing & Capabilities** for each target: pick the same team you used for
    iOS. The extension's bundle id stays a child of the app's
    (`es.ricojam.onthebeach.ShareExtension`); a free personal team is fine for
    running locally on your own Mac.
-4. Choose the **My Mac (Mac Catalyst)** run destination and **Run**. The shell
+2. Choose the **My Mac (Mac Catalyst)** run destination and **Run**. The shell
    opens as a Mac window showing the live site.
 
 **Using it on macOS:** in Safari (or Finder, Notes, most apps) use the **Share**

--- a/docs/plans/2026-07-10-ios-xcode-ci-design.md
+++ b/docs/plans/2026-07-10-ios-xcode-ci-design.md
@@ -84,8 +84,10 @@ with "'UTType' is only available in iOS 14.0 or newer".)
 - **Steps:** checkout → select Xcode → setup Bun → **setup Ruby 3.3** →
   `gem install cocoapods xcodeproj` → `bun install` → placeholder
   `build/client/index.html` → dummy `Secrets.xcconfig` → `bun run cap:add` →
-  `ruby scripts/add-share-extension.rb` → `xcodebuild … -sdk iphonesimulator
-  CODE_SIGNING_ALLOWED=NO build`.
+  `ruby scripts/add-share-extension.rb` → `xcodebuild … build` for **both** the
+  iOS Simulator and **Mac Catalyst** destinations (`CODE_SIGNING_ALLOWED=NO`).
+  The Catalyst build reuses the same generated project + Pods, so it's mostly
+  incremental compile.
 
 Two environment gotchas encoded in the workflow:
 
@@ -99,10 +101,6 @@ Two environment gotchas encoded in the workflow:
 
 ## Non-goals (YAGNI)
 
-- **Mac Catalyst build.** `ShareViewController.swift` is byte-for-byte identical
-  across iOS and Catalyst, so the iOS-simulator compile already covers the code
-  that changes. A second Catalyst destination adds runner time and Pod
-  destination fiddling for near-zero extra signal.
 - **Pods/DerivedData caching.** Kept the first version simple; a caching pass is
   a straightforward later optimization if macOS minutes become a concern.
 - **Code signing / device or TestFlight builds.** This is a compile check, not a
@@ -111,6 +109,7 @@ Two environment gotchas encoded in the workflow:
 ## Verification
 
 Reproduced the full flow locally on macOS (Xcode 26.6): `cap add` → script →
-`xcodebuild` for the iOS Simulator with signing disabled. Confirmed the script
-is idempotent, that `ShareViewController.swift` is genuinely compiled, and that
-`ShareExtension.appex` is produced and embedded in `App.app`.
+`xcodebuild` with signing disabled, for **both** the iOS Simulator and Mac
+Catalyst destinations. Confirmed the script is idempotent, that
+`ShareViewController.swift` is genuinely compiled, and that `ShareExtension.appex`
+is produced and embedded in `App.app` for both destinations.


### PR DESCRIPTION
Follow-up to the reproducible iOS build + CI work (merged as `f3701b1`).

## What
- **CI now builds Mac Catalyst too**, alongside the iOS Simulator. The Share Extension only reaches the macOS share menu if both it and the app build for Catalyst, and Pods-Catalyst breakage is a documented failure mode — so it's worth its own build. Reuses the already-generated project + Pods, so it's mostly incremental compile.
- **Docs synced to iOS 26.** `scripts/add-share-extension.rb` now raises the App target, project, and extension to a single iOS 26 floor (from Capacitor's generated 13.0) and enables Catalyst on both targets, so `docs/ios-native-app.md` §6's manual "add Mac destination" steps are gone and only signing + run remain manual. Design doc updated to match.

## Verification
Both destinations built locally with signing disabled (Xcode 26.6): `App` + `ShareExtension` compile and `ShareExtension.appex` embeds for **iphonesimulator** and **Mac Catalyst**. The injection script is idempotent (re-run → one target, one embed phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)