### PR TITLE
feat(mac): install to /Applications + point at a local server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "cap:sync": "cap sync ios",
     "cap:open": "cap open ios",
     "mac": "bash scripts/build-mac.sh",
+    "mac:install": "bash scripts/build-mac.sh --install",
+    "mac:local": "OTB_APP_URL=http://localhost:3000 bash scripts/build-mac.sh --install",
     "ios": "bash scripts/build-ios.sh",
     "brand:assets": "bash scripts/generate-brand-assets.sh"
   },

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -16,9 +16,28 @@
 # Catalyst app macOS requires it signed. We sign automatically with your team
 # (override with OTB_DEV_TEAM=... if it ever changes).
 
+#
+# Flags:
+#   --install   After building, copy the .app into /Applications (or
+#               ~/Applications if that isn't writable) and launch it from there,
+#               so it's a permanent app you can open from Spotlight/Launchpad —
+#               not one that only runs out of build/. Pair with
+#               OTB_APP_URL=http://localhost:3000 (see `bun run mac:local`) to
+#               install a shell around your *local* server. Note: because the app
+#               is only a WKWebView shell, an installed localhost build shows
+#               content only while that local server is running.
+
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 source scripts/lib/native-build-common.sh
+
+INSTALL=0
+for arg in "$@"; do
+  case "$arg" in
+    --install) INSTALL=1 ;;
+    *) echo "build-mac: unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 native_preflight
 native_regenerate
@@ -44,5 +63,21 @@ xcodebuild \
 # Debug-iphoneos build may also be present.
 APP=$(find "$DERIVED/Build/Products/Debug-maccatalyst" -maxdepth 1 -name '*.app' -type d | head -1)
 [[ -n "$APP" ]] || { echo "build-mac: no .app under $DERIVED/Build/Products/Debug-maccatalyst" >&2; exit 1; }
+
+if [[ "$INSTALL" == 1 ]]; then
+  # /Applications is admin-group writable on a typical Mac; fall back to the
+  # per-user ~/Applications (also indexed by Spotlight/Launchpad) if it isn't,
+  # so this never needs sudo. Install under the friendly product name — the
+  # built wrapper is App.app (Capacitor's PRODUCT_NAME), but the bundle filename
+  # is cosmetic and the menu-bar title comes from CFBundleName either way.
+  dest_dir="/Applications"; [[ -w "$dest_dir" ]] || dest_dir="$HOME/Applications"
+  mkdir -p "$dest_dir"
+  APP_DEST="$dest_dir/On The Beach.app"
+  rm -rf "$APP_DEST"
+  cp -R "$APP" "$APP_DEST"
+  log "Installed → $APP_DEST"
+  APP="$APP_DEST"
+fi
+
 log "Launching $APP"
 open "$APP"


### PR DESCRIPTION
## What

Builds on the `bun run mac` / `bun run ios` tooling with a way to **install** the Mac app permanently and point it at a **local** server.

```bash
bun run mac:install   # permanent /Applications install, pointed at production
bun run mac:local     # permanent /Applications install, pointed at localhost:3000
```

Plus a general `--install` flag on `scripts/build-mac.sh`.

## Why

`bun run mac` launches the app out of `build/` and always targets production. This adds:
- **A real installed app** — copied into `/Applications` (falls back to `~/Applications` if unwritable, so no sudo), so it shows in Spotlight/Launchpad and survives `build/` being cleaned.
- **Local-server targeting** — `mac:local` bakes `OTB_APP_URL=http://localhost:3000` into the build so you can use your local dev/build in a native window.

## Important constraint (documented in the script)

The native app is only a **WKWebView shell** around `server.url` — On The Beach is a full-stack SSR app, so there's no bundled offline build. A `mac:local` install therefore renders **only while your local server is running** (`bun run dev`, or `bun run build && bun run start`). With nothing on `:3000` it shows a blank/error page.

## Verification

With a local server up on `:3000`, ran `bun run mac:local` end-to-end:
- `** BUILD SUCCEEDED **`, signed with the developer identity.
- Installed to `/Applications/On The Beach.app`.
- Confirmed the **installed bundle's baked `server.url` is `http://localhost:3000`** (read back from `Contents/Resources/capacitor.config.json`) — i.e. it really targets local, not production.
- App launched and confirmed running while the server returned HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)