### PR TITLE
fix: create the item_suggestions table production never got, and look up suggestions on demand

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -12,3 +12,11 @@ Run a safe database migration workflow:
 4. On confirmation, run `bun run db:migrate` to apply the migration
 5. Run `bun run typecheck` to verify the schema types are still consistent
 6. Report success or any errors
+
+**Never hand-edit `drizzle/meta/_journal.json` to insert a migration with a
+backdated `when` timestamp.** Drizzle's migrator only applies entries whose
+`when` is newer than the last applied migration's timestamp, so any database
+that has already migrated past the inserted slot (i.e. production) will skip
+the migration forever — silently. This happened with `0007_item_suggestions`
+(healed by `0012_ensure_item_suggestions`). A new migration must always be
+appended with a current timestamp, which is what `bun run db:generate` does.

--- a/drizzle/0012_ensure_item_suggestions.sql
+++ b/drizzle/0012_ensure_item_suggestions.sql
@@ -1,0 +1,24 @@
+-- Re-create item_suggestions for databases that skipped migration 0007.
+--
+-- 0007_item_suggestions was retro-inserted into the journal with a fabricated
+-- timestamp (1775150000000) that slots between 0006 and 0008. Drizzle's
+-- migrator only applies entries newer than the last applied migration's
+-- timestamp, so any database that had already applied 0008 by then — i.e.
+-- production — skipped 0007 forever and never got the table. Every
+-- suggestion query has thrown since, which is why the "you might also like"
+-- prompt never worked in production while passing in every fresh database.
+--
+-- IF NOT EXISTS makes this a no-op for databases that did apply 0007.
+CREATE TABLE IF NOT EXISTS `item_suggestions` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `source_item_id` integer NOT NULL REFERENCES `music_items`(`id`) ON DELETE CASCADE,
+  `title` text NOT NULL,
+  `artist_name` text NOT NULL,
+  `item_type` text NOT NULL DEFAULT 'album',
+  `year` integer,
+  `musicbrainz_release_id` text,
+  `status` text NOT NULL DEFAULT 'pending',
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_item_suggestions_source_item_id` ON `item_suggestions` (`source_item_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1782498225328,
       "tag": "0011_orange_nextwave",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1783963047782,
+      "tag": "0012_ensure_item_suggestions",
+      "breakpoints": true
     }
   ]
 }

--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -1,5 +1,7 @@
 const MB_API_BASE = "https://musicbrainz.org/ws/2";
-const USER_AGENT = "on-the-beach/1.0 (https://github.com/your-repo)";
+// MusicBrainz requires a User-Agent identifying the app with contact info —
+// placeholder/generic UAs get throttled or blocked (403/503).
+const USER_AGENT = "on-the-beach/1.0 (https://github.com/richpjames/on-the-beach)";
 
 export interface MusicBrainzFields {
   year: number | null;
@@ -78,17 +80,15 @@ interface MbArtistSearchResponse {
 async function fetchArtistMbid(artistName: string): Promise<string | null> {
   const params = new URLSearchParams({ query: artistName, limit: "1", fmt: "json" });
   const url = `${MB_API_BASE}/artist?${params}`;
-  try {
-    const response = await fetch(url, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as MbArtistSearchResponse;
-    const first = data.artists?.[0];
-    return typeof first?.id === "string" ? first.id : null;
-  } catch {
-    return null;
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`MusicBrainz artist search returned ${response.status} for "${artistName}"`);
   }
+  const data = (await response.json()) as MbArtistSearchResponse;
+  const first = data.artists?.[0];
+  return typeof first?.id === "string" ? first.id : null;
 }
 
 async function fetchArtistReleases(mbid: string): Promise<MbArtistRelease[]> {
@@ -97,11 +97,22 @@ async function fetchArtistReleases(mbid: string): Promise<MbArtistRelease[]> {
   const response = await fetch(url, {
     headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
   });
-  if (!response.ok) return [];
+  if (!response.ok) {
+    throw new Error(`MusicBrainz artist lookup returned ${response.status} for ${mbid}`);
+  }
   const data = (await response.json()) as MbArtistReleasesResponse;
   return Array.isArray(data.releases) ? (data.releases as MbArtistRelease[]) : [];
 }
 
+/**
+ * Find another release by the artist that isn't in `trackedTitles`, preferring
+ * the one closest in year to `sourceYear` (or the most recent when null).
+ *
+ * Returns null when the artist can't be found or has no untracked releases.
+ * Network failures and non-2xx MusicBrainz responses THROW so callers can
+ * tell "nothing to suggest" apart from "the lookup failed" — swallowing them
+ * here made production failures (rate limiting, blocked UAs) invisible.
+ */
 export async function findSuggestedRelease(opts: {
   mbArtistId: string | null;
   artistName: string;
@@ -109,43 +120,58 @@ export async function findSuggestedRelease(opts: {
   sourceYear: number | null;
 }): Promise<SuggestedRelease | null> {
   const { mbArtistId, artistName, trackedTitles, sourceYear } = opts;
+  const searchLog = { artistName, mbArtistId, sourceYear };
 
-  try {
-    const mbid = mbArtistId ?? (await fetchArtistMbid(artistName));
-    if (!mbid) return null;
-
-    const releases = await fetchArtistReleases(mbid);
-    if (releases.length === 0) return null;
-
-    const candidates = releases.filter((r) => {
-      if (typeof r.title !== "string" || !r.title) return false;
-      return !trackedTitles.has(r.title.toLowerCase().trim());
-    });
-
-    if (candidates.length === 0) return null;
-
-    const withYear = candidates.map((r) => ({
-      title: r.title as string,
-      year: parseYear(r.date),
-      musicbrainzReleaseId: typeof r.id === "string" ? r.id : null,
-      itemType: typeof r["primary-type"] === "string" ? r["primary-type"].toLowerCase() : "album",
-    }));
-
-    if (sourceYear === null) {
-      withYear.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
-      return withYear[0] ?? null;
-    }
-
-    withYear.sort(
-      (a, b) =>
-        Math.abs((a.year ?? sourceYear) - sourceYear) -
-        Math.abs((b.year ?? sourceYear) - sourceYear),
-    );
-
-    return withYear[0] ?? null;
-  } catch {
+  const mbid = mbArtistId ?? (await fetchArtistMbid(artistName));
+  if (!mbid) {
+    console.info("[musicbrainz] No artist match for suggestion lookup", searchLog);
     return null;
   }
+
+  const releases = await fetchArtistReleases(mbid);
+  const candidates = releases.filter((r) => {
+    if (typeof r.title !== "string" || !r.title) return false;
+    return !trackedTitles.has(r.title.toLowerCase().trim());
+  });
+
+  if (candidates.length === 0) {
+    console.info("[musicbrainz] No suggestible releases", {
+      ...searchLog,
+      mbid,
+      releaseCount: releases.length,
+      trackedCount: trackedTitles.size,
+    });
+    return null;
+  }
+
+  const withYear = candidates.map((r) => ({
+    title: r.title as string,
+    year: parseYear(r.date),
+    musicbrainzReleaseId: typeof r.id === "string" ? r.id : null,
+    itemType: typeof r["primary-type"] === "string" ? r["primary-type"].toLowerCase() : "album",
+  }));
+
+  if (sourceYear === null) {
+    // Most recent first; undated releases last.
+    withYear.sort((a, b) => (b.year ?? -Infinity) - (a.year ?? -Infinity));
+  } else {
+    // Closest in year to the source release; undated releases last rather
+    // than treated as a perfect match.
+    const distance = (year: number | null) =>
+      year === null ? Number.MAX_SAFE_INTEGER : Math.abs(year - sourceYear);
+    withYear.sort((a, b) => distance(a.year) - distance(b.year));
+  }
+
+  const picked = withYear[0] ?? null;
+  console.info("[musicbrainz] Suggestion lookup result", {
+    ...searchLog,
+    mbid,
+    releaseCount: releases.length,
+    candidateCount: candidates.length,
+    picked: picked ? { title: picked.title, year: picked.year } : null,
+  });
+
+  return picked;
 }
 
 export async function lookupRelease(

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -24,7 +24,7 @@ import {
 } from "../music-item-creator";
 import { hydrateItemStacks } from "../hydrate-item-stacks";
 import { UnsupportedMusicLinkError } from "../scraper";
-import { findPendingSuggestionForItem } from "../suggestions";
+import { ensureSuggestionForItemNow, findPendingSuggestionForItem } from "../suggestions";
 import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
 import type {
   CreateMusicItemInput,
@@ -494,9 +494,13 @@ musicItemRoutes.patch("/:id", async (c) => {
   let suggestion = null;
   if (input.listenStatus === "listened") {
     try {
-      suggestion = await findPendingSuggestionForItem(id);
-    } catch {
+      // Prefetched suggestion if one is ready, else a bounded on-demand
+      // lookup — covers items marked listened before the background prefetch
+      // finished (or whose prefetch failed).
+      suggestion = await ensureSuggestionForItemNow(id);
+    } catch (err) {
       // Non-critical — suggestion lookup must not block the status update
+      console.error("[api] suggestion lookup failed during PATCH", id, err);
     }
   }
 

--- a/server/suggestions.ts
+++ b/server/suggestions.ts
@@ -83,21 +83,67 @@ export async function findPendingSuggestionForItem(
   return findPendingSuggestionForArtist(itemRow.artistName);
 }
 
+export type SuggestionFetchOutcome =
+  // A new pending suggestion was stored.
+  | "stored"
+  // The artist already has a pending suggestion — nothing to do.
+  | "already-pending"
+  // MusicBrainz has no untracked release to suggest; retried after a day.
+  | "no-candidates"
+  // The lookup failed (network, rate limit, blocked UA); retried on the
+  // next sweep or creation — transient failures must not back off for 24h.
+  | "error"
+  // No artist name, or the artist is inside its no-candidates backoff window.
+  | "skipped";
+
+// Artists whose last lookup found nothing suggestible — don't hammer
+// MusicBrainz for them on every attempt. Cleared on server restart.
+// Lookup *errors* deliberately do not enter this map.
+const emptyLookupBackoff = new Map<string, number>();
+const EMPTY_LOOKUP_BACKOFF_MS = 24 * 60 * 60 * 1000;
+
+// One lookup per artist at a time. Without this, the on-demand lookup at
+// state-change time can race the background prefetch fired at creation: both
+// pass the "no pending suggestion" check and both insert a row. A concurrent
+// caller joins the in-flight lookup instead.
+const inFlightByArtist = new Map<string, Promise<SuggestionFetchOutcome>>();
+
 /**
  * Look up one extra release by the item's artist on MusicBrainz and store it
  * as a pending suggestion. Skips artists that already have a pending
  * suggestion (one "extra" per artist) and never re-suggests a release that is
  * already tracked or was previously suggested (accepted or dismissed).
- *
- * Returns true when a new suggestion was stored.
  */
-export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<boolean> {
-  if (!item.artist_name) return false;
+export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<SuggestionFetchOutcome> {
+  const artistName = item.artist_name;
+  if (!artistName) return "skipped";
+
+  const artistKey = normalize(artistName);
+  const inFlight = inFlightByArtist.get(artistKey);
+  if (inFlight) return inFlight;
+
+  const run = fetchAndStoreSuggestionLocked({ ...item, artist_name: artistName }, artistKey);
+  inFlightByArtist.set(artistKey, run);
+  try {
+    return await run;
+  } finally {
+    inFlightByArtist.delete(artistKey);
+  }
+}
+
+async function fetchAndStoreSuggestionLocked(
+  item: ItemSummary & { artist_name: string },
+  backoffKey: string,
+): Promise<SuggestionFetchOutcome> {
+  const backoffUntil = emptyLookupBackoff.get(backoffKey);
+  if (backoffUntil !== undefined && backoffUntil > Date.now()) {
+    return "skipped";
+  }
 
   try {
     const previousSuggestions = await suggestionsForArtist(item.artist_name);
     if (previousSuggestions.some((row) => row.status === "pending")) {
-      return false;
+      return "already-pending";
     }
 
     // Exclude releases already in the library…
@@ -122,7 +168,10 @@ export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<boolea
       sourceYear: item.year,
     });
 
-    if (!suggestion) return false;
+    if (!suggestion) {
+      emptyLookupBackoff.set(backoffKey, Date.now() + EMPTY_LOOKUP_BACKOFF_MS);
+      return "no-candidates";
+    }
 
     await db.insert(itemSuggestions).values({
       sourceItemId: item.id,
@@ -133,10 +182,19 @@ export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<boolea
       musicbrainzReleaseId: suggestion.musicbrainzReleaseId,
       status: "pending",
     });
-    return true;
+    emptyLookupBackoff.delete(backoffKey);
+    console.info("[suggestions] stored suggestion", {
+      artist: item.artist_name,
+      title: suggestion.title,
+      sourceItemId: item.id,
+    });
+    return "stored";
   } catch (err) {
-    console.error("[suggestions] Failed to fetch/store suggestion for item", item.id, err);
-    return false;
+    console.error(
+      `[suggestions] lookup failed for artist "${item.artist_name}" (item ${item.id}):`,
+      err,
+    );
+    return "error";
   }
 }
 
@@ -152,18 +210,65 @@ export function fetchSuggestionInBackground(item: ItemSummary): void {
   });
 }
 
-// Artists whose last lookup found nothing suggestible — don't hammer
-// MusicBrainz for them on every sweep. Cleared on server restart.
-const emptyLookupBackoff = new Map<string, number>();
-const EMPTY_LOOKUP_BACKOFF_MS = 24 * 60 * 60 * 1000;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resolve a suggestion for an item at state-change time, looking one up on
+ * the spot when nothing was prefetched — e.g. the item was marked listened
+ * seconds after being added (before the background prefetch finished), or the
+ * earlier prefetch failed. Bounded so the status update stays responsive: on
+ * timeout the lookup keeps running in the background and its result is
+ * stored for next time.
+ */
+export async function ensureSuggestionForItemNow(
+  itemId: number,
+  timeoutMs = 4_500,
+): Promise<StoredSuggestion | null> {
+  const prefetched = await findPendingSuggestionForItem(itemId);
+  if (prefetched) return prefetched;
+
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
+
+  const itemRow = await db
+    .select({
+      artistName: artists.name,
+      year: musicItems.year,
+      mbArtistId: musicItems.musicbrainzArtistId,
+    })
+    .from(musicItems)
+    .innerJoin(artists, eq(musicItems.artistId, artists.id))
+    .where(eq(musicItems.id, itemId))
+    .get();
+  if (!itemRow?.artistName) return null;
+
+  console.info("[suggestions] no prefetched suggestion — looking up on demand", {
+    itemId,
+    artist: itemRow.artistName,
+  });
+
+  const lookup = fetchAndStoreSuggestion({
+    id: itemId,
+    artist_name: itemRow.artistName,
+    year: itemRow.year,
+    musicbrainz_artist_id: itemRow.mbArtistId,
+  });
+  const outcome = await Promise.race([lookup, sleep(timeoutMs).then(() => "timeout" as const)]);
+
+  if (outcome === "timeout") {
+    console.warn("[suggestions] on-demand lookup timed out; result will store in background", {
+      itemId,
+    });
+    return null;
+  }
+
+  return findPendingSuggestionForItem(itemId);
+}
 
 /** MusicBrainz allows ~1 request/second; each artist lookup makes up to two. */
 function sweepThrottleMs(): number {
   const fromEnv = Number(process.env.OTB_SUGGESTION_SWEEP_THROTTLE_MS);
   return Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 2_500;
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Ensure every artist with at least one 'to-listen' item has a pending
@@ -204,6 +309,7 @@ export async function ensureSuggestionsForToListenArtists(): Promise<void> {
 
   const now = Date.now();
   let fetched = 0;
+  const outcomes: Record<string, number> = {};
   for (const [key, candidate] of perArtist) {
     if (covered.has(key)) continue;
     const backoffUntil = emptyLookupBackoff.get(key);
@@ -212,22 +318,17 @@ export async function ensureSuggestionsForToListenArtists(): Promise<void> {
     if (fetched > 0) await sleep(sweepThrottleMs());
     fetched += 1;
 
-    const stored = await fetchAndStoreSuggestion({
+    const outcome = await fetchAndStoreSuggestion({
       id: candidate.itemId,
       artist_name: candidate.artistName,
       year: candidate.year,
       musicbrainz_artist_id: candidate.mbArtistId,
     });
-
-    if (stored) {
-      emptyLookupBackoff.delete(key);
-    } else {
-      emptyLookupBackoff.set(key, now + EMPTY_LOOKUP_BACKOFF_MS);
-    }
+    outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
   }
 
   if (fetched > 0) {
-    console.log(`[suggestions] sweep looked up ${fetched} artist(s)`);
+    console.log(`[suggestions] sweep looked up ${fetched} artist(s):`, outcomes);
   }
 }
 

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -107,17 +107,48 @@ describe("findSuggestedRelease", () => {
     expect(result?.title).toBe("Chiastic Slide");
   });
 
-  test("returns null on fetch error", async () => {
-    spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network error"));
+  test("ranks undated releases last instead of treating them as a perfect year match", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistReleasesResponse([
+        { id: "r1", title: "Undated Compilation" },
+        { id: "r2", title: "Dead Men Don't Smoke Marijuana", date: "1994" },
+      ]),
+    );
 
     const result = await findSuggestedRelease({
       mbArtistId: "artist-uuid",
-      artistName: "Autechre",
+      artistName: "S. E. Rogie",
       trackedTitles: new Set(),
-      sourceYear: 1995,
+      sourceYear: 2022,
     });
 
-    expect(result).toBeNull();
+    expect(result?.title).toBe("Dead Men Don't Smoke Marijuana");
+  });
+
+  test("throws on fetch error so callers can distinguish failure from no-candidates", async () => {
+    spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("network error"));
+
+    expect(
+      findSuggestedRelease({
+        mbArtistId: "artist-uuid",
+        artistName: "Autechre",
+        trackedTitles: new Set(),
+        sourceYear: 1995,
+      }),
+    ).rejects.toThrow("network error");
+  });
+
+  test("throws on a non-2xx MusicBrainz response (e.g. rate limiting)", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("rate limited", { status: 503 }));
+
+    expect(
+      findSuggestedRelease({
+        mbArtistId: "artist-uuid",
+        artistName: "Autechre",
+        trackedTitles: new Set(),
+        sourceYear: 1995,
+      }),
+    ).rejects.toThrow("503");
   });
 });
 

--- a/tests/unit/suggestions.test.ts
+++ b/tests/unit/suggestions.test.ts
@@ -7,6 +7,7 @@ import { normalize } from "../../server/utils";
 import {
   fetchAndStoreSuggestion,
   findPendingSuggestionForItem,
+  ensureSuggestionForItemNow,
   ensureSuggestionsForToListenArtists,
   __clearSuggestionSweepBackoff,
 } from "../../server/suggestions";
@@ -45,50 +46,88 @@ const testSuggestion: musicbrainz.SuggestedRelease = {
 };
 
 describe("fetchAndStoreSuggestion", () => {
+  beforeEach(() => {
+    __clearSuggestionSweepBackoff();
+  });
+
   afterEach(() => {
     mock.restore();
   });
 
-  test("does nothing when item has no artist_name", async () => {
+  test("skips when item has no artist_name", async () => {
     const mbSpy = spyOn(musicbrainz, "findSuggestedRelease");
 
-    const stored = await fetchAndStoreSuggestion({
+    const outcome = await fetchAndStoreSuggestion({
       id: 1,
       artist_name: null,
       year: null,
       musicbrainz_artist_id: null,
     });
 
-    expect(stored).toBe(false);
+    expect(outcome).toBe("skipped");
     expect(mbSpy).not.toHaveBeenCalled();
   });
 
-  test("does nothing when findSuggestedRelease returns null", async () => {
-    spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(null);
+  test("reports no-candidates when findSuggestedRelease returns null, then backs off", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(null);
     const { itemId } = await createArtistWithItem("Nothing Found FM", "Static");
 
-    const stored = await fetchAndStoreSuggestion({
+    const first = await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Nothing Found FM",
+      year: 1994,
+      musicbrainz_artist_id: null,
+    });
+    const second = await fetchAndStoreSuggestion({
       id: itemId,
       artist_name: "Nothing Found FM",
       year: 1994,
       musicbrainz_artist_id: null,
     });
 
-    expect(stored).toBe(false);
+    expect(first).toBe("no-candidates");
+    expect(second).toBe("skipped");
+    expect(mbSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports error without backing off when the lookup throws", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockRejectedValue(
+      new Error("MusicBrainz artist search returned 503"),
+    );
+    const { itemId } = await createArtistWithItem("Rate Limited Band", "Throttled");
+
+    const first = await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Rate Limited Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+    // A transient failure must not suppress the artist for 24h — the next
+    // attempt retries the lookup.
+    const second = await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Rate Limited Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+
+    expect(first).toBe("error");
+    expect(second).toBe("error");
+    expect(mbSpy).toHaveBeenCalledTimes(2);
   });
 
   test("stores a pending suggestion for the item's artist", async () => {
     spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
     const { itemId } = await createArtistWithItem("Autechre Store Test", "Amber");
 
-    const stored = await fetchAndStoreSuggestion({
+    const outcome = await fetchAndStoreSuggestion({
       id: itemId,
       artist_name: "Autechre Store Test",
       year: 1994,
       musicbrainz_artist_id: null,
     });
 
-    expect(stored).toBe(true);
+    expect(outcome).toBe("stored");
     const row = await db
       .select()
       .from(itemSuggestions)
@@ -116,9 +155,38 @@ describe("fetchAndStoreSuggestion", () => {
       musicbrainz_artist_id: null,
     });
 
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(first).toBe("stored");
+    expect(second).toBe("already-pending");
     expect(mbSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent calls for the same artist share one lookup and store one row", async () => {
+    // The background prefetch fired at creation and the on-demand lookup at
+    // state-change time can overlap — they must not both insert.
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(testSuggestion), 30)),
+    );
+    const { itemId } = await createArtistWithItem("Concurrent Band", "Race Album");
+    const summary = {
+      id: itemId,
+      artist_name: "Concurrent Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    };
+
+    const [first, second] = await Promise.all([
+      fetchAndStoreSuggestion(summary),
+      fetchAndStoreSuggestion(summary),
+    ]);
+
+    expect(first).toBe("stored");
+    expect(second).toBe("stored");
+    expect(mbSpy).toHaveBeenCalledTimes(1);
+    const rows = await db
+      .select()
+      .from(itemSuggestions)
+      .where(eq(itemSuggestions.sourceItemId, itemId));
+    expect(rows.length).toBe(1);
   });
 
   test("excludes previously suggested (dismissed) titles from the next lookup", async () => {
@@ -150,6 +218,10 @@ describe("fetchAndStoreSuggestion", () => {
 });
 
 describe("findPendingSuggestionForItem", () => {
+  beforeEach(() => {
+    __clearSuggestionSweepBackoff();
+  });
+
   afterEach(() => {
     mock.restore();
   });
@@ -197,6 +269,79 @@ describe("findPendingSuggestionForItem", () => {
   });
 });
 
+describe("ensureSuggestionForItemNow", () => {
+  beforeEach(() => {
+    __clearSuggestionSweepBackoff();
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+  });
+
+  afterEach(() => {
+    mock.restore();
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+  });
+
+  test("returns the prefetched suggestion without a live lookup", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    const { itemId } = await createArtistWithItem("Prefetched Now Band", "Ready Album");
+    await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Prefetched Now Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+    mbSpy.mockClear();
+
+    const found = await ensureSuggestionForItemNow(itemId);
+
+    expect(found?.title).toBe("Tri Repetae");
+    expect(mbSpy).not.toHaveBeenCalled();
+  });
+
+  test("looks up a suggestion on demand when nothing was prefetched", async () => {
+    // The exact race the prompt used to lose: item marked listened before the
+    // background prefetch stored anything.
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    const { itemId } = await createArtistWithItem("On Demand Band", "Fresh Album");
+
+    const found = await ensureSuggestionForItemNow(itemId);
+
+    expect(mbSpy).toHaveBeenCalledTimes(1);
+    expect(found?.title).toBe("Tri Repetae");
+    expect(found?.status).toBe("pending");
+  });
+
+  test("returns null when the lookup exceeds the timeout, but stores in background", async () => {
+    let resolveLookup: (value: musicbrainz.SuggestedRelease) => void;
+    spyOn(musicbrainz, "findSuggestedRelease").mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLookup = resolve;
+      }),
+    );
+    const { itemId } = await createArtistWithItem("Slow Lookup Band", "Slow Album");
+
+    const found = await ensureSuggestionForItemNow(itemId, 50);
+    expect(found).toBeNull();
+
+    // The in-flight lookup completes later and stores the suggestion for
+    // the next state change.
+    resolveLookup!(testSuggestion);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const later = await findPendingSuggestionForItem(itemId);
+    expect(later?.title).toBe("Tri Repetae");
+  });
+
+  test("does not perform a live lookup under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease");
+    const { itemId } = await createArtistWithItem("Disabled Now Band", "Quiet Album");
+
+    const found = await ensureSuggestionForItemNow(itemId);
+
+    expect(found).toBeNull();
+    expect(mbSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("ensureSuggestionsForToListenArtists", () => {
   beforeEach(() => {
     __clearSuggestionSweepBackoff();
@@ -211,8 +356,6 @@ describe("ensureSuggestionsForToListenArtists", () => {
   });
 
   test("prefetches a suggestion for a to-listen artist with none pending", async () => {
-    // Give artists from earlier tests pending suggestions so the sweep only
-    // looks at the artist created here.
     const uncoveredName = `Sweep Band ${Date.now()}`;
     const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
     const { itemId } = await createArtistWithItem(uncoveredName, "Sweep Album");
@@ -252,6 +395,20 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
     expect(callsAfterFirst).toBe(1);
     expect(callsAfterSecond).toBe(1);
+  });
+
+  test("retries artists whose lookup errored", async () => {
+    const flakyName = `Flaky Band ${Date.now()}`;
+    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockRejectedValue(
+      new Error("MusicBrainz artist lookup returned 503"),
+    );
+    await createArtistWithItem(flakyName, "Retry Album");
+
+    await ensureSuggestionsForToListenArtists();
+    await ensureSuggestionsForToListenArtists();
+
+    const calls = mbSpy.mock.calls.filter((c) => c[0].artistName === flakyName).length;
+    expect(calls).toBe(2);
   });
 
   test("no-ops under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {


### PR DESCRIPTION
## Why the suggestion prompt has never worked in production

The `item_suggestions` table **does not exist in the production database**. Migration `0007_item_suggestions` was retro-inserted into the drizzle journal with a fabricated timestamp (`1775150000000`) slotted between 0006 and 0008. Drizzle's migrator only applies entries newer than the last applied migration's timestamp, so any database that had already applied 0008 — production — skipped 0007 forever. Every suggestion query has thrown `no such table` since, swallowed by the surrounding error handling, while fresh databases (tests, CI, previews) applied the chain in order and worked.

Confirmed against production: `POST /api/music-items/:id/suggestion/accept` returns **500** for any id, where a present-but-empty table returns 404 — while MusicBrainz lookups from the same server (`POST /api/release/lookup`) succeed, ruling out network/UA causes.

## Changes

**Migration heal**
- Add `0012_ensure_item_suggestions` with a current timestamp, recreating the table and index with `IF NOT EXISTS` (no-op for databases that did apply 0007). Verified against a simulated production database — last applied timestamp past 0007, table absent — that `migrate()` now creates it.
- Document the backdated-journal hazard in the `db-migration` skill.

**Robustness for the state-change flow**
- `PATCH` to `listened` now falls back to a bounded (4.5s) on-demand MusicBrainz lookup when no suggestion is prefetched — covers items marked listened before the background prefetch finishes; on timeout the in-flight lookup still stores its result for next time.
- Lookups are serialized per artist so the on-demand path joins an in-flight background prefetch instead of racing it and double-inserting.
- `findSuggestedRelease` now throws on network errors and non-2xx responses instead of returning null, and `fetchAndStoreSuggestion` reports a typed outcome — only a genuine "no candidates" result backs off for 24h; transient failures retry.
- Every pipeline step logs (artist match, release/candidate counts, pick, store/skip reason) so production failures are visible in server logs.
- Identify the app to MusicBrainz with the real repo URL — the placeholder User-Agent violated MB's identification policy.
- Rank undated releases last when picking the closest-in-year candidate instead of treating an unknown year as a perfect match.

## Testing

- 489 unit tests pass (16 new/updated across `suggestions` and `musicbrainz`), typecheck and lint clean.
- Migration verified on both a fresh database (full chain applies, 0012 no-ops) and a simulated production database (0012 creates the table).
- End-to-end reproduction with real captured MusicBrainz payloads for S.E. Rogie: marking a release listened immediately after adding now returns a suggestion (~1.6s) instead of null, with a single stored row.

After deploy, the startup sweep will prefetch a suggestion for every artist with a to-listen release, and marking any release listened will surface the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNh3bbGyop3RcWb1ouERHx

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNh3bbGyop3RcWb1ouERHx)_