### PR TITLE
Reuse the add bar as a live search for the current list

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verify
+description: Build, launch, and drive this app locally to observe a change working end-to-end.
+---
+
+# Verifying changes in On The Beach
+
+SvelteKit + Bun app with a SQLite DB. The production e2e fixtures
+(`playwright/fixtures/parallel-test.ts`) are the reference for how to boot it.
+
+## Build + launch
+
+```bash
+bun run build                       # outputs build/index.js (adapter-node)
+
+# Seed an isolated DB in a temp dir, then boot the built server:
+export DATABASE_PATH=/path/to/tmp/verify.db NODE_ENV=test OTB_DISABLE_EXTERNAL_LOOKUPS=1
+bun server/db/seed.ts
+PORT=4173 ORIGIN=http://127.0.0.1:4173 bun build/index.js
+```
+
+- `ORIGIN` must be set to the real http origin or the CSRF check rejects POSTs.
+- `OTB_DISABLE_EXTERNAL_LOOKUPS=1` blocks iTunes/Discogs/etc. lookups (same as e2e).
+- Ready when `GET /api/music-items` returns 200. Use `curl --noproxy 127.0.0.1`.
+
+## Seeding data / test hooks
+
+- `POST /api/__test__/reset` clears all items/stacks (test env only).
+- Create items directly: `POST /api/music-items` with JSON like
+  `{"artistName":"Burial","title":"Untrue","itemType":"album"}`.
+- API POSTs need an `origin: http://127.0.0.1:<port>` header (CSRF).
+
+## Driving the UI
+
+Chromium is preinstalled at `/opt/pw-browsers/chromium`; drive with a
+`playwright-core` script run under `bun`, launching with
+`{ executablePath: "/opt/pw-browsers/chromium", args: ["--no-sandbox"] }`.
+
+Useful selectors: add bar = `getByPlaceholder("search or paste a link")`;
+list cards = `.music-card`; list container = `#music-list` (note: `.music-list`
+class also sits on a wrapper — use the id); browse search input =
+`#browse-search`; its clear button = `#search-clear-btn`.
+
+## Gotchas
+
+- Default filter on `/` is **To Listen**, so freshly created items are visible
+  but `listened` ones are not.
+- With external lookups disabled, submitting free text via the Add button
+  completes without a link picker or any visible result — don't read that as
+  a regression.

--- a/src/lib/components/AddForm.svelte
+++ b/src/lib/components/AddForm.svelte
@@ -2,7 +2,7 @@
   import { tick } from "svelte";
   import type { StackWithCount } from "../../types";
   import type { AddFormValues } from "../../ui/domain/add-form";
-  import { getCoverScanErrorMessage } from "../../ui/domain/add-form";
+  import { getCoverScanErrorMessage, toListSearchQuery } from "../../ui/domain/add-form";
   import { constrainDimensions } from "../../ui/domain/scan";
   import { addFormMachine, RECORD_DURATION_MS } from "../../ui/state/add-form-machine";
   import { api } from "../api";
@@ -15,6 +15,7 @@
     appReady,
     onStackCreated,
     onItemCreated,
+    onSearch,
   }: {
     form: MachineHandle<typeof addFormMachine>;
     stacks: StackWithCount[];
@@ -23,6 +24,8 @@
     onStackCreated: () => Promise<void>;
     /** An item was created — refresh the list and stack bar. */
     onItemCreated: () => void;
+    /** The add bar doubles as a search box — live-filter the list as the user types. */
+    onSearch: (query: string) => void;
   } = $props();
 
   const ctx = $derived(form.snapshot.context);
@@ -75,8 +78,20 @@
     };
   }
 
+  // Track what we last pushed so clearing the form only resets the list
+  // filter when the add bar itself set it (not a query typed in the browse
+  // search panel).
+  let lastSearchQuery = "";
+  function syncSearch(): void {
+    const query = toListSearchQuery(url);
+    if (query === lastSearchQuery) return;
+    lastSearchQuery = query;
+    onSearch(query);
+  }
+
   function resetFields(): void {
     url = "";
+    syncSearch();
     artist = "";
     title = "";
     itemType = "album";
@@ -250,6 +265,7 @@
         placeholder="search or paste a link"
         class="input"
         bind:value={url}
+        oninput={syncSearch}
       />
       <input
         type="file"

--- a/src/lib/components/MainPage.svelte
+++ b/src/lib/components/MainPage.svelte
@@ -296,6 +296,7 @@
     appReady={ctx.isReady}
     onStackCreated={refreshStacks}
     onItemCreated={() => app.send({ type: "ITEM_CREATED" })}
+    onSearch={(query) => app.send({ type: "SEARCH_UPDATED", query })}
   />
 
   <section class="stack-section">

--- a/src/ui/domain/add-form.ts
+++ b/src/ui/domain/add-form.ts
@@ -36,6 +36,19 @@ export function buildCreateMusicItemInputFromValues(values: AddFormValues): Crea
   };
 }
 
+/**
+ * The add bar doubles as a live filter for the current list. Link-looking
+ * input is exempt — a pasted URL would match nothing and empty the list
+ * mid-add.
+ */
+export function toListSearchQuery(value: string): string {
+  const text = value.trim();
+  if (/^https?:\/\//i.test(text) || /^www\./i.test(text) || text.includes("://")) {
+    return "";
+  }
+  return text;
+}
+
 export function getCoverScanErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.includes("uploadReleaseImage")) {
     return "Couldn't save the image. Enter details manually.";

--- a/tests/unit/app-domain.test.ts
+++ b/tests/unit/app-domain.test.ts
@@ -4,6 +4,7 @@ import {
   buildCreateMusicItemInputFromValues,
   getCoverScanErrorMessage,
   hasAnyNonEmptyField,
+  toListSearchQuery,
 } from "../../src/ui/domain/add-form";
 import {
   buildMusicItemFilters,
@@ -136,6 +137,17 @@ describe("app domain helpers", () => {
     expect(getEmptyStateHint("all", "ambient")).toContain("switch filters");
     expect(getEmptyStateHint("scheduled")).toContain("release page");
     expect(getEmptyStateHint("looking-for-price-drop" as never)).toBeNull();
+  });
+
+  it("turns add bar text into a list search query, exempting links", () => {
+    expect(toListSearchQuery("  aphex twin  ")).toBe("aphex twin");
+    expect(toListSearchQuery("R.E.M.")).toBe("R.E.M.");
+    expect(toListSearchQuery("")).toBe("");
+    expect(toListSearchQuery("   ")).toBe("");
+    expect(toListSearchQuery("https://example.bandcamp.com/album/x")).toBe("");
+    expect(toListSearchQuery("HTTP://EXAMPLE.COM")).toBe("");
+    expect(toListSearchQuery("www.example.com/release")).toBe("");
+    expect(toListSearchQuery("spotify://track/123")).toBe("");
   });
 
   it("returns scan alert messages for known error types", () => {


### PR DESCRIPTION
## What

Typing in the top "search or paste a link" bar now live-filters the current list, reusing the existing `SEARCH_UPDATED` event on the app machine — the same state the browse search panel drives, so the two inputs stay in sync (the browse panel's clear button also clears a filter set from the add bar).

## Details

- New `toListSearchQuery` helper in `src/ui/domain/add-form.ts`: trims the input and exempts link-looking text (`http(s)://`, `www.`, any `scheme://`) so pasting a URL mid-add doesn't empty the list.
- `AddForm` gets an `onSearch` prop wired to the url input's `oninput`; `MainPage` maps it to `SEARCH_UPDATED`.
- When the form resets after a successful add, the filter clears — but only if the add bar itself set it, so a query typed in the browse search panel survives adds made via Photo/Listen.
- Unit tests for the helper; also checked all existing Playwright specs fill this input with URLs only, so they're unaffected.
- Adds a project `verify` skill capturing the local build/launch/drive recipe used to verify this end-to-end.

## Verification

Built the app, seeded three items, and drove it with Playwright: typing an artist filters to matching cards, no-match text shows the "No matches" empty state, clearing restores the list, pasted URLs leave the list untouched, and the browse search input mirrors the query. Unit tests (480) and e2e suite pass except 3 pre-existing `persistent-player` failures that also fail on unmodified `main` in this sandbox (external Bandcamp embeds unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTDv19X9YRZMoqLrwjSGNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTDv19X9YRZMoqLrwjSGNK)_