### PR TITLE
chore(native): add mac:bootstrap to install Mac build prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cap:add": "cap add ios",
     "cap:sync": "cap sync ios",
     "cap:open": "cap open ios",
+    "mac:bootstrap": "bash scripts/bootstrap-mac.sh",
     "mac": "bash scripts/build-mac.sh",
     "mac:install": "bash scripts/build-mac.sh --install",
     "mac:local": "OTB_APP_URL=http://localhost:3000 bash scripts/build-mac.sh --install",

--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# One-time setup for building the native Mac app on a fresh Mac — one command.
+#
+#   bun run mac:bootstrap    (or: bash scripts/bootstrap-mac.sh)
+#
+# `bun run mac` / `mac:install` can build, sign, and launch the Catalyst app
+# without ever opening Xcode — but only once the toolchain it shells out to is in
+# place. That toolchain (Xcode, Bun, CocoaPods, a writable Ruby, ImageMagick) and
+# a signing identity are exactly the friction when you move to a *second* Mac.
+# This script installs and verifies all of it, so a new machine goes from a bare
+# checkout to a runnable share-sheet build in two commands:
+#
+#   bash scripts/bootstrap-mac.sh   # this — installs + verifies prerequisites
+#   bun run mac:install             # build → sign → /Applications → launch
+#
+# It's idempotent: every step checks first and only acts on what's missing, so
+# re-running it is a safe way to diagnose a half-set-up machine. It never uses
+# sudo silently — anything needing elevation (Xcode license, the Xcode path) is
+# printed as an instruction, not run for you.
+#
+# See docs/ios-native-app.md for the why behind each prerequisite.
+
+set -euo pipefail
+cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+# Reuse the same team default and logger shape as the build scripts so output
+# reads consistently across the native tooling.
+DEV_TEAM="${OTB_DEV_TEAM:-W2BS7F6CHM}"
+log()  { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; }
+
+# Track soft failures (things we can't fix for the user, like a full-Xcode or
+# Apple-ID install) so we can exit non-zero with a single summary at the end
+# rather than aborting on the first one — the user should see the whole list.
+BLOCKERS=()
+
+[[ "$(uname)" == "Darwin" ]] || { fail "This script only runs on macOS."; exit 1; }
+
+# --- Homebrew -----------------------------------------------------------------
+# Everything below installs through Homebrew, so it comes first. We don't attempt
+# the interactive Homebrew installer here (it wants its own confirmation and sudo
+# flow); if it's absent we point at the one-liner and stop, since nothing else
+# can proceed without it.
+if ! command -v brew >/dev/null 2>&1; then
+  fail "Homebrew not found — install it first, then re-run this script:"
+  echo '    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' >&2
+  exit 1
+fi
+ok "Homebrew present"
+
+# --- Homebrew formulae --------------------------------------------------------
+# command -v is the truth for "is it usable", not `brew list` — a formula can be
+# installed but shadowed, and the build scripts call these by name on PATH.
+#   bun         — the project runtime / task runner
+#   cocoapods   — `pod install` during cap add (two local pods, no network)
+#   ruby        — a *writable* Ruby; native_regenerate refuses system Ruby 2.6
+#   imagemagick — `magick`, needed by brand:assets for the app icon + splash
+install_formula() {
+  local cmd="$1" formula="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    ok "$cmd present"
+  else
+    log "Installing $formula"
+    brew install "$formula"
+    ok "$cmd installed"
+  fi
+}
+
+install_formula bun    oven-sh/bun/bun
+install_formula pod    cocoapods
+install_formula magick imagemagick
+
+# Ruby is special. The system Ruby at /usr/bin/ruby satisfies `command -v ruby`
+# but is the exact read-only 2.6 the build refuses, and Homebrew's ruby is
+# keg-only (not linked, to avoid clobbering system Ruby) — so `command -v ruby`
+# stays /usr/bin/ruby even once it's installed. Check for the *keg* directly,
+# which is precisely what native_regenerate resolves against.
+brew_ruby="$(brew --prefix ruby 2>/dev/null)/bin/ruby"
+if [[ -x "$brew_ruby" ]]; then
+  ok "Homebrew ruby present ($brew_ruby)"
+else
+  log "Installing ruby (system Ruby is read-only and rejected by the build)"
+  brew install ruby
+  ok "ruby installed — the build resolves it via \`brew --prefix ruby\`, no linking needed"
+fi
+
+# --- Xcode --------------------------------------------------------------------
+# A Catalyst app has to be *compiled*, so the full Xcode is non-negotiable — the
+# Command Line Tools alone can't build it. Xcode ships only through the App Store,
+# which we can't script, so here we can only detect and instruct.
+if xcodebuild -version >/dev/null 2>&1; then
+  ok "Xcode present ($(xcodebuild -version | head -1))"
+else
+  fail "Full Xcode not found (Command Line Tools alone can't build a Catalyst app)."
+  echo "    1. Install Xcode from the App Store." >&2
+  echo "    2. Point the toolchain at it: sudo xcode-select -s /Applications/Xcode.app" >&2
+  echo "    3. Accept the license:        sudo xcodebuild -license accept" >&2
+  BLOCKERS+=("Install full Xcode and select it with xcode-select")
+fi
+
+# --- Signing identity ---------------------------------------------------------
+# `mac:install` signs automatically, but only if Xcode holds an Apple ID whose
+# team can vend an "Apple Development" certificate. Presence of such an identity
+# in the keychain is the cheapest proxy for "you're signed in and provisioned".
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "Apple Development"; then
+  ok "Apple Development signing identity present"
+else
+  fail "No 'Apple Development' signing identity found."
+  echo "    Open Xcode ▸ Settings ▸ Accounts, add the Apple ID for team $DEV_TEAM," >&2
+  echo "    then let Xcode create a development certificate for it." >&2
+  BLOCKERS+=("Add your Apple ID (team $DEV_TEAM) in Xcode ▸ Settings ▸ Accounts")
+fi
+
+# --- Ingest key (soft) --------------------------------------------------------
+# Not required to *build* — the build falls back to a placeholder — but without a
+# real key the share sheet posts to nowhere, which is the whole point on a second
+# machine. Warn, don't block.
+if grep -q '^OTB_INGEST_API_KEY=' .env 2>/dev/null; then
+  ok "OTB_INGEST_API_KEY found in .env"
+else
+  warn "No OTB_INGEST_API_KEY in .env — the app will build, but shares won't post."
+  warn "  Copy a .env with a real key from your other machine before mac:install."
+fi
+
+# --- Summary ------------------------------------------------------------------
+echo
+if (( ${#BLOCKERS[@]} == 0 )); then
+  ok "All build prerequisites satisfied. Next:  bun install && bun run mac:install"
+else
+  fail "Setup incomplete — resolve these, then re-run this script:"
+  for b in "${BLOCKERS[@]}"; do echo "    • $b" >&2; done
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds `scripts/bootstrap-mac.sh` and a `bun run mac:bootstrap` alias that installs and verifies the toolchain the native Mac build needs, so a second Mac goes from a bare checkout to a signed share-sheet build in two commands:

```bash
bun run mac:bootstrap    # installs + verifies prerequisites
bun install
bun run mac:install      # build → sign → /Applications → launch
```

## Why

`bun run mac`/`mac:install` can build, sign, and launch the Catalyst app without opening Xcode — but only once the toolchain it shells out to is in place. That toolchain (Xcode, Bun, CocoaPods, a *writable* Ruby, ImageMagick) plus a signing identity is exactly the friction when moving to another Mac. This turns the setup half of `docs/ios-native-app.md` into one command.

## Behavior

- **Idempotent + self-diagnosing** — every prerequisite reports `✓` or prints the exact fix; safe to re-run to diagnose a half-set-up machine.
- **Never silent sudo** — anything needing elevation (full Xcode, `xcode-select`, license) is printed as an instruction, not run for you.
- **Ruby checked correctly** — verifies the keg-only Homebrew Ruby at `$(brew --prefix ruby)/bin/ruby` (what `native_regenerate` actually uses), not `command -v ruby`, which stays the rejected system Ruby.
- **Soft-warns** on a missing `OTB_INGEST_API_KEY` — the app builds, but the share sheet won't post without a real key.
- Blockers it can't fix for you (full Xcode, Apple ID sign-in) are collected into a single non-zero summary instead of aborting on the first miss.

## Testing

Ran on an already-configured Mac — reports all prerequisites green (`exit 0`); `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)