### PR TITLE
feat(native): one-command local build of the Mac + iPhone app

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cap:sync": "cap sync ios",
     "cap:open": "cap open ios",
     "mac": "bash scripts/build-mac.sh",
+    "ios": "bash scripts/build-ios.sh",
     "brand:assets": "bash scripts/generate-brand-assets.sh"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cap:add": "cap add ios",
     "cap:sync": "cap sync ios",
     "cap:open": "cap open ios",
+    "mac": "bash scripts/build-mac.sh",
     "brand:assets": "bash scripts/generate-brand-assets.sh"
   },
   "dependencies": {

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build, install, and launch the native app on a connected iPhone — one command.
+#
+#   bun run ios
+#
+# The device-targeted sibling of build-mac.sh: same generated project + injected
+# Share Extension, but built and *signed for a real device*, then pushed onto the
+# connected iPhone and launched — so you can test the genuine on-device iOS share
+# sheet without opening Xcode.
+#
+# Requires a paired iPhone that's connected, unlocked, and has Developer Mode on.
+# We sign automatically with your team (override with OTB_DEV_TEAM=...);
+# -allowProvisioningUpdates registers the device and mints profiles as needed.
+
+set -euo pipefail
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+source scripts/lib/native-build-common.sh
+
+# --- Find the connected device ------------------------------------------------
+# `devicectl list devices` marks a reachable, paired device "available (…)";
+# an "unavailable" one has no trailing par, so `available \(` matches only the
+# usable ones. The UUID column is the CoreDevice identifier devicectl installs by.
+device_line=$(xcrun devicectl list devices 2>/dev/null | grep -iE 'iphone|ipad' | grep -E 'available \(' | head -1 || true)
+UDID=$(printf '%s' "$device_line" | grep -oE '[0-9A-Fa-f-]{36}' | head -1 || true)
+if [[ -z "$UDID" ]]; then
+  echo "build-ios: no connected iPhone found." >&2
+  echo "  Connect + unlock your iPhone (Developer Mode on), then rerun. Current devices:" >&2
+  xcrun devicectl list devices >&2 || true
+  exit 1
+fi
+DEVICE_NAME=$(printf '%s' "$device_line" | awk -F'   +' '{print $NF}')
+log "Target device: ${DEVICE_NAME:-$UDID} ($UDID)"
+
+native_preflight
+native_regenerate
+
+# --- Build (signed for the device) --------------------------------------------
+log "Building for device (signing with team $DEV_TEAM)"
+xcodebuild \
+  -workspace ios/App/App.xcworkspace \
+  -scheme App \
+  -configuration Debug \
+  -destination "id=$UDID" \
+  -derivedDataPath "$DERIVED" \
+  DEVELOPMENT_TEAM="$DEV_TEAM" \
+  CODE_SIGN_STYLE=Automatic \
+  -allowProvisioningUpdates \
+  build
+
+# --- Install + launch ---------------------------------------------------------
+APP=$(find "$DERIVED/Build/Products/Debug-iphoneos" -maxdepth 1 -name '*.app' -type d | head -1)
+[[ -n "$APP" ]] || { echo "build-ios: no device .app under $DERIVED/Build/Products/Debug-iphoneos" >&2; exit 1; }
+BUNDLE_ID=$(plutil -extract CFBundleIdentifier raw "$APP/Info.plist")
+
+log "Installing $APP"
+xcrun devicectl device install app --device "$UDID" "$APP"
+log "Launching $BUNDLE_ID"
+xcrun devicectl device process launch --terminate-existing --device "$UDID" "$BUNDLE_ID"

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -6,17 +6,10 @@
 # On The Beach ships as a thin Capacitor shell (a WKWebView pointed at the live
 # site) plus a native Share Extension. The whole `ios/` Xcode project is
 # generated, not committed (see docs/ios-native-app.md), so this script does the
-# full loop the way CI does — regenerate the project from scratch, inject the
-# Share Extension target — then goes one step further than CI: it *signs, builds,
-# and launches* the Mac Catalyst app on this machine, so you can actually use it
-# (and test the macOS share menu) without ever opening Xcode.
-#
-# Regeneration is cheap here: the Podfile has only two *local* pods (Capacitor +
-# CapacitorCordova, both `:path` into node_modules), so `pod install` does no
-# network work. That's why we always regenerate rather than trying to detect a
-# stale project — it can never drift, and it costs seconds. The real cost is the
-# xcodebuild *compile*, which we keep fast by pinning -derivedDataPath to a fixed
-# location so Xcode's incremental compile cache survives across runs.
+# full loop the way CI does — regenerate the project, inject the Share Extension —
+# then goes one step further than CI: it *signs, builds, and launches* the Mac
+# Catalyst app on this machine, so you can actually use it (and test the macOS
+# share menu) without ever opening Xcode.
 #
 # What this needs that CI doesn't: your Apple signing identity. CI compiles with
 # CODE_SIGNING_ALLOWED=NO (a build is enough to catch breakage); to *run* a
@@ -24,72 +17,13 @@
 # (override with OTB_DEV_TEAM=... if it ever changes).
 
 set -euo pipefail
-
-# Run from the repo root regardless of where the script was invoked from, so all
-# the relative paths below (native/, ios/, build/) resolve.
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+source scripts/lib/native-build-common.sh
 
-# Your Apple Developer Team ID, used for automatic signing. Overridable via env
-# so the script isn't the source of truth for a value that can change.
-DEV_TEAM="${OTB_DEV_TEAM:-W2BS7F6CHM}"
+native_preflight
+native_regenerate
 
-# Fixed derived-data path: keeps Xcode's compile cache between runs even though
-# we blow away and regenerate ios/ each time (derived data is keyed by project
-# location, so a fresh project at the same path still hits the cache).
-DERIVED="build/ios"
-
-log() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
-
-# --- 1. Preflight -------------------------------------------------------------
-# The Share Extension substitutes OTB_INGEST_API_KEY (from the gitignored
-# Secrets.xcconfig) into its Info.plist at build time. Precedence: keep a real
-# key you've already set up, otherwise lift it from .env, otherwise fall back to
-# a placeholder so the app still compiles and launches (shares just won't post).
-SECRETS="native/ShareExtension/Secrets.xcconfig"
-if [[ -f "$SECRETS" ]]; then
-  log "Using existing $SECRETS"
-elif key=$(grep -E '^OTB_INGEST_API_KEY=' .env 2>/dev/null | head -1 | cut -d= -f2-) && [[ -n "${key:-}" ]]; then
-  printf 'OTB_INGEST_API_KEY = %s\n' "$key" > "$SECRETS"
-  log "Wrote $SECRETS from .env"
-else
-  printf 'OTB_INGEST_API_KEY = placeholder-key\n' > "$SECRETS"
-  log "No key found — wrote placeholder $SECRETS (shares won't post until you set a real key)"
-fi
-
-# `cap sync` copies webDir (build/client) into the app and fails if it's absent.
-# server.url serves the live site, so the copied bundle is never used — a
-# placeholder satisfies the check without a full `bun run build`. Leave a real
-# build in place if one already exists.
-if [[ ! -f build/client/index.html ]]; then
-  mkdir -p build/client
-  printf '<!doctype html><title>On The Beach</title>' > build/client/index.html
-fi
-
-# --- 2. Regenerate the iOS project --------------------------------------------
-# `cap add` runs a CocoaPods "checkBundler" pre-flight that, under macOS's
-# read-only system Ruby (/usr/bin/ruby 2.6), tries to gem-install bundler into a
-# read-only dir and aborts with Gem::FilePermissionError (see the troubleshooting
-# section of docs/ios-native-app.md). Put a writable Homebrew Ruby ahead of the
-# system one on PATH so gem/bundle/pod — and the xcodeproj gem that
-# add-share-extension.rb needs — all resolve to a writable toolchain.
-if [[ "$(command -v ruby)" == "/usr/bin/ruby" ]]; then
-  brew_ruby="$(brew --prefix ruby 2>/dev/null)/bin"
-  if [[ -x "$brew_ruby/ruby" ]]; then
-    export PATH="$brew_ruby:$PATH"
-    log "Using Homebrew Ruby for project generation ($brew_ruby)"
-  else
-    echo "build-mac: active Ruby is the read-only system Ruby and no Homebrew Ruby found." >&2
-    echo "  Fix: brew install ruby  (see docs/ios-native-app.md troubleshooting)" >&2
-    exit 1
-  fi
-fi
-
-log "Regenerating ios/ project"
-rm -rf ios
-bun run cap:add
-ruby scripts/add-share-extension.rb
-
-# --- 3. Build (signed, Mac Catalyst) ------------------------------------------
+# --- Build (signed, Mac Catalyst) ---------------------------------------------
 # A *concrete* Mac Catalyst destination (not CI's generic one) produces a
 # runnable .app. -allowProvisioningUpdates lets Xcode fetch/refresh the signing
 # assets non-interactively.
@@ -105,8 +39,10 @@ xcodebuild \
   -allowProvisioningUpdates \
   build
 
-# --- 4. Launch ----------------------------------------------------------------
-APP=$(find "$DERIVED/Build/Products" -maxdepth 2 -name '*.app' -type d | head -1)
-[[ -n "$APP" ]] || { echo "build-mac: no .app found under $DERIVED/Build/Products" >&2; exit 1; }
+# --- Launch -------------------------------------------------------------------
+# Scope to the Catalyst product dir: build-ios.sh shares this DERIVED path, so a
+# Debug-iphoneos build may also be present.
+APP=$(find "$DERIVED/Build/Products/Debug-maccatalyst" -maxdepth 1 -name '*.app' -type d | head -1)
+[[ -n "$APP" ]] || { echo "build-mac: no .app under $DERIVED/Build/Products/Debug-maccatalyst" >&2; exit 1; }
 log "Launching $APP"
 open "$APP"

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Build and launch the native Mac app locally — no Xcode UI, one command.
+#
+#   bun run mac
+#
+# On The Beach ships as a thin Capacitor shell (a WKWebView pointed at the live
+# site) plus a native Share Extension. The whole `ios/` Xcode project is
+# generated, not committed (see docs/ios-native-app.md), so this script does the
+# full loop the way CI does — regenerate the project from scratch, inject the
+# Share Extension target — then goes one step further than CI: it *signs, builds,
+# and launches* the Mac Catalyst app on this machine, so you can actually use it
+# (and test the macOS share menu) without ever opening Xcode.
+#
+# Regeneration is cheap here: the Podfile has only two *local* pods (Capacitor +
+# CapacitorCordova, both `:path` into node_modules), so `pod install` does no
+# network work. That's why we always regenerate rather than trying to detect a
+# stale project — it can never drift, and it costs seconds. The real cost is the
+# xcodebuild *compile*, which we keep fast by pinning -derivedDataPath to a fixed
+# location so Xcode's incremental compile cache survives across runs.
+#
+# What this needs that CI doesn't: your Apple signing identity. CI compiles with
+# CODE_SIGNING_ALLOWED=NO (a build is enough to catch breakage); to *run* a
+# Catalyst app macOS requires it signed. We sign automatically with your team
+# (override with OTB_DEV_TEAM=... if it ever changes).
+
+set -euo pipefail
+
+# Run from the repo root regardless of where the script was invoked from, so all
+# the relative paths below (native/, ios/, build/) resolve.
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+# Your Apple Developer Team ID, used for automatic signing. Overridable via env
+# so the script isn't the source of truth for a value that can change.
+DEV_TEAM="${OTB_DEV_TEAM:-W2BS7F6CHM}"
+
+# Fixed derived-data path: keeps Xcode's compile cache between runs even though
+# we blow away and regenerate ios/ each time (derived data is keyed by project
+# location, so a fresh project at the same path still hits the cache).
+DERIVED="build/ios"
+
+log() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+
+# --- 1. Preflight -------------------------------------------------------------
+# The Share Extension substitutes OTB_INGEST_API_KEY (from the gitignored
+# Secrets.xcconfig) into its Info.plist at build time. Precedence: keep a real
+# key you've already set up, otherwise lift it from .env, otherwise fall back to
+# a placeholder so the app still compiles and launches (shares just won't post).
+SECRETS="native/ShareExtension/Secrets.xcconfig"
+if [[ -f "$SECRETS" ]]; then
+  log "Using existing $SECRETS"
+elif key=$(grep -E '^OTB_INGEST_API_KEY=' .env 2>/dev/null | head -1 | cut -d= -f2-) && [[ -n "${key:-}" ]]; then
+  printf 'OTB_INGEST_API_KEY = %s\n' "$key" > "$SECRETS"
+  log "Wrote $SECRETS from .env"
+else
+  printf 'OTB_INGEST_API_KEY = placeholder-key\n' > "$SECRETS"
+  log "No key found — wrote placeholder $SECRETS (shares won't post until you set a real key)"
+fi
+
+# `cap sync` copies webDir (build/client) into the app and fails if it's absent.
+# server.url serves the live site, so the copied bundle is never used — a
+# placeholder satisfies the check without a full `bun run build`. Leave a real
+# build in place if one already exists.
+if [[ ! -f build/client/index.html ]]; then
+  mkdir -p build/client
+  printf '<!doctype html><title>On The Beach</title>' > build/client/index.html
+fi
+
+# --- 2. Regenerate the iOS project --------------------------------------------
+# `cap add` runs a CocoaPods "checkBundler" pre-flight that, under macOS's
+# read-only system Ruby (/usr/bin/ruby 2.6), tries to gem-install bundler into a
+# read-only dir and aborts with Gem::FilePermissionError (see the troubleshooting
+# section of docs/ios-native-app.md). Put a writable Homebrew Ruby ahead of the
+# system one on PATH so gem/bundle/pod — and the xcodeproj gem that
+# add-share-extension.rb needs — all resolve to a writable toolchain.
+if [[ "$(command -v ruby)" == "/usr/bin/ruby" ]]; then
+  brew_ruby="$(brew --prefix ruby 2>/dev/null)/bin"
+  if [[ -x "$brew_ruby/ruby" ]]; then
+    export PATH="$brew_ruby:$PATH"
+    log "Using Homebrew Ruby for project generation ($brew_ruby)"
+  else
+    echo "build-mac: active Ruby is the read-only system Ruby and no Homebrew Ruby found." >&2
+    echo "  Fix: brew install ruby  (see docs/ios-native-app.md troubleshooting)" >&2
+    exit 1
+  fi
+fi
+
+log "Regenerating ios/ project"
+rm -rf ios
+bun run cap:add
+ruby scripts/add-share-extension.rb
+
+# --- 3. Build (signed, Mac Catalyst) ------------------------------------------
+# A *concrete* Mac Catalyst destination (not CI's generic one) produces a
+# runnable .app. -allowProvisioningUpdates lets Xcode fetch/refresh the signing
+# assets non-interactively.
+log "Building Mac Catalyst app (signing with team $DEV_TEAM)"
+xcodebuild \
+  -workspace ios/App/App.xcworkspace \
+  -scheme App \
+  -configuration Debug \
+  -destination 'platform=macOS,variant=Mac Catalyst' \
+  -derivedDataPath "$DERIVED" \
+  DEVELOPMENT_TEAM="$DEV_TEAM" \
+  CODE_SIGN_STYLE=Automatic \
+  -allowProvisioningUpdates \
+  build
+
+# --- 4. Launch ----------------------------------------------------------------
+APP=$(find "$DERIVED/Build/Products" -maxdepth 2 -name '*.app' -type d | head -1)
+[[ -n "$APP" ]] || { echo "build-mac: no .app found under $DERIVED/Build/Products" >&2; exit 1; }
+log "Launching $APP"
+open "$APP"

--- a/scripts/lib/native-build-common.sh
+++ b/scripts/lib/native-build-common.sh
@@ -1,0 +1,80 @@
+# shellcheck shell=bash
+# Shared setup for the local native-app build scripts (build-mac.sh, build-ios.sh).
+#
+# Both scripts do the same first half — make the Share Extension key + web
+# placeholder available, sidestep the system-Ruby CocoaPods failure, and
+# regenerate the (gitignored, generated) ios/ project from scratch — then differ
+# only in how they build, install, and launch. That common half lives here so it
+# can't drift between the two.
+#
+# Source this AFTER `set -euo pipefail` and after cd'ing to the repo root, then
+# call `native_preflight` and `native_regenerate` before your platform-specific
+# xcodebuild.
+
+# Your Apple Developer Team ID, used for automatic signing. Overridable via env
+# so no script is the source of truth for a value that can change.
+DEV_TEAM="${OTB_DEV_TEAM:-W2BS7F6CHM}"
+
+# Fixed derived-data path: keeps Xcode's compile cache between runs even though
+# we blow away and regenerate ios/ each time (derived data is keyed by project
+# location, so a fresh project at the same path still hits the cache).
+DERIVED="build/ios"
+
+log() { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+
+# --- Preflight ----------------------------------------------------------------
+# The Share Extension substitutes OTB_INGEST_API_KEY (from the gitignored
+# Secrets.xcconfig) into its Info.plist at build time. Precedence: keep a real
+# key you've already set up, otherwise lift it from .env, otherwise fall back to
+# a placeholder so the app still compiles and launches (shares just won't post).
+native_preflight() {
+  local secrets="native/ShareExtension/Secrets.xcconfig" key
+  if [[ -f "$secrets" ]]; then
+    log "Using existing $secrets"
+  elif key=$(grep -E '^OTB_INGEST_API_KEY=' .env 2>/dev/null | head -1 | cut -d= -f2-) && [[ -n "${key:-}" ]]; then
+    printf 'OTB_INGEST_API_KEY = %s\n' "$key" > "$secrets"
+    log "Wrote $secrets from .env"
+  else
+    printf 'OTB_INGEST_API_KEY = placeholder-key\n' > "$secrets"
+    log "No key found — wrote placeholder $secrets (shares won't post until you set a real key)"
+  fi
+
+  # `cap sync` copies webDir (build/client) into the app and fails if it's
+  # absent. server.url serves the live site, so the copied bundle is never used —
+  # a placeholder satisfies the check without a full `bun run build`. Leave a real
+  # build in place if one already exists.
+  if [[ ! -f build/client/index.html ]]; then
+    mkdir -p build/client
+    printf '<!doctype html><title>On The Beach</title>' > build/client/index.html
+  fi
+}
+
+# --- Regenerate the iOS project -----------------------------------------------
+# Regeneration is cheap here (the Podfile has only two *local* pods, so
+# `pod install` does no network work), so we always regenerate rather than try to
+# detect a stale project — it can never drift and costs seconds.
+native_regenerate() {
+  # `cap add` runs a CocoaPods "checkBundler" pre-flight that, under macOS's
+  # read-only system Ruby (/usr/bin/ruby 2.6), tries to gem-install bundler into a
+  # read-only dir and aborts with Gem::FilePermissionError (see the troubleshooting
+  # section of docs/ios-native-app.md). Put a writable Homebrew Ruby ahead of the
+  # system one on PATH so gem/bundle/pod — and the xcodeproj gem that
+  # add-share-extension.rb needs — all resolve to a writable toolchain.
+  if [[ "$(command -v ruby)" == "/usr/bin/ruby" ]]; then
+    local brew_ruby
+    brew_ruby="$(brew --prefix ruby 2>/dev/null)/bin"
+    if [[ -x "$brew_ruby/ruby" ]]; then
+      export PATH="$brew_ruby:$PATH"
+      log "Using Homebrew Ruby for project generation ($brew_ruby)"
+    else
+      echo "native-build: active Ruby is the read-only system Ruby and no Homebrew Ruby found." >&2
+      echo "  Fix: brew install ruby  (see docs/ios-native-app.md troubleshooting)" >&2
+      exit 1
+    fi
+  fi
+
+  log "Regenerating ios/ project"
+  rm -rf ios
+  bun run cap:add
+  ruby scripts/add-share-extension.rb
+}


### PR DESCRIPTION
## What

Two commands to build and run the native app locally, no Xcode UI:

```
bun run mac   # build, sign & launch the Mac (Catalyst) app on this machine
bun run ios   # build, sign, install & launch on a connected iPhone
```

## Why

The app is a thin Capacitor shell (WKWebView on the live site) plus a native Share Extension. The whole `ios/` project is generated, not committed, and the existing CI job only *compiles* it unsigned. To actually **run** the app you had to open Xcode and drive build/sign/run by hand. These script that away, giving a fast inner loop for using the app and testing the real macOS share menu / iOS share sheet.

## How it works

Shared half — `scripts/lib/native-build-common.sh` (sourced by both):

1. **Preflight** — keep an existing `Secrets.xcconfig`, else source `OTB_INGEST_API_KEY` from `.env`, else write a placeholder; ensure the `webDir` placeholder exists.
2. **Ruby fix** — prepend Homebrew Ruby to `PATH` *only* when the read-only macOS system Ruby is active, sidestepping the documented `cap add` `Gem::FilePermissionError`.
3. **Regenerate** — `rm -rf ios` → `cap:add` → `add-share-extension.rb`. Always fresh (only two local pods → cheap, never drifts).

Platform-specific halves:

- **`scripts/build-mac.sh`** — `xcodebuild` for a concrete Mac Catalyst destination, automatic signing (team overridable via `OTB_DEV_TEAM`), then `open` the `.app`.
- **`scripts/build-ios.sh`** — auto-detect the connected paired iPhone, build signed for it (`-allowProvisioningUpdates` registers the device), then `xcrun devicectl` install + launch. Errors clearly (and lists devices) if none is connected.

Both share one `-derivedDataPath` (`build/ios`) so Xcode's compile cache survives reruns; each scopes its launch lookup to its own `Debug-<platform>` product dir.

## Verification

Ran both end-to-end on a Mac with a paired iPhone 16e:

- `bun run mac` → `** BUILD SUCCEEDED **`, signed, `ShareExtension.appex` embedded, app launched and confirmed running.
- `bun run ios` → `** BUILD SUCCEEDED **`, signed via the iOS Team Provisioning Profile, installed to the iPhone (`es.ricojam.onthebeach`), and launched on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)