### PR TITLE
fix: make the suggestion dialogue usable on the release page

### DIFF
--- a/playwright/suggestion-on-listened.spec.ts
+++ b/playwright/suggestion-on-listened.spec.ts
@@ -53,4 +53,50 @@ test("suggestion modal appears when a release is marked listened on the release 
   await expect(modal).toBeVisible({ timeout: 5_000 });
   await expect(modal).toContainText("Tri Repetae");
   await expect(modal).toContainText("Autechre");
+
+  // It must overlay the viewport, not sit in document flow below the release
+  // (the release-page body class used to override its fixed positioning).
+  const position = await modal.evaluate((el) => getComputedStyle(el).position);
+  expect(position).toBe("fixed");
+});
+
+test("accepting a suggestion adds the release to the to-listen list", async ({ page, request }) => {
+  const res = await request.post("/api/music-items", {
+    data: { title: "Amber", artistName: "Autechre", listenStatus: "to-listen", year: 1994 },
+  });
+  const item = await res.json();
+
+  // Stand in for the MusicBrainz prefetch, which is disabled under test.
+  await request.post("/api/__test__/suggestions", {
+    data: {
+      sourceItemId: item.id,
+      title: "Tri Repetae",
+      artistName: "Autechre",
+      itemType: "album",
+      year: 1995,
+    },
+  });
+
+  await page.goto(`/r/${item.id}`);
+  await page.locator("#status-select").selectOption("listened");
+
+  const modal = page.locator("#suggestion-picker-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+
+  // Accept must POST to the real item id (a live prop read after the modal
+  // closed used to send /api/music-items/null/... and create nothing).
+  const acceptResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/music-items/${item.id}/suggestion/accept`) &&
+      response.request().method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#suggestion-picker-accept").click();
+  expect((await acceptResponse).status()).toBe(201);
+
+  const list = await (await request.get("/api/music-items?listenStatus=to-listen")).json();
+  const items = Array.isArray(list) ? list : list.items;
+  const added = items.find((entry: { title: string }) => entry.title === "Tri Repetae");
+  expect(added).toBeTruthy();
+  expect(added.listen_status).toBe("to-listen");
 });

--- a/server/routes/test.ts
+++ b/server/routes/test.ts
@@ -8,6 +8,7 @@ import {
   stacks,
   stackParents,
   musicItemOrder,
+  itemSuggestions,
 } from "../db/schema";
 
 export const testRoutes = new Hono();
@@ -17,10 +18,30 @@ testRoutes.post("/reset", async (c) => {
   await db.delete(musicItemStacks);
   await db.delete(stackParents);
   await db.delete(musicLinks);
+  await db.delete(itemSuggestions);
   await db.delete(musicItems);
   await db.delete(musicItemOrder);
   await db.delete(artists);
   await db.delete(stacks);
   // sources are seeded/static — leave them alone
   return c.json({ success: true });
+});
+
+// Seed a pending suggestion directly, standing in for the MusicBrainz
+// prefetch (external lookups are disabled under test).
+testRoutes.post("/suggestions", async (c) => {
+  const body = await c.req.json();
+  const [inserted] = await db
+    .insert(itemSuggestions)
+    .values({
+      sourceItemId: body.sourceItemId,
+      title: body.title,
+      artistName: body.artistName,
+      itemType: body.itemType ?? "album",
+      year: body.year ?? null,
+      musicbrainzReleaseId: body.musicbrainzReleaseId ?? null,
+      status: "pending",
+    })
+    .returning();
+  return c.json(inserted, 201);
 });

--- a/src/lib/components/SuggestionPickerModal.svelte
+++ b/src/lib/components/SuggestionPickerModal.svelte
@@ -28,15 +28,28 @@
 
   async function accept(): Promise<void> {
     if (sourceItemId === null) return;
+    // Snapshot the id: destructured $props() reads are live, and onClosed()
+    // nulls the parent state this prop is bound to.
+    const itemId = sourceItemId;
     onClosed();
-    await api.acceptSuggestion(sourceItemId);
+    try {
+      await api.acceptSuggestion(itemId);
+    } catch {
+      alert("Failed to add release.");
+      return;
+    }
     onAccepted();
   }
 
   async function dismiss(): Promise<void> {
     if (sourceItemId === null) return;
+    const itemId = sourceItemId;
     onClosed();
-    await api.dismissSuggestion(sourceItemId);
+    try {
+      await api.dismissSuggestion(itemId);
+    } catch {
+      alert("Failed to dismiss suggestion.");
+    }
   }
 
   $effect(() => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2767,7 +2767,10 @@ a:hover {
   }
 }
 
-.release-page-body > :not(.release-page__backdrop):not(.player-window),
+/* .link-picker overlays (link picker, suggestion picker) must keep their
+   fixed positioning — this rule would otherwise drop them into document
+   flow below the release. */
+.release-page-body > :not(.release-page__backdrop):not(.player-window):not(.link-picker),
 .release-page-body .main {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
## Problem

The release detail page already reuses the same \`SuggestionPickerModal\` as the home page, but two bugs made it broken in practice:

1. **The dialogue rendered in the wrong place.** The release page adds a \`release-page-body\` class whose stacking rule (\`.release-page-body > :not(...)\`) has higher specificity than \`.link-picker\` and overrode the modal's \`position: fixed\` with \`relative\` — dropping it into document flow *below* the release, where it's easy to miss. On the home page the same modal is a centered overlay.

2. **Accepting a suggestion added nothing to the "to listen" list.** In Svelte 5, destructured \`$props()\` are live getters. \`accept()\` called \`onClosed()\` — which nulls the parent's bound \`sourceItemId\` — *before* reading the id, so the request went to \`POST /api/music-items/null/suggestion/accept\` and silently 400'd. \`dismiss()\` had the identical bug (dismissed suggestions stayed pending).

## Fix

- Exclude \`.link-picker\` overlays from the \`release-page-body\` stacking rule so the modal keeps its fixed, centered positioning on both pages.
- Snapshot \`sourceItemId\` into a local before calling \`onClosed()\` in both \`accept()\` and \`dismiss()\`.
- Both handlers now surface a failed request with an \`alert(...)\` (matching the existing release-page error pattern) instead of failing invisibly — which is why bug 2 went unnoticed.

## Tests

- New e2e test covering the full accept flow: modal opens on the release page, accept returns 201, and the suggested release lands in the to-listen list. Plus a \`position: fixed\` assertion guarding the CSS regression.
- Added a \`/api/__test__/suggestions\` seed endpoint (MusicBrainz lookups are disabled under test) and made \`reset\` clear the \`item_suggestions\` table.

All green: typecheck, 489 unit tests, and the full 35-test chromium e2e suite.