### PR TITLE
Fix stack name clicks and horizontal scrollbar touch handling

### DIFF
--- a/src/lib/components/HorizontalScrollbar.svelte
+++ b/src/lib/components/HorizontalScrollbar.svelte
@@ -81,16 +81,16 @@
   }
 
   $effect(() => {
-    document.addEventListener("mouseup", stopRepeatScroll);
+    document.addEventListener("pointerup", stopRepeatScroll);
     window.addEventListener("blur", stopRepeatScroll);
     return () => {
-      document.removeEventListener("mouseup", stopRepeatScroll);
+      document.removeEventListener("pointerup", stopRepeatScroll);
       window.removeEventListener("blur", stopRepeatScroll);
       stopRepeatScroll();
     };
   });
 
-  function onTrackMouseDown(event: MouseEvent): void {
+  function onTrackPointerDown(event: PointerEvent): void {
     if (!target || !trackEl) return;
     if ((event.target as HTMLElement).id === thumbId) return;
 
@@ -103,7 +103,7 @@
     });
   }
 
-  function onDragMove(event: MouseEvent): void {
+  function onDragMove(event: PointerEvent): void {
     if (!drag || !target || !trackEl) return;
 
     const scrollRange = target.scrollWidth - target.clientWidth;
@@ -121,14 +121,19 @@
 
   function onDragEnd(): void {
     drag = null;
-    document.removeEventListener("mousemove", onDragMove);
+    document.removeEventListener("pointermove", onDragMove);
   }
 
-  function onThumbMouseDown(event: MouseEvent): void {
+  function onThumbPointerDown(event: PointerEvent): void {
     event.preventDefault();
+    const thumb = event.currentTarget as HTMLElement;
+    if (event.pointerId !== undefined && typeof thumb.setPointerCapture === "function") {
+      thumb.setPointerCapture(event.pointerId);
+    }
     drag = { startX: event.clientX, startLeft: thumbLeft };
-    document.addEventListener("mousemove", onDragMove);
-    document.addEventListener("mouseup", onDragEnd, { once: true });
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
   }
 </script>
 
@@ -139,9 +144,10 @@
     data-stack-scroll-btn="left"
     tabindex="-1"
     onclick={() => scrollByStep(-80)}
-    onmousedown={() => startRepeatScroll(-80)}
-    onmouseup={stopRepeatScroll}
-    onmouseleave={stopRepeatScroll}
+    onpointerdown={() => startRepeatScroll(-80)}
+    onpointerup={stopRepeatScroll}
+    onpointercancel={stopRepeatScroll}
+    onpointerleave={stopRepeatScroll}
   >
     ◀
   </button>
@@ -150,14 +156,14 @@
     class="stack-scrollbar__track"
     role="presentation"
     bind:this={trackEl}
-    onmousedown={onTrackMouseDown}
+    onpointerdown={onTrackPointerDown}
   >
     <div
       id={thumbId}
       class="stack-scrollbar__thumb"
       role="presentation"
       style="width: {thumbWidth}px; left: {thumbLeft}px"
-      onmousedown={onThumbMouseDown}
+      onpointerdown={onThumbPointerDown}
     ></div>
   </div>
   <button
@@ -166,9 +172,10 @@
     data-stack-scroll-btn="right"
     tabindex="-1"
     onclick={() => scrollByStep(80)}
-    onmousedown={() => startRepeatScroll(80)}
-    onmouseup={stopRepeatScroll}
-    onmouseleave={stopRepeatScroll}
+    onpointerdown={() => startRepeatScroll(80)}
+    onpointerup={stopRepeatScroll}
+    onpointercancel={stopRepeatScroll}
+    onpointerleave={stopRepeatScroll}
   >
     ▶
   </button>

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -649,13 +649,23 @@
           </div>
           <div id="stack-picker-list" class="release-page__edit-stacks-list">
             {#each visibleStacks as stack (stack.id)}
-              <label class="stack-dropdown__item">
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+              <label
+                class="stack-dropdown__item"
+                onclick={(event) => {
+                  // Toggle explicitly so clicking the name text works as
+                  // reliably as clicking the box — native <label>→checkbox
+                  // click forwarding dropped text clicks in some browsers.
+                  event.preventDefault();
+                  toggleStack(stack.id, !assignedIds.has(stack.id));
+                }}
+              >
                 <input
                   type="checkbox"
                   class="stack-dropdown__checkbox"
                   data-sid={stack.id}
                   checked={assignedIds.has(stack.id)}
-                  onchange={(e) => toggleStack(stack.id, e.currentTarget.checked)}
                 />
                 {stack.name}
               </label>

--- a/src/lib/components/StackDropdown.svelte
+++ b/src/lib/components/StackDropdown.svelte
@@ -104,13 +104,28 @@
   </div>
   <div class="stack-dropdown__list">
     {#each visibleStacks as stack (stack.id)}
-      <label class="stack-dropdown__item">
+      <!-- Keyboard access is preserved: the nested checkbox is focusable and
+           Space fires a click that bubbles to this handler. -->
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <label
+        class="stack-dropdown__item"
+        onclick={(event) => {
+          // Toggle explicitly so clicking anywhere on the row — the name text,
+          // the padding, or the box — reliably flips the assignment exactly
+          // once. Relying on the browser's native <label>→checkbox forwarding
+          // dropped text clicks in some browsers (e.g. Safari), so the box
+          // was the only thing that worked. preventDefault stops the native
+          // toggle; the checkbox stays a controlled reflection of state.
+          event.preventDefault();
+          onToggle(stack.id, !selectedStackIds.has(stack.id));
+        }}
+      >
         <input
           type="checkbox"
           class="stack-dropdown__checkbox"
           data-stack-id={stack.id}
           checked={selectedStackIds.has(stack.id)}
-          onchange={(e) => onToggle(stack.id, e.currentTarget.checked)}
         />
         {stack.name}
       </label>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -750,6 +750,9 @@ select.input {
   grid-template-columns: 24px minmax(0, 1fr) 24px;
   align-items: stretch;
   border-top: 1px solid var(--chrome-dark);
+  /* Let the scrollbar handle its own touch gestures (thumb drag / track tap)
+     instead of the browser treating them as page scrolls. */
+  touch-action: none;
 }
 
 .stack-scrollbar__button,


### PR DESCRIPTION
Two related mobile/interaction fixes for the stacks UI.

## 1. Clicking a stack's name now selects it, not just the checkbox

The stack-assignment lists — the card `+` dropdown (`StackDropdown.svelte`) and the release page "Stacks" section (`ReleasePage.svelte`) — wrapped each checkbox and name in a `<label>` and relied on the browser's native label→checkbox click forwarding. That forwarding dropped clicks on the **name text** in some browsers (e.g. Safari): the row highlighted as if it registered, but the assignment never persisted, so only the small checkbox actually worked.

Now the toggle is handled explicitly on the row: a click anywhere (name text, padding, or the box) calls `preventDefault()` and flips the assignment exactly once. The checkbox becomes a controlled reflection of state. Keyboard access is preserved — the nested checkbox stays focusable and Space fires a click that bubbles to the handler.

## 2. Horizontal stack scrollbar now works on touch

The stack-bar scrollbar still used mouse-only events (`mousedown`/`mousemove`/`mouseup`) and had no `touch-action` rule, unlike the vertical music scrollbar which was already migrated to Pointer Events. On touch devices the thumb drag never engaged the JS drag logic, so the browser handled the gesture itself and the bar snapped back to its previous position instead of holding — the "it shoots back" behaviour.

`HorizontalScrollbar.svelte` is migrated to Pointer Events with `setPointerCapture` and `pointercancel` handling (mirroring `VerticalScrollbar.svelte`), and `touch-action: none` is added to `.stack-scrollbar` so the browser stops treating thumb drags and track taps as page scrolls.

## Verification

- **Stack name click:** drove it in a real browser — clicking the name text adds the stack and persists to the server; clicking again removes it (proving a single toggle, not a double-fire); clicking the box still works.
- **Scrollbar:** reproduced with genuine touch events (via CDP, `pointerType: touch`). Before: touch-dragging the thumb left `scrollLeft` at `0`. After: it scrolled and **held**. Confirmed with a negative control (revert → fails, restore → passes).
- All stack e2e suites pass (`stacks.spec.ts`, `stack-dropdown-scroll.spec.ts`), 461 unit tests pass, typecheck clean (0 errors / 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzH5dhiRmzgPPrwejpGbK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzH5dhiRmzgPPrwejpGbK9)_