### PR TITLE
feat: let the share sheet set a scheduled reminder date

### DIFF
--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -7,8 +7,9 @@ import MobileCoreServices
 /// When the user taps "On The Beach" in the share sheet, iOS/macOS instantiates
 /// this controller inside the Share Extension process and hands us the shared
 /// content via `extensionContext`. We show a small compose form so the user can
-/// add an optional note and pick any number of lists (existing or new), then POST
-/// the link to the app's ingest endpoint (`/api/ingest/link`) with a `Bearer` token.
+/// add an optional note, pick any number of lists (existing or new), and set an
+/// optional scheduled reminder date, then POST the link to the app's ingest
+/// endpoint (`/api/ingest/link`) with a `Bearer` token.
 ///
 /// The extension talks to the server directly rather than opening the app, so a
 /// share succeeds even when the app isn't running.
@@ -40,6 +41,15 @@ final class ShareViewController: UIViewController {
     private var stackNames: [String] = []
     private var selectedListNames: [String] = []
 
+    /// Formats a chosen schedule as a locale-independent `yyyy-MM-dd` string —
+    /// the same shape the web date picker sends to `/api/music-items/:id/reminder`.
+    private static let scheduleFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
     private let compose = ComposeFormController()
     private lazy var navController = UINavigationController(rootViewController: compose)
 
@@ -65,7 +75,7 @@ final class ShareViewController: UIViewController {
 
         compose.onCancel = { [weak self] in self?.cancel() }
         compose.onPickList = { [weak self] in self?.pushListPicker() }
-        compose.onSubmit = { [weak self] note in self?.submit(note: note) }
+        compose.onSubmit = { [weak self] note, remindAt in self?.submit(note: note, remindAt: remindAt) }
 
         extractSharedURL { [weak self] url in
             guard let self else { return }
@@ -95,13 +105,13 @@ final class ShareViewController: UIViewController {
 
     // MARK: - Submit / cancel
 
-    private func submit(note: String) {
+    private func submit(note: String, remindAt: Date?) {
         guard let url = sharedURL else {
             cancel()
             return
         }
         compose.setPosting(true)
-        postLink(url: url, note: note, listNames: selectedListNames) { [weak self] result in
+        postLink(url: url, note: note, listNames: selectedListNames, remindAt: remindAt) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success:
@@ -231,6 +241,7 @@ final class ShareViewController: UIViewController {
         url: URL,
         note: String,
         listNames: [String],
+        remindAt: Date?,
         completion: @escaping (PostResult) -> Void
     ) {
         guard let endpoint = URL(string: baseURL + "/api/ingest/link") else {
@@ -245,6 +256,9 @@ final class ShareViewController: UIViewController {
         var payload: [String: Any] = ["url": url.absoluteString]
         if !note.isEmpty { payload["notes"] = note }
         if !listNames.isEmpty { payload["listNames"] = listNames }
+        // Send the schedule as a plain yyyy-MM-dd date, matching the web reminder
+        // control; the server parses it with `new Date(...)`.
+        if let remindAt { payload["remindAt"] = Self.scheduleFormatter.string(from: remindAt) }
 
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
@@ -279,19 +293,22 @@ final class ShareViewController: UIViewController {
     }
 }
 
-/// The compose form: an optional note field and a tappable "List" row, with
-/// Cancel/Add in the navigation bar. It owns no state and does no networking —
-/// it reports Cancel, Add (with the note text), and List taps back to its
+/// The compose form: an optional note field, a tappable "List" row, and a
+/// "Remind me" switch that reveals a date picker, with Cancel/Add in the
+/// navigation bar. It owns no state and does no networking — it reports Cancel,
+/// Add (with the note text and any chosen date), and List taps back to its
 /// container via closures.
 private final class ComposeFormController: UIViewController, UITextViewDelegate {
     var onCancel: (() -> Void)?
-    var onSubmit: ((String) -> Void)?
+    var onSubmit: ((String, Date?) -> Void)?
     var onPickList: (() -> Void)?
 
     private let urlLabel = UILabel()
     private let noteView = UITextView()
     private let notePlaceholder = UILabel()
     private let listValueLabel = UILabel()
+    private let scheduleSwitch = UISwitch()
+    private let datePicker = UIDatePicker()
     private let spinner = UIActivityIndicatorView(style: .medium)
     private lazy var addButton = UIBarButtonItem(
         title: "Add", style: .done, target: self, action: #selector(didTapAdd)
@@ -324,9 +341,19 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         notePlaceholder.font = .preferredFont(forTextStyle: .body)
         notePlaceholder.textColor = .placeholderText
 
-        let listRow = makeListRow()
+        // Schedule: a compact date picker revealed only when "Remind me" is on, so
+        // an unscheduled share sends no date. Default to tomorrow, and never let
+        // the user pick a past day.
+        datePicker.datePickerMode = .date
+        datePicker.preferredDatePickerStyle = .compact
+        datePicker.minimumDate = Calendar.current.startOfDay(for: Date())
+        datePicker.date = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        datePicker.isHidden = true
 
-        let stack = UIStackView(arrangedSubviews: [urlLabel, noteView, listRow])
+        let listRow = makeListRow()
+        let scheduleRow = makeScheduleRow()
+
+        let stack = UIStackView(arrangedSubviews: [urlLabel, noteView, listRow, scheduleRow, datePicker])
         stack.axis = .vertical
         stack.spacing = 12
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -392,6 +419,37 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         return container
     }
 
+    /// Builds the "Remind me" row: a title and a switch that reveals the date picker.
+    private func makeScheduleRow() -> UIView {
+        let container = UIView()
+        container.backgroundColor = .secondarySystemGroupedBackground
+        container.layer.cornerRadius = 10
+
+        let title = UILabel()
+        title.text = "Remind me"
+        title.font = .preferredFont(forTextStyle: .body)
+        title.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        scheduleSwitch.addTarget(self, action: #selector(didToggleSchedule), for: .valueChanged)
+        scheduleSwitch.setContentHuggingPriority(.required, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [title, scheduleSwitch])
+        row.axis = .horizontal
+        row.spacing = 8
+        row.alignment = .center
+        row.isLayoutMarginsRelativeArrangement = true
+        row.layoutMargins = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(row)
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: container.topAnchor),
+            row.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            row.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        return container
+    }
+
     // MARK: - Updates from the container
 
     func setURL(_ url: URL?) {
@@ -426,9 +484,17 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
     @objc private func didTapCancel() { onCancel?() }
     @objc private func didTapList() { onPickList?() }
 
+    /// Reveal or hide the date picker alongside the "Remind me" switch.
+    @objc private func didToggleSchedule() {
+        UIView.animate(withDuration: 0.2) {
+            self.datePicker.isHidden = !self.scheduleSwitch.isOn
+        }
+    }
+
     @objc private func didTapAdd() {
         let note = noteView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        onSubmit?(note)
+        let remindAt = scheduleSwitch.isOn ? datePicker.date : nil
+        onSubmit?(note, remindAt)
     }
 
     // MARK: - UITextViewDelegate

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -10,7 +10,7 @@ import { extractReleaseInfo, extractReleaseInfoFromWebContext } from "../vision"
 import { getWebContext } from "../google-vision";
 import { lookupRelease } from "../musicbrainz";
 import { db } from "../db";
-import { stacks, musicItemStacks } from "../db/schema";
+import { stacks, musicItemStacks, musicItems } from "../db/schema";
 import type { CreateMusicItemInput, ScanResult } from "../../src/types";
 
 interface EmailEnvelope {
@@ -46,6 +46,7 @@ export interface IngestStack {
 export type ListStacksFn = () => Promise<IngestStack[]>;
 export type ResolveOrCreateStackFn = (name: string) => Promise<IngestStack>;
 export type AttachItemToStackFn = (itemId: number, stackId: number) => Promise<void>;
+export type SetItemReminderFn = (itemId: number, remindAt: Date) => Promise<void>;
 
 export interface IngestRoutesDeps {
   scanPhoto?: ScanPhotoFn;
@@ -53,6 +54,7 @@ export interface IngestRoutesDeps {
   listStacks?: ListStacksFn;
   resolveOrCreateStack?: ResolveOrCreateStackFn;
   attachItemToStack?: AttachItemToStackFn;
+  setItemReminder?: SetItemReminderFn;
 }
 
 /** Every list, id + name, alphabetised — the payload the extension's picker shows. */
@@ -97,6 +99,30 @@ async function defaultAttachItemToStack(itemId: number, stackId: number): Promis
   await db.insert(musicItemStacks).values({ musicItemId: itemId, stackId }).onConflictDoNothing();
 }
 
+/** Set an item's scheduled reminder date — the share sheet's "Remind me". */
+async function defaultSetItemReminder(itemId: number, remindAt: Date): Promise<void> {
+  await db
+    .update(musicItems)
+    .set({ remindAt, updatedAt: new Date() })
+    .where(eq(musicItems.id, itemId));
+}
+
+/**
+ * Parse an optional `remindAt` scheduled date from a /link request body. Returns
+ * the parsed Date, `null` when absent/blank, or an `error` when present but not a
+ * valid date string — mirroring the strictness of the /:id/reminder endpoint so a
+ * mis-formatted client is surfaced rather than silently dropping the schedule.
+ */
+function parseRemindAt(body: unknown): { date: Date | null } | { error: string } {
+  if (!body || typeof body !== "object") return { date: null };
+  const { remindAt } = body as Record<string, unknown>;
+  if (remindAt === undefined || remindAt === null || remindAt === "") return { date: null };
+  if (typeof remindAt !== "string") return { error: "remindAt must be a date string" };
+  const date = new Date(remindAt);
+  if (isNaN(date.getTime())) return { error: "remindAt must be a valid date" };
+  return { date };
+}
+
 /**
  * Gather the list names a /link request wants the item filed into, from either
  * `listNames` (multi-select share sheet) or the legacy single `listName`.
@@ -135,6 +161,7 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
   const listStacks = deps.listStacks ?? defaultListStacks;
   const resolveOrCreateStack = deps.resolveOrCreateStack ?? defaultResolveOrCreateStack;
   const attachItemToStack = deps.attachItemToStack ?? defaultAttachItemToStack;
+  const setItemReminder = deps.setItemReminder ?? defaultSetItemReminder;
 
   const routes = new Hono();
 
@@ -252,6 +279,14 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
     // same list picked twice only files the item once.
     const listNames = collectListNames(body);
 
+    // Optional scheduled date ("Remind me" in the share sheet). Absent/blank
+    // leaves the item unscheduled; a present-but-invalid value is a client bug.
+    const remindAtResult = parseRemindAt(body);
+    if ("error" in remindAtResult) {
+      return c.json({ error: remindAtResult.error }, 400);
+    }
+    const remindAt = remindAtResult.date;
+
     // Notes are only meaningful for a freshly-created item; createMusicItemsFromUrl
     // returns a duplicate's existing item unchanged, so passing them there can never
     // clobber an existing note.
@@ -274,6 +309,12 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
       for (const result of results) {
         for (const list of lists) {
           await attachItemToStack(result.item.id, list.id);
+        }
+        // Apply the schedule to every returned item — including duplicates, so
+        // re-sharing an already-saved item to set (or update) its date works,
+        // just like re-sharing to file it into a list does.
+        if (remindAt) {
+          await setItemReminder(result.item.id, remindAt);
         }
         if (result.created) {
           scheduleAppleMusicBackfill(result.item.id);

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -10,6 +10,7 @@ const mockScan = mock();
 const mockListStacks = mock();
 const mockResolveOrCreateStack = mock();
 const mockAttachItemToStack = mock();
+const mockSetItemReminder = mock();
 
 // Mock the music-item-creator module before importing any route, overriding
 // only the functions the ingest routes call. bun's mock.module() persists
@@ -38,6 +39,7 @@ function makeApp() {
       listStacks: mockListStacks,
       resolveOrCreateStack: mockResolveOrCreateStack,
       attachItemToStack: mockAttachItemToStack,
+      setItemReminder: mockSetItemReminder,
     }),
   );
   return app;
@@ -365,6 +367,97 @@ describe("POST /api/ingest/link with list and notes", () => {
     const body = await res.json();
     expect(mockResolveOrCreateStack).not.toHaveBeenCalled();
     expect(body.lists).toEqual([]);
+  });
+});
+
+describe("POST /api/ingest/link with a scheduled date", () => {
+  const originalEnv = { ...process.env };
+  const url = "https://artist.bandcamp.com/album/cool-album";
+
+  beforeEach(() => {
+    process.env.INGEST_API_KEY = "test-secret";
+    delete process.env.INGEST_ENABLED;
+    mockCreateMany.mockReset();
+    mockSetItemReminder.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("sets the reminder on the created item", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 7, title: "Cool Album", primary_url: url } as any, created: true },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      { url, remindAt: "2026-08-01" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSetItemReminder).toHaveBeenCalledTimes(1);
+    const [itemId, date] = mockSetItemReminder.mock.calls[0];
+    expect(itemId).toBe(7);
+    expect(date).toBeInstanceOf(Date);
+    expect((date as Date).toISOString()).toBe(new Date("2026-08-01").toISOString());
+  });
+
+  it("also schedules a duplicate item, so re-sharing to set a date works", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 9, title: "Cool Album" } as any, created: false },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      { url, remindAt: "2026-08-01" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSetItemReminder).toHaveBeenCalledWith(9, expect.any(Date));
+  });
+
+  it("leaves the item unscheduled when no date is given", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 1, title: "Cool Album", primary_url: url } as any, created: true },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(app, { url }, { apiKey: "test-secret" });
+
+    expect(res.status).toBe(200);
+    expect(mockSetItemReminder).not.toHaveBeenCalled();
+  });
+
+  it("ignores a blank date", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 1, title: "Cool Album", primary_url: url } as any, created: true },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(app, { url, remindAt: "" }, { apiKey: "test-secret" });
+
+    expect(res.status).toBe(200);
+    expect(mockSetItemReminder).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid date and creates nothing", async () => {
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      { url, remindAt: "not-a-date" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("remindAt");
+    expect(mockCreateMany).not.toHaveBeenCalled();
+    expect(mockSetItemReminder).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Adds an optional **scheduled reminder date** to the native share extension's compose form. Sharing a link into On The Beach can now schedule when to listen, not just add a note and pick lists.

## Changes

**Native share extension** (`native/ShareExtension/ShareViewController.swift`)
- New **"Remind me"** switch that reveals a compact date picker (defaults to tomorrow, no past dates).
- When enabled, the chosen day is sent to `/api/ingest/link` as a locale-independent `yyyy-MM-dd` `remindAt` — the same shape the web reminder control uses.

**Ingest route** (`server/routes/ingest.ts`)
- `/link` now accepts an optional `remindAt`: absent/blank leaves the item unscheduled, a malformed value returns `400`, and a valid date sets the item's `remind_at` — the same field the release page's reminder control drives (feeding the "Scheduled" filter and reminder cron).
- The schedule is applied to every returned item, **including duplicates**, so re-sharing an already-saved item to set or update its date works — matching how re-sharing files an item into a list.
- Wired through an injectable `setItemReminder` dependency, matching the existing `resolveOrCreateStack` / `attachItemToStack` pattern.

**Tests** (`tests/unit/ingest.test.ts`)
- New coverage: reminder set on a created item, scheduling a duplicate, no date given, blank date ignored, and a `400` for an invalid date that creates nothing.

## Testing

- `bun test tests/unit/ingest.test.ts` — 50 pass
- lint (`oxlint`), format (`oxfmt --check`), and typecheck clean on the changed files

## Notes

- The Swift wasn't compiled in this environment (no Xcode) — verified by review; worth a quick build check.
- The date is day-granular (matching the web `type="date"` control). A specific time-of-day would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxBwXWtR6edUH9dDeWDSR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxBwXWtR6edUH9dDeWDSR9)_