### PR TITLE
fix(ios): grant the Share Extension macOS network entitlement

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -87,6 +87,18 @@ jobs:
       - name: Inject Share Extension target
         run: ruby scripts/add-share-extension.rb
 
+      - name: Verify Share Extension macOS entitlements
+        # Regression guard for a bug that only bit the real Mac app: macOS always
+        # sandboxes an app extension, so without com.apple.security.network.client
+        # the extension's ingest POST is silently denied and shared links never
+        # land. Neither iOS nor a signing-disabled CI *build* surfaces this, so
+        # assert the config directly: the entitlements file grants network, and
+        # the injector wired it onto the extension target (macOS-scoped).
+        run: |
+          grep -q 'com.apple.security.network.client' native/ShareExtension/ShareExtension.entitlements
+          grep -q 'com.apple.security.app-sandbox' native/ShareExtension/ShareExtension.entitlements
+          grep -q 'CODE_SIGN_ENTITLEMENTS\[sdk=macosx\*\]' ios/App/App.xcodeproj/project.pbxproj
+
       - name: Build App + Share Extension (iOS Simulator)
         # Building the App scheme also builds the embedded ShareExtension target,
         # so ShareViewController.swift is genuinely compiled. No signing needed

--- a/native/ShareExtension/ShareExtension.entitlements
+++ b/native/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- macOS/Mac Catalyst only (wired via CODE_SIGN_ENTITLEMENTS[sdk=macosx*] in
+	     scripts/add-share-extension.rb, so iOS device signing is untouched).
+
+	     macOS ALWAYS runs an app extension inside the "plugin" App Sandbox,
+	     regardless of whether the binary opts in. The host app can dodge the
+	     sandbox by simply not enabling it, but an extension cannot — so without
+	     network.client the extension's URLSession POST to /api/ingest/link is
+	     silently denied and the shared link never leaves the machine. These two
+	     keys grant the extension outbound network inside its sandbox. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/add-share-extension.rb
+++ b/scripts/add-share-extension.rb
@@ -35,6 +35,7 @@ NATIVE_DIR = File.join(REPO_ROOT, "native", "ShareExtension")
 SWIFT_SOURCE = File.join(NATIVE_DIR, "ShareViewController.swift")
 INFO_PLIST = File.join(NATIVE_DIR, "Info.plist")
 SECRETS_XCCONFIG = File.join(NATIVE_DIR, "Secrets.xcconfig")
+ENTITLEMENTS = File.join(NATIVE_DIR, "ShareExtension.entitlements")
 
 EXT_NAME = "ShareExtension"
 APP_TARGET_NAME = "App"
@@ -138,6 +139,13 @@ ext_target.build_configurations.each do |config|
     # menu. Xcode derives MACOSX_DEPLOYMENT_TARGET from the iOS floor, so no
     # separate Mac version is needed.
     "SUPPORTS_MACCATALYST" => "YES",
+    # macOS ALWAYS sandboxes an app extension ("plugin" profile), and without
+    # network.client the extension's URLSession POST to the ingest endpoint is
+    # silently denied — the share never leaves the machine. Grant the sandbox +
+    # outbound network via an entitlements file. Scope it to the macOS SDK (which
+    # is what Mac Catalyst builds against) so iOS device signing — which has no
+    # such entitlements in its provisioning profile — is untouched.
+    "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" => "../../native/ShareExtension/ShareExtension.entitlements",
   )
 end
 
@@ -147,8 +155,10 @@ end
 group = project.main_group.new_group(EXT_NAME, NATIVE_DIR)
 swift_ref = group.new_file(SWIFT_SOURCE)
 ext_target.add_file_references([swift_ref])
-# Keep the Info.plist visible in the navigator (it isn't a build input).
+# Keep the Info.plist + entitlements visible in the navigator (not build inputs;
+# the entitlements is referenced via CODE_SIGN_ENTITLEMENTS above).
 group.new_file(INFO_PLIST)
+group.new_file(ENTITLEMENTS) if File.exist?(ENTITLEMENTS)
 
 # --- Wire the ingest-key xcconfig --------------------------------------------
 # Secrets.xcconfig provides OTB_INGEST_API_KEY, substituted into Info.plist at


### PR DESCRIPTION
## The bug

Sharing a link from the **Mac** app silently failed — the share sheet opened, you tapped Add, the form closed with no error, but nothing was added.

## Root cause

macOS **always** runs an app extension inside the "plugin" App Sandbox. The extension shipped with only `get-task-allow` in its entitlements — no `com.apple.security.network.client`. So its `URLSession` POST to `/api/ingest/link` was **denied by the sandbox**, and the shared link never left the machine.

The asymmetry that hid it: the **host app** has no sandbox entitlement either, but a regular Catalyst app without `app-sandbox` simply runs *un*-sandboxed, so its WKWebView networking works fine. An **app extension cannot escape** the sandbox — so it alone needed `network.client` spelled out.

It never showed up on **iOS** (no App Sandbox requirement) or in **CI** (simulator + Catalyst builds use `CODE_SIGNING_ALLOWED=NO`, so entitlements aren't enforced) — only the real signed Mac app was affected.

## Evidence

- `codesign -d --entitlements` on the built extension: **only `get-task-allow`**.
- Live `log stream` during a share: the extension launched into `_SandboxProfile => "plugin"`, then `ExtensionKit: … killing plugin` / `Could not signal service …: 113`.
- The URL, key, and endpoint were all correct — an identical `curl` from outside the sandbox created the item fine.

## Fix

- Add `native/ShareExtension/ShareExtension.entitlements` granting `com.apple.security.app-sandbox` + `com.apple.security.network.client`.
- Wire it onto the extension target via `CODE_SIGN_ENTITLEMENTS[sdk=macosx*]` in `scripts/add-share-extension.rb` — **scoped to the macOS SDK** (which Mac Catalyst builds against) so iOS device signing, whose provisioning profile carries no such entitlements, is untouched.
- Add a CI guard in `ios-build.yml` asserting the entitlements file grants network and the injector wired it into the project — so this can't silently regress.

## Verification

`codesign` of the freshly built extension now reports:

```
com.apple.security.app-sandbox  => true
com.apple.security.get-task-allow => true
com.apple.security.network.client => true   ← was missing
```

Note: this fixes the *signed Mac app*. Automatically driving the macOS share sheet end-to-end is XCUITest territory (flaky, heavy); the CI guard above catches the actual regression (missing entitlement) cheaply instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)