### PR TITLE
Add rating filter to random pick feature

### DIFF
--- a/src/lib/components/BrowseControls.svelte
+++ b/src/lib/components/BrowseControls.svelte
@@ -10,7 +10,7 @@
     onPickRandom,
   }: {
     app: MachineHandle<typeof appMachine>;
-    onPickRandom: () => Promise<{ id: number } | null>;
+    onPickRandom: (rating?: number | null) => Promise<{ id: number } | null>;
   } = $props();
 
   const ctx = $derived(app.snapshot.context);
@@ -87,14 +87,74 @@
   let randomBtnText = $state("🎲 Pick One");
   let randomBtnDisabled = $state(false);
 
-  async function pickRandom(): Promise<void> {
+  // Press-and-hold on Pick One opens a menu to constrain the roll to a rating.
+  const RATING_OPTIONS: number[] = [5, 4.5, 4, 3.5, 3, 2.5, 2, 1.5, 1, 0.5];
+  const LONG_PRESS_MS = 450;
+  let ratingMenuOpen = $state(false);
+  let pickRandomEl: HTMLElement | undefined = $state();
+  let longPressTimer: ReturnType<typeof setTimeout> | undefined;
+  let longPressFired = false;
+
+  function ratingStars(value: number): string {
+    const full = Math.floor(value);
+    return "★".repeat(full) + (value - full >= 0.5 ? "½" : "");
+  }
+
+  function openRatingMenu(): void {
+    if (randomBtnDisabled) return;
+    ratingMenuOpen = true;
+  }
+
+  function closeRatingMenu(): void {
+    ratingMenuOpen = false;
+  }
+
+  function startLongPress(): void {
+    longPressFired = false;
+    clearLongPress();
+    longPressTimer = setTimeout(() => {
+      longPressFired = true;
+      openRatingMenu();
+    }, LONG_PRESS_MS);
+  }
+
+  function clearLongPress(): void {
+    if (longPressTimer !== undefined) {
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+  }
+
+  function onPickRandomClick(): void {
+    // Suppress the click that follows a long-press (it already opened the menu).
+    if (longPressFired) {
+      longPressFired = false;
+      return;
+    }
+    void pickRandom(null);
+  }
+
+  function onPickRandomContextMenu(event: Event): void {
+    // Prevent the native context / callout menu so hold-to-open works everywhere.
+    event.preventDefault();
+    clearLongPress();
+    longPressFired = true;
+    openRatingMenu();
+  }
+
+  function selectRating(rating: number | null): void {
+    closeRatingMenu();
+    void pickRandom(rating);
+  }
+
+  async function pickRandom(rating: number | null): Promise<void> {
     if (randomBtnDisabled) return;
     randomBtnDisabled = true;
     randomBtnText = "🎲 Rolling…";
     try {
-      const picked = await onPickRandom();
+      const picked = await onPickRandom(rating);
       if (!picked) {
-        randomBtnText = "🎲 Nothing yet";
+        randomBtnText = rating === null ? "🎲 Nothing yet" : "🎲 No matches";
         setTimeout(() => {
           randomBtnText = "🎲 Pick One";
           randomBtnDisabled = false;
@@ -116,10 +176,14 @@
       if (!browseToolsEl.contains(target)) {
         app.send({ type: "BROWSE_PANELS_CLOSED" });
       }
+      if (pickRandomEl instanceof HTMLElement && !pickRandomEl.contains(target)) {
+        closeRatingMenu();
+      }
     };
     const onEscape = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
         app.send({ type: "BROWSE_PANELS_CLOSED" });
+        closeRatingMenu();
       }
     };
     document.addEventListener("click", onDocumentClick);
@@ -141,15 +205,46 @@
           onclick={() => selectFilter(value)}>{label}</button
         >
       {/each}
-      <button
-        type="button"
-        id="pick-random-btn"
-        class="filter-btn filter-btn--action"
-        title="Pick a random item from To Listen"
-        aria-label="Pick a random item from To Listen"
-        disabled={randomBtnDisabled}
-        onclick={pickRandom}>{randomBtnText}</button
-      >
+      <div class="pick-random" bind:this={pickRandomEl}>
+        <button
+          type="button"
+          id="pick-random-btn"
+          class="filter-btn filter-btn--action"
+          title="Pick a random item from To Listen — hold to pick by rating"
+          aria-label="Pick a random item from To Listen. Press and hold to pick by star rating."
+          aria-haspopup="menu"
+          aria-expanded={ratingMenuOpen ? "true" : "false"}
+          disabled={randomBtnDisabled}
+          onclick={onPickRandomClick}
+          onpointerdown={startLongPress}
+          onpointerup={clearLongPress}
+          onpointerleave={clearLongPress}
+          onpointercancel={clearLongPress}
+          oncontextmenu={onPickRandomContextMenu}>{randomBtnText}</button
+        >
+        {#if ratingMenuOpen}
+          <div class="pick-random__menu" role="menu" aria-label="Pick a release rated">
+            <div class="pick-random__menu-heading">Pick one rated…</div>
+            <button
+              type="button"
+              class="pick-random__menu-item"
+              role="menuitem"
+              onclick={() => selectRating(null)}>Any rating</button
+            >
+            {#each RATING_OPTIONS as value (value)}
+              <button
+                type="button"
+                class="pick-random__menu-item"
+                role="menuitem"
+                onclick={() => selectRating(value)}
+              >
+                <span class="pick-random__menu-stars" aria-hidden="true">{ratingStars(value)}</span>
+                <span class="pick-random__menu-label">{value} star{value === 1 ? "" : "s"}</span>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
     </div>
     <div class="browse-tools" bind:this={browseToolsEl}>
       <div class="browse-tools__mobile-actions">

--- a/src/lib/components/MainPage.svelte
+++ b/src/lib/components/MainPage.svelte
@@ -4,6 +4,7 @@
   import { onMount, untrack } from "svelte";
   import type { ItemSuggestion, ListenStatus, MusicItemFull, StackWithCount } from "../../types";
   import { buildContextKey, buildMusicItemFilters } from "../../ui/domain/music-list";
+  import { normalizeStarRating } from "../../ui/components/star-rating";
   import { addFormMachine } from "../../ui/state/add-form-machine";
   import { appMachine } from "../../ui/state/app-machine";
   import {
@@ -253,13 +254,17 @@
     target.classList.remove("music-card--roulette");
   }
 
-  async function pickRandom(): Promise<{ id: number } | null> {
+  async function pickRandom(rating: number | null = null): Promise<{ id: number } | null> {
     const filters = buildMusicItemFilters("to-listen", ctx.currentStack);
     const result = await api.listMusicItems(filters);
-    if (result.items.length === 0) {
+    const pool =
+      rating === null
+        ? result.items
+        : result.items.filter((item) => normalizeStarRating(item.rating) === rating);
+    if (pool.length === 0) {
       return null;
     }
-    const picked = result.items[Math.floor(Math.random() * result.items.length)];
+    const picked = pool[Math.floor(Math.random() * pool.length)];
     await rouletteToCard(picked.id);
     await goto(`/r/${picked.id}`);
     return picked;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -902,6 +902,75 @@ select.input {
   color: var(--chrome-dark);
 }
 
+.pick-random {
+  position: relative;
+  margin-left: auto;
+  display: inline-flex;
+  /* Suppress the touch callout so press-and-hold opens our menu instead. */
+  -webkit-touch-callout: none;
+}
+
+.pick-random .filter-btn--action {
+  margin-left: 0;
+}
+
+.pick-random__menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  right: 0;
+  z-index: 40;
+  min-width: 160px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--chrome);
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-raised);
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.35);
+  padding: 2px;
+}
+
+.pick-random__menu-heading {
+  padding: 3px 8px 4px;
+  font-size: var(--text-sm, 0.75rem);
+  font-weight: bold;
+  color: #000000;
+  border-bottom: 1px solid var(--bevel-sunken);
+  margin-bottom: 2px;
+}
+
+.pick-random__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  color: #000000;
+  font-size: var(--text-base);
+  text-align: left;
+  cursor: pointer;
+}
+
+.pick-random__menu-item:hover,
+.pick-random__menu-item:focus-visible {
+  background: var(--chrome-mid);
+  outline: none;
+}
+
+.pick-random__menu-stars {
+  color: #b8860b;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.pick-random__menu-label {
+  margin-left: auto;
+  color: var(--chrome-dark, #555);
+  font-size: var(--text-sm, 0.75rem);
+}
+
 .browse-tools {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Enhanced the "Pick One" random selection feature with the ability to filter results by star rating. Users can now press and hold the button to open a menu and select a specific rating constraint, or pick from any rating as before.

## Key Changes
- **BrowseControls.svelte**: 
  - Modified `onPickRandom` callback signature to accept an optional `rating` parameter
  - Added long-press detection (450ms) to open a rating selection menu
  - Implemented rating menu UI with 10 rating options (5.0 down to 0.5 stars) plus "Any rating"
  - Added helper function `ratingStars()` to format star ratings with full and half stars
  - Enhanced button with pointer event handlers and context menu prevention for cross-platform support
  - Updated button accessibility attributes (`aria-haspopup`, `aria-expanded`)
  - Added logic to close menu on document click or Escape key

- **MainPage.svelte**:
  - Updated `pickRandom()` function to accept optional `rating` parameter
  - Added filtering logic to constrain the random pool to items matching the selected rating
  - Integrated `normalizeStarRating()` utility for consistent rating comparison
  - Updated error message to distinguish between "Nothing yet" (any rating) and "No matches" (filtered rating)

- **main.css**:
  - Added `.pick-random` container with relative positioning and touch callout suppression
  - Styled `.pick-random__menu` as a dropdown with scrolling support
  - Added menu item styling with hover/focus states
  - Implemented star display with golden color (#b8860b) and proper spacing

## Implementation Details
- Long-press detection uses pointer events for better mobile/touch support
- Context menu is prevented to allow press-and-hold to work consistently across platforms
- Menu closes automatically when clicking outside or pressing Escape
- Rating filtering uses exact matching via `normalizeStarRating()` for consistency
- Menu is positioned absolutely below the button with proper z-index layering

https://claude.ai/code/session_01LQxaVVxfGFWXaQmVuhfnjE