### PR TITLE
iOS CI: run on macos-26 for iOS-26-era Xcode

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Select Xcode
-        # latest-stable on the macos-15 image. Pin to an explicit version here if
+        # latest-stable on the macos-26 image. Pin to an explicit version here if
         # you need byte-for-byte reproducibility across image updates.
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -108,11 +108,14 @@ jobs:
         # a documented failure mode), so it's worth its own build. Reuses the
         # already-generated project + Pods, so it's mostly incremental compile.
         #
-        # Use a *generic* Catalyst destination, not "My Mac": the runner's macOS
-        # (15.x) is older than the iOS-26-era Xcode's minimum for a runnable "My
-        # Mac", so a concrete destination fails with "Xcode doesn't support My
-        # Mac's macOS …". A generic destination is build-only — it never resolves
-        # to My Mac — so it compiles for Catalyst regardless of the host OS.
+        # Use a *generic* Catalyst destination, not "My Mac". This is a
+        # compile-only check: a generic destination never resolves to a concrete
+        # bootable Mac, so it needs no signing and no runnable My Mac — it just
+        # proves the App + extension compile and link for Catalyst (the point of
+        # this job). The macos-26 runner now matches the iOS-26-era Xcode, so a
+        # concrete "My Mac" destination would also resolve here — switch to it
+        # (dropping CODE_SIGNING_ALLOWED=NO won't be enough; you'd need signing)
+        # only if you later want CI to *run*, not just build, the Catalyst app.
         run: |
           xcodebuild \
             -workspace ios/App/App.xcworkspace \

--- a/docs/plans/2026-07-10-ios-xcode-ci-design.md
+++ b/docs/plans/2026-07-10-ios-xcode-ci-design.md
@@ -80,7 +80,7 @@ with "'UTType' is only available in iOS 14.0 or newer".)
   `capacitor.config.ts`, the script, the workflow, `package.json`, `bun.lock`;
   plus `workflow_dispatch`. macOS runners bill at 10x Linux minutes, and the
   shell loads the live site, so web-only PRs don't need it.
-- **Runner:** `macos-15`, Xcode `latest-stable`.
+- **Runner:** `macos-26`, Xcode `latest-stable`.
 - **Steps:** checkout → select Xcode → setup Bun → **setup Ruby 3.3** →
   `gem install cocoapods xcodeproj` → `bun install` → placeholder
   `build/client/index.html` → dummy `Secrets.xcconfig` → `bun run cap:add` →


### PR DESCRIPTION
## What

Bumps the iOS build workflow's runner from `macos-15` to **`macos-26`** so CI uses the iOS-26-era Xcode toolchain the app now targets (`IPHONEOS_DEPLOYMENT_TARGET = 26.0`).

## Why

The Share Extension reaches the **macOS share menu** only if both it and its host app build for **Mac Catalyst**, and the app's deployment floor is iOS 26. `macos-15`'s latest-stable Xcode is a mismatch; `macos-26` (GA GitHub-hosted runner since Feb 2026, Apple Silicon) ships the matching toolchain as `latest-stable`.

## Changes

- `.github/workflows/ios-build.yml`: `runs-on: macos-15` → `macos-26`; refreshed the "Select Xcode" comment.
- Rewrote the Catalyst-step comment. Its old rationale — "the macOS 15 runner is too old for a runnable *My Mac*" — is no longer true on macOS 26, so it would have been a comment that lies about the code. The build **stays** a `generic/platform=macOS,variant=Mac Catalyst` destination on purpose: this is a **compile-only** check that needs no signing. The comment now notes macOS 26 *would* support a runnable "My Mac" if CI is ever meant to run (not just build) the Catalyst app.
- `docs/plans/2026-07-10-ios-xcode-ci-design.md`: runner line synced to `macos-26`.

## Verification

- `macos-26` confirmed as a GA GitHub-hosted runner label (Apple Silicon).
- Workflow YAML re-validated (parses clean).
- No remaining `macos-15` / `15.x` references anywhere in the repo.
- Note: the real test is the first CI run on `macos-26` — it pins a newer Xcode, a stricter compile than before, which is exactly the SDK the app targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)