### PR TITLE
Pull cover artwork when resolving an Apple Music release

### DIFF
--- a/docs/areas/integrations/apple-music.md
+++ b/docs/areas/integrations/apple-music.md
@@ -43,12 +43,18 @@ team-scoped catalogue access and expires. It is served from:
 
 `searchAppleMusic` (in `server/scraper.ts`) first tries the Apple Music Catalog
 API (`server/apple-music-catalog.ts`) using the developer token, then falls back
-to the iTunes Search API. Both return a `music.apple.com` URL; the catalogue API
-path yields URLs that carry the catalogue ids MusicKit needs for playback.
+to the iTunes Search API. Both return a `ServiceSearchResult` — the
+`music.apple.com` URL plus the release's cover `artworkUrl` when the service
+exposes one. The catalogue API path yields URLs that carry the catalogue ids
+MusicKit needs for playback; its artwork template is resolved to a concrete
+1200×1200 image (the iTunes path upscales `artworkUrl100` the same way).
 
 The lookup is wired into the shared secondary-link enrichment
 (`server/secondary-link-enrichment.ts`), so nothing else changes about when or
-how Apple Music links are attached to items.
+how Apple Music links are attached to items. When the resolved release carries
+artwork and the item has none of its own, that cover is saved to the item's
+`artworkUrl` (never overwriting existing art) — so pulling a release from Apple
+Music now brings its artwork along too.
 
 ## Browser playback
 

--- a/server/apple-music-backfill.ts
+++ b/server/apple-music-backfill.ts
@@ -1,25 +1,32 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { db } from "./db/index";
 import { musicItems, musicLinks, sources, artists } from "./db/schema";
 import { parseUrl } from "./utils";
-import { searchAppleMusic } from "./scraper";
+import { searchAppleMusic, type ServiceSearchResult } from "./scraper";
 
 export interface ItemInfoForLookup {
   title: string;
   artistName: string | null;
   primarySource: string | null;
   primaryUrl: string | null;
+  /** The item's current cover art, if any — a lookup only fills a gap, never overwrites. */
+  artworkUrl: string | null;
 }
 
 export type FetchItemForLookupFn = (id: number) => Promise<ItemInfoForLookup | null>;
 export type GetExistingAppleMusicLinkFn = (itemId: number) => Promise<string | null>;
 export type SaveAppleMusicLinkFn = (itemId: number, url: string) => Promise<void>;
-export type SearchAppleMusicFn = (title: string, artist: string | null) => Promise<string | null>;
+export type SaveArtworkFn = (itemId: number, artworkUrl: string) => Promise<void>;
+export type SearchAppleMusicFn = (
+  title: string,
+  artist: string | null,
+) => Promise<ServiceSearchResult | null>;
 
 export interface AppleMusicBackfillDeps {
   fetchItem: FetchItemForLookupFn;
   getExistingLink: GetExistingAppleMusicLinkFn;
   saveLink: SaveAppleMusicLinkFn;
+  saveArtwork: SaveArtworkFn;
   search: SearchAppleMusicFn;
 }
 
@@ -53,6 +60,7 @@ async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup 
       artistName: artists.name,
       primarySource: sources.name,
       primaryUrl: musicLinks.url,
+      artworkUrl: musicItems.artworkUrl,
     })
     .from(musicItems)
     .leftJoin(artists, eq(musicItems.artistId, artists.id))
@@ -72,6 +80,7 @@ async function defaultFetchItemForLookup(id: number): Promise<ItemInfoForLookup 
     artistName: row.artistName ?? null,
     primarySource: row.primarySource ?? null,
     primaryUrl: row.primaryUrl ?? null,
+    artworkUrl: row.artworkUrl ?? null,
   };
 }
 
@@ -108,10 +117,23 @@ async function defaultSaveAppleMusicLink(itemId: number, url: string): Promise<v
   }
 }
 
+/**
+ * Persist cover art discovered during a lookup, but only when the item still has
+ * none — the `IS NULL` guard leaves any artwork the user set (or an earlier
+ * lookup found) untouched.
+ */
+async function defaultSaveAppleMusicArtwork(itemId: number, artworkUrl: string): Promise<void> {
+  await db
+    .update(musicItems)
+    .set({ artworkUrl })
+    .where(and(eq(musicItems.id, itemId), isNull(musicItems.artworkUrl)));
+}
+
 export const defaultAppleMusicBackfillDeps: AppleMusicBackfillDeps = {
   fetchItem: defaultFetchItemForLookup,
   getExistingLink: defaultGetExistingAppleMusicLink,
   saveLink: defaultSaveAppleMusicLink,
+  saveArtwork: defaultSaveAppleMusicArtwork,
   search: searchAppleMusic,
 };
 
@@ -146,13 +168,19 @@ export async function backfillAppleMusicLink(
     return { status: "existing", url: existing };
   }
 
-  const appleMusicUrl = await deps.search(item.title, item.artistName);
-  if (!appleMusicUrl) {
+  const result = await deps.search(item.title, item.artistName);
+  if (!result) {
     return { status: "not_found" };
   }
 
-  await deps.saveLink(itemId, appleMusicUrl);
-  return { status: "added", url: appleMusicUrl };
+  await deps.saveLink(itemId, result.url);
+
+  // Backfill cover art from the same lookup when the item has none of its own.
+  if (result.artworkUrl && !item.artworkUrl) {
+    await deps.saveArtwork(itemId, result.artworkUrl);
+  }
+
+  return { status: "added", url: result.url };
 }
 
 /**

--- a/server/apple-music-catalog.ts
+++ b/server/apple-music-catalog.ts
@@ -12,6 +12,18 @@ import { getDeveloperToken, getStorefront, isAppleMusicConfigured } from "./appl
 
 const API_BASE = "https://api.music.apple.com/v1/catalog";
 
+/** The square pixel size we bake into Apple Music artwork template URLs. */
+const ARTWORK_SIZE = 1200;
+
+/**
+ * The result of resolving a release on a streaming service: its catalogue URL
+ * plus, when the service exposes one, a ready-to-use cover artwork URL.
+ */
+export interface ServiceSearchResult {
+  url: string;
+  artworkUrl: string | null;
+}
+
 function normalizeForMatch(s: string): string {
   return s
     .toLowerCase()
@@ -25,6 +37,7 @@ interface CatalogResource {
     name?: unknown;
     artistName?: unknown;
     url?: unknown;
+    artwork?: unknown;
   };
 }
 
@@ -33,16 +46,43 @@ function getString(value: unknown): string | undefined {
 }
 
 /**
+ * Resolve an Apple Music artwork template into a concrete image URL.
+ *
+ * Catalogue resources carry artwork as a templated URL with `{w}`/`{h}` (and
+ * sometimes `{c}`/`{f}`) placeholders, e.g.
+ * `https://…/{w}x{h}bb.{f}`. We bake in a fixed square size so the stored URL
+ * points straight at a usable cover image.
+ */
+function resolveCatalogArtworkUrl(artwork: unknown): string | null {
+  if (!artwork || typeof artwork !== "object") return null;
+  const template = getString((artwork as { url?: unknown }).url);
+  if (!template) return null;
+  return template
+    .replace(/\{w\}/g, String(ARTWORK_SIZE))
+    .replace(/\{h\}/g, String(ARTWORK_SIZE))
+    .replace(/\{c\}/g, "bb")
+    .replace(/\{f\}/g, "jpg");
+}
+
+/** Build a search result from a matched catalogue resource, or null if it has no URL. */
+function toResult(resource: CatalogResource): ServiceSearchResult | null {
+  const url = getString(resource.attributes?.url);
+  if (!url) return null;
+  return { url, artworkUrl: resolveCatalogArtworkUrl(resource.attributes?.artwork) };
+}
+
+/**
  * Search the Apple Music catalogue for a release by title and artist, returning
- * the best-matching catalogue URL, or null when unconfigured, on error, or when
- * nothing matches confidently. Mirrors the three-pass matching used for the
- * iTunes search (exact title+artist, compatible title+artist, artist-only).
+ * the best-matching catalogue URL together with its cover artwork, or null when
+ * unconfigured, on error, or when nothing matches confidently. Mirrors the
+ * three-pass matching used for the iTunes search (exact title+artist, compatible
+ * title+artist, artist-only).
  */
 export async function searchAppleMusicCatalog(
   title: string,
   artist: string | null,
   timeoutMs = 8000,
-): Promise<string | null> {
+): Promise<ServiceSearchResult | null> {
   if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
   if (!isAppleMusicConfigured()) return null;
 
@@ -104,8 +144,8 @@ export async function searchAppleMusicCatalog(
       const name = getString(c.attributes?.name);
       if (!name || normalizeForMatch(name) !== normalizedTitle) continue;
       if (!artistMatches(getString(c.attributes?.artistName))) continue;
-      const url = getString(c.attributes?.url);
-      if (url) return url;
+      const result = toResult(c);
+      if (result) return result;
     }
 
     // Pass 2: compatible title (prefix either way) + artist.
@@ -113,15 +153,15 @@ export async function searchAppleMusicCatalog(
       const name = getString(c.attributes?.name);
       if (!name || !titlesCompatible(name)) continue;
       if (!artistMatches(getString(c.attributes?.artistName))) continue;
-      const url = getString(c.attributes?.url);
-      if (url) return url;
+      const result = toResult(c);
+      if (result) return result;
     }
 
     // Pass 3: first artist-matching result (the query is already specific).
     for (const c of candidates) {
       if (!artistMatches(getString(c.attributes?.artistName))) continue;
-      const url = getString(c.attributes?.url);
-      if (url) return url;
+      const result = toResult(c);
+      if (result) return result;
     }
 
     return null;

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -4,7 +4,9 @@ import {
   type ExtractedReleaseCandidate,
 } from "./link-extractor";
 import { fetchDiscogsRelease } from "./discogs";
-import { searchAppleMusicCatalog } from "./apple-music-catalog";
+import { searchAppleMusicCatalog, type ServiceSearchResult } from "./apple-music-catalog";
+
+export type { ServiceSearchResult } from "./apple-music-catalog";
 
 export interface OgData {
   ogTitle?: string;
@@ -1140,7 +1142,7 @@ function normalizeForMatch(s: string): string {
 
 /**
  * Search Apple Music for a release by title and artist, returning the best
- * matching catalogue URL, or null if not found.
+ * matching catalogue URL together with its cover artwork, or null if not found.
  *
  * Prefers the official Apple Music Catalog API (api.music.apple.com) when
  * MusicKit is configured — those URLs carry the catalogue ids the browser SDK
@@ -1151,15 +1153,16 @@ export async function searchAppleMusic(
   title: string,
   artist: string | null,
   timeoutMs = 8000,
-): Promise<string | null> {
-  const catalogUrl = await searchAppleMusicCatalog(title, artist, timeoutMs);
-  if (catalogUrl) return catalogUrl;
+): Promise<ServiceSearchResult | null> {
+  const catalogResult = await searchAppleMusicCatalog(title, artist, timeoutMs);
+  if (catalogResult) return catalogResult;
   return searchAppleMusicViaItunes(title, artist, timeoutMs);
 }
 
 /**
  * Search Apple Music via the open iTunes Search API. Returns the Apple Music
- * URL for the best matching result, or null if not found.
+ * URL for the best matching result together with its cover artwork, or null if
+ * not found.
  *
  * Matching strategy (in order):
  *  1. Exact title + artist match
@@ -1171,7 +1174,7 @@ export async function searchAppleMusicViaItunes(
   title: string,
   artist: string | null,
   timeoutMs = 8000,
-): Promise<string | null> {
+): Promise<ServiceSearchResult | null> {
   // Test environments set this to keep the release page deterministic — the
   // visual snapshot can't depend on whether iTunes responds in time.
   if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
@@ -1227,6 +1230,16 @@ export async function searchAppleMusicViaItunes(
       }
     }
 
+    function toResult(result: Record<string, unknown>): ServiceSearchResult | undefined {
+      const url = resultUrl(result);
+      if (!url) return undefined;
+      const artworkUrl =
+        normalizeAppleMusicImageUrl(
+          firstDefined(getString(result.artworkUrl100), getString(result.artworkUrl60)),
+        ) ?? null;
+      return { url, artworkUrl };
+    }
+
     // Pass 1: exact title + artist
     for (const result of data.results) {
       if (!isRecord(result)) continue;
@@ -1236,8 +1249,8 @@ export async function searchAppleMusicViaItunes(
       );
       if (!resultTitle || normalizeForMatch(resultTitle) !== normalizedTitle) continue;
       if (!artistMatches(getString(result.artistName))) continue;
-      const url = resultUrl(result);
-      if (url) return url;
+      const match = toResult(result);
+      if (match) return match;
     }
 
     // Pass 2: compatible title (one is a prefix of the other) + artist
@@ -1249,16 +1262,16 @@ export async function searchAppleMusicViaItunes(
       );
       if (!resultTitle || !titlesCompatible(resultTitle)) continue;
       if (!artistMatches(getString(result.artistName))) continue;
-      const url = resultUrl(result);
-      if (url) return url;
+      const match = toResult(result);
+      if (match) return match;
     }
 
     // Pass 3: first result whose artist matches (search query is already scoped)
     for (const result of data.results) {
       if (!isRecord(result)) continue;
       if (!artistMatches(getString(result.artistName))) continue;
-      const url = resultUrl(result);
-      if (url) return url;
+      const match = toResult(result);
+      if (match) return match;
     }
 
     return null;
@@ -1282,7 +1295,7 @@ export async function searchSpotify(
   _title: string,
   _artist: string | null,
   _timeoutMs = 8000,
-): Promise<string | null> {
+): Promise<ServiceSearchResult | null> {
   if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
 
   const clientId = process.env.SPOTIFY_CLIENT_ID;

--- a/server/secondary-link-enrichment.ts
+++ b/server/secondary-link-enrichment.ts
@@ -1,8 +1,8 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { db } from "./db/index";
 import { artists, musicItems, musicLinks, sources } from "./db/schema";
 import { parseUrl } from "./utils";
-import { searchAppleMusic, searchSpotify } from "./scraper";
+import { searchAppleMusic, searchSpotify, type ServiceSearchResult } from "./scraper";
 import { getLookupService, type LookupService } from "./settings";
 
 // ---------------------------------------------------------------------------
@@ -24,7 +24,7 @@ export interface ServiceConfig {
   displayName: string;
   /** Host fragment identifying a primary URL already on this service. */
   urlFragment: string;
-  search: (title: string, artist: string | null) => Promise<string | null>;
+  search: (title: string, artist: string | null) => Promise<ServiceSearchResult | null>;
 }
 
 export const LOOKUP_SERVICE_CONFIG: Record<LookupService, ServiceConfig> = {
@@ -47,6 +47,8 @@ export interface ItemInfoForLookup {
   artistName: string | null;
   primarySource: string | null;
   primaryUrl: string | null;
+  /** The item's current cover art, if any — a lookup only fills a gap, never overwrites. */
+  artworkUrl: string | null;
   /** Set once a lookup has been attempted (hit or miss); used to avoid re-querying. */
   lookupAttemptedAt: Date | null;
 }
@@ -58,8 +60,9 @@ export type SearchServiceFn = (
   title: string,
   artist: string | null,
   service: LookupService,
-) => Promise<string | null>;
+) => Promise<ServiceSearchResult | null>;
 export type SaveLinkFn = (itemId: number, url: string, sourceName: string) => Promise<void>;
+export type SaveArtworkFn = (itemId: number, artworkUrl: string) => Promise<void>;
 export type StampLookupFn = (itemId: number) => Promise<void>;
 
 export async function fetchItemForLookup(id: number): Promise<ItemInfoForLookup | null> {
@@ -69,6 +72,7 @@ export async function fetchItemForLookup(id: number): Promise<ItemInfoForLookup 
       artistName: artists.name,
       primarySource: sources.name,
       primaryUrl: musicLinks.url,
+      artworkUrl: musicItems.artworkUrl,
       lookupAttemptedAt: musicItems.lookupAttemptedAt,
     })
     .from(musicItems)
@@ -89,6 +93,7 @@ export async function fetchItemForLookup(id: number): Promise<ItemInfoForLookup 
     artistName: row.artistName ?? null,
     primarySource: row.primarySource ?? null,
     primaryUrl: row.primaryUrl ?? null,
+    artworkUrl: row.artworkUrl ?? null,
     lookupAttemptedAt: row.lookupAttemptedAt ?? null,
   };
 }
@@ -133,6 +138,18 @@ export async function stampLookup(itemId: number): Promise<void> {
     .where(eq(musicItems.id, itemId));
 }
 
+/**
+ * Persist cover art discovered during a lookup, but only when the item still has
+ * none — the `IS NULL` guard means an artwork the user set (or an earlier lookup
+ * found) is never clobbered, even under a concurrent enrichment.
+ */
+export async function saveArtwork(itemId: number, artworkUrl: string): Promise<void> {
+  await db
+    .update(musicItems)
+    .set({ artworkUrl })
+    .where(and(eq(musicItems.id, itemId), isNull(musicItems.artworkUrl)));
+}
+
 const defaultSearch: SearchServiceFn = (title, artist, service) =>
   LOOKUP_SERVICE_CONFIG[service].search(title, artist);
 
@@ -142,6 +159,7 @@ export interface SecondaryLookupDeps {
   getExisting: GetExistingLinkFn;
   search: SearchServiceFn;
   save: SaveLinkFn;
+  saveArtwork: SaveArtworkFn;
   stamp: StampLookupFn;
 }
 
@@ -151,6 +169,7 @@ export const defaultSecondaryLookupDeps: SecondaryLookupDeps = {
   getExisting: getExistingLink,
   search: defaultSearch,
   save: saveLink,
+  saveArtwork,
   stamp: stampLookup,
 };
 
@@ -198,15 +217,21 @@ export async function lookupSecondaryLinkForItem(
     return { kind: "skipped", reason: "already_attempted" };
   }
 
-  const url = await deps.search(item.title, item.artistName, service);
+  const result = await deps.search(item.title, item.artistName, service);
   await deps.stamp(itemId);
 
-  if (!url) {
+  if (!result) {
     return { kind: "result", service, serviceDisplayName: cfg.displayName, url: null };
   }
 
-  await deps.save(itemId, url, cfg.sourceName);
-  return { kind: "result", service, serviceDisplayName: cfg.displayName, url };
+  await deps.save(itemId, result.url, cfg.sourceName);
+
+  // Backfill cover art from the same lookup when the item has none of its own.
+  if (result.artworkUrl && !item.artworkUrl) {
+    await deps.saveArtwork(itemId, result.artworkUrl);
+  }
+
+  return { kind: "result", service, serviceDisplayName: cfg.displayName, url: result.url };
 }
 
 /** Convenience wrapper returning just the resolved URL (or null). */

--- a/tests/unit/apple-music-backfill.test.ts
+++ b/tests/unit/apple-music-backfill.test.ts
@@ -7,23 +7,32 @@ import {
 const mockFetchItem = mock();
 const mockGetExistingLink = mock();
 const mockSaveLink = mock();
+const mockSaveArtwork = mock();
 const mockSearch = mock();
 
 const deps: AppleMusicBackfillDeps = {
   fetchItem: mockFetchItem,
   getExistingLink: mockGetExistingLink,
   saveLink: mockSaveLink,
+  saveArtwork: mockSaveArtwork,
   search: mockSearch,
 };
+
+/** A search hit for the given URL, with optional cover artwork. */
+function hit(url: string, artworkUrl: string | null = null) {
+  return { url, artworkUrl };
+}
 
 describe("backfillAppleMusicLink", () => {
   beforeEach(() => {
     mockFetchItem.mockReset();
     mockGetExistingLink.mockReset();
     mockSaveLink.mockReset();
+    mockSaveArtwork.mockReset();
     mockSearch.mockReset();
     mockGetExistingLink.mockResolvedValue(null);
     mockSaveLink.mockResolvedValue(undefined);
+    mockSaveArtwork.mockResolvedValue(undefined);
     mockSearch.mockResolvedValue(null);
   });
 
@@ -75,8 +84,9 @@ describe("backfillAppleMusicLink", () => {
       artistName: "Massive Attack",
       primarySource: "discogs",
       primaryUrl: "https://www.discogs.com/release/1",
+      artworkUrl: null,
     });
-    mockSearch.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/456");
+    mockSearch.mockResolvedValue(hit("https://music.apple.com/gb/album/blue-lines/456"));
 
     const result = await backfillAppleMusicLink(7, deps);
 
@@ -86,6 +96,40 @@ describe("backfillAppleMusicLink", () => {
     });
     expect(mockSearch).toHaveBeenCalledWith("Blue Lines", "Massive Attack");
     expect(mockSaveLink).toHaveBeenCalledWith(7, "https://music.apple.com/gb/album/blue-lines/456");
+  });
+
+  test("backfills cover art from the match when the item has none", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "Blue Lines",
+      artistName: "Massive Attack",
+      primarySource: "discogs",
+      primaryUrl: "https://www.discogs.com/release/1",
+      artworkUrl: null,
+    });
+    mockSearch.mockResolvedValue(
+      hit("https://music.apple.com/gb/album/blue-lines/456", "https://cdn/cover/1200x1200bb.jpg"),
+    );
+
+    await backfillAppleMusicLink(7, deps);
+
+    expect(mockSaveArtwork).toHaveBeenCalledWith(7, "https://cdn/cover/1200x1200bb.jpg");
+  });
+
+  test("does not overwrite cover art the item already has", async () => {
+    mockFetchItem.mockResolvedValue({
+      title: "Blue Lines",
+      artistName: "Massive Attack",
+      primarySource: "discogs",
+      primaryUrl: "https://www.discogs.com/release/1",
+      artworkUrl: "https://existing/cover.jpg",
+    });
+    mockSearch.mockResolvedValue(
+      hit("https://music.apple.com/gb/album/blue-lines/456", "https://cdn/cover/1200x1200bb.jpg"),
+    );
+
+    await backfillAppleMusicLink(7, deps);
+
+    expect(mockSaveArtwork).not.toHaveBeenCalled();
   });
 
   test("returns not_found when the search yields no match", async () => {

--- a/tests/unit/apple-music-catalog.test.ts
+++ b/tests/unit/apple-music-catalog.test.ts
@@ -28,6 +28,7 @@ interface CatalogItem {
   name: string;
   artistName: string;
   url: string;
+  artwork?: { url: string; width?: number; height?: number };
 }
 
 function catalogResponse(albums: CatalogItem[], songs: CatalogItem[] = []): Response {
@@ -76,7 +77,7 @@ describe("searchAppleMusicCatalog", () => {
     );
 
     const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
-    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/123");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/blue-lines/123");
 
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(url).toContain("https://api.music.apple.com/v1/catalog/gb/search");
@@ -96,7 +97,48 @@ describe("searchAppleMusicCatalog", () => {
       ]),
     );
     const result = await searchAppleMusicCatalog("Michael Nyman (1981 album)", "Michael Nyman");
-    expect(result).toBe("https://music.apple.com/gb/album/michael-nyman/456");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/michael-nyman/456");
+  });
+
+  test("resolves the artwork template to a concrete cover URL", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Blue Lines",
+          artistName: "Massive Attack",
+          url: "https://music.apple.com/gb/album/blue-lines/123",
+          artwork: {
+            url: "https://is1-ssl.mzstatic.com/image/thumb/abc/{w}x{h}{c}.{f}",
+            width: 1200,
+            height: 1200,
+          },
+        },
+      ]),
+    );
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toEqual({
+      url: "https://music.apple.com/gb/album/blue-lines/123",
+      artworkUrl: "https://is1-ssl.mzstatic.com/image/thumb/abc/1200x1200bb.jpg",
+    });
+  });
+
+  test("returns a null artworkUrl when the resource has no artwork", async () => {
+    configure();
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      catalogResponse([
+        {
+          name: "Blue Lines",
+          artistName: "Massive Attack",
+          url: "https://music.apple.com/gb/album/blue-lines/123",
+        },
+      ]),
+    );
+    const result = await searchAppleMusicCatalog("Blue Lines", "Massive Attack");
+    expect(result).toEqual({
+      url: "https://music.apple.com/gb/album/blue-lines/123",
+      artworkUrl: null,
+    });
   });
 
   test("prefers albums over songs", async () => {
@@ -120,7 +162,7 @@ describe("searchAppleMusicCatalog", () => {
       ),
     );
     const result = await searchAppleMusicCatalog("Discovery", "Daft Punk");
-    expect(result).toBe("https://music.apple.com/gb/album/discovery/1");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/discovery/1");
   });
 
   test("returns null when nothing matches the artist", async () => {
@@ -182,7 +224,7 @@ describe("searchAppleMusic orchestration", () => {
     );
 
     const result = await searchAppleMusic("Blue Lines", "Massive Attack");
-    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/from-catalog");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/blue-lines/from-catalog");
     // Only the catalogue endpoint was hit — no iTunes fallback fetch.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0]?.[0]).toContain("api.music.apple.com");
@@ -208,7 +250,7 @@ describe("searchAppleMusic orchestration", () => {
       );
 
     const result = await searchAppleMusic("Blue Lines", "Massive Attack");
-    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/from-itunes");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/blue-lines/from-itunes");
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(fetchSpy.mock.calls[1]?.[0]).toContain("itunes.apple.com");
   });

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -1018,7 +1018,41 @@ describe("searchAppleMusic", () => {
       ]),
     );
     const result = await searchAppleMusic("Blue Lines", "Massive Attack");
-    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/123");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/blue-lines/123");
+    mock.restore();
+  });
+
+  test("returns the cover artwork, upscaled to 1200x1200, alongside the URL", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockItunesResponse([
+        {
+          collectionName: "Blue Lines",
+          artistName: "Massive Attack",
+          collectionViewUrl: "https://music.apple.com/gb/album/blue-lines/123",
+          artworkUrl100: "https://is1-ssl.mzstatic.com/image/thumb/Music/abc/100x100bb.jpg",
+        },
+      ]),
+    );
+    const result = await searchAppleMusic("Blue Lines", "Massive Attack");
+    expect(result).toEqual({
+      url: "https://music.apple.com/gb/album/blue-lines/123",
+      artworkUrl: "https://is1-ssl.mzstatic.com/image/thumb/Music/abc/1200x1200bb.jpg",
+    });
+    mock.restore();
+  });
+
+  test("returns a null artworkUrl when the iTunes result has no artwork", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockItunesResponse([
+        {
+          collectionName: "Blue Lines",
+          artistName: "Massive Attack",
+          collectionViewUrl: "https://music.apple.com/gb/album/blue-lines/123",
+        },
+      ]),
+    );
+    const result = await searchAppleMusic("Blue Lines", "Massive Attack");
+    expect(result?.artworkUrl).toBeNull();
     mock.restore();
   });
 
@@ -1034,7 +1068,7 @@ describe("searchAppleMusic", () => {
     );
     // DB title is "Michael Nyman (1981 album)" — Apple Music has "Michael Nyman"
     const result = await searchAppleMusic("Michael Nyman (1981 album)", "Michael Nyman");
-    expect(result).toBe("https://music.apple.com/gb/album/michael-nyman/456");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/michael-nyman/456");
     mock.restore();
   });
 
@@ -1049,7 +1083,7 @@ describe("searchAppleMusic", () => {
       ]),
     );
     const result = await searchAppleMusic("Music Has the Right to Children", "Boards of Canada");
-    expect(result).toBe("https://music.apple.com/album/boc/789");
+    expect(result?.url).toBe("https://music.apple.com/album/boc/789");
     mock.restore();
   });
 
@@ -1085,7 +1119,7 @@ describe("searchAppleMusic", () => {
       ]),
     );
     const result = await searchAppleMusic("A Song", "Artist");
-    expect(result).toBe("https://music.apple.com/track/999");
+    expect(result?.url).toBe("https://music.apple.com/track/999");
     mock.restore();
   });
 
@@ -1100,7 +1134,7 @@ describe("searchAppleMusic", () => {
       ]),
     );
     const result = await searchAppleMusic("Blue Lines", "Massive Attack");
-    expect(result).toBe("https://music.apple.com/gb/album/blue-lines/123");
+    expect(result?.url).toBe("https://music.apple.com/gb/album/blue-lines/123");
     mock.restore();
   });
 
@@ -1115,7 +1149,7 @@ describe("searchAppleMusic", () => {
       ]),
     );
     const result = await searchAppleMusic("A Song", "Artist");
-    expect(result).toBe("https://music.apple.com/us/album/name/456");
+    expect(result?.url).toBe("https://music.apple.com/us/album/name/456");
     mock.restore();
   });
 });

--- a/tests/unit/secondary-link-enrichment.test.ts
+++ b/tests/unit/secondary-link-enrichment.test.ts
@@ -13,9 +13,18 @@ const fetchItem = mock();
 const getExisting = mock();
 const search = mock();
 const save = mock();
+const saveArtwork = mock();
 const stamp = mock();
 
-const deps: SecondaryLookupDeps = { getService, fetchItem, getExisting, search, save, stamp };
+const deps: SecondaryLookupDeps = {
+  getService,
+  fetchItem,
+  getExisting,
+  search,
+  save,
+  saveArtwork,
+  stamp,
+};
 
 function item(overrides: Partial<ItemInfoForLookup> = {}): ItemInfoForLookup {
   return {
@@ -23,9 +32,15 @@ function item(overrides: Partial<ItemInfoForLookup> = {}): ItemInfoForLookup {
     artistName: "Massive Attack",
     primarySource: null,
     primaryUrl: null,
+    artworkUrl: null,
     lookupAttemptedAt: null,
     ...overrides,
   };
+}
+
+/** A search hit for the given URL, with optional cover artwork. */
+function hit(url: string, artworkUrl: string | null = null) {
+  return { url, artworkUrl };
 }
 
 beforeEach(() => {
@@ -34,10 +49,12 @@ beforeEach(() => {
   getExisting.mockReset();
   search.mockReset();
   save.mockReset();
+  saveArtwork.mockReset();
   stamp.mockReset();
   getService.mockResolvedValue("apple_music" as LookupService);
   getExisting.mockResolvedValue(null);
   save.mockResolvedValue(undefined);
+  saveArtwork.mockResolvedValue(undefined);
   stamp.mockResolvedValue(undefined);
 });
 
@@ -69,7 +86,7 @@ describe("lookupSecondaryLinkForItem", () => {
     fetchItem.mockResolvedValue(
       item({ primarySource: "spotify", primaryUrl: "https://open.spotify.com/album/abc" }),
     );
-    search.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/456");
+    search.mockResolvedValue(hit("https://music.apple.com/gb/album/blue-lines/456"));
     const outcome = await lookupSecondaryLinkForItem(1, deps);
     expect(outcome.kind).toBe("result");
     expect(search).toHaveBeenCalledWith("Blue Lines", "Massive Attack", "apple_music");
@@ -105,7 +122,7 @@ describe("lookupSecondaryLinkForItem", () => {
 
   test("on a hit: saves the link and stamps the marker", async () => {
     fetchItem.mockResolvedValue(item());
-    search.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/456");
+    search.mockResolvedValue(hit("https://music.apple.com/gb/album/blue-lines/456"));
     const outcome = await lookupSecondaryLinkForItem(5, deps);
     expect(outcome).toEqual({
       kind: "result",
@@ -119,6 +136,31 @@ describe("lookupSecondaryLinkForItem", () => {
       "apple_music",
     );
     expect(stamp).toHaveBeenCalledWith(5);
+  });
+
+  test("on a hit with artwork: backfills the item's cover when it has none", async () => {
+    fetchItem.mockResolvedValue(item({ artworkUrl: null }));
+    search.mockResolvedValue(
+      hit("https://music.apple.com/gb/album/blue-lines/456", "https://cdn/cover/1200x1200bb.jpg"),
+    );
+    await lookupSecondaryLinkForItem(5, deps);
+    expect(saveArtwork).toHaveBeenCalledWith(5, "https://cdn/cover/1200x1200bb.jpg");
+  });
+
+  test("does not overwrite artwork the item already has", async () => {
+    fetchItem.mockResolvedValue(item({ artworkUrl: "https://existing/cover.jpg" }));
+    search.mockResolvedValue(
+      hit("https://music.apple.com/gb/album/blue-lines/456", "https://cdn/cover/1200x1200bb.jpg"),
+    );
+    await lookupSecondaryLinkForItem(5, deps);
+    expect(saveArtwork).not.toHaveBeenCalled();
+  });
+
+  test("saves no artwork when the hit carries none", async () => {
+    fetchItem.mockResolvedValue(item({ artworkUrl: null }));
+    search.mockResolvedValue(hit("https://music.apple.com/gb/album/blue-lines/456", null));
+    await lookupSecondaryLinkForItem(5, deps);
+    expect(saveArtwork).not.toHaveBeenCalled();
   });
 
   test("on a miss: stamps the marker but saves nothing", async () => {
@@ -138,7 +180,7 @@ describe("lookupSecondaryLinkForItem", () => {
   test("uses the active service from settings (Spotify)", async () => {
     getService.mockResolvedValue("spotify" as LookupService);
     fetchItem.mockResolvedValue(item({ primarySource: "apple_music" }));
-    search.mockResolvedValue("https://open.spotify.com/album/xyz");
+    search.mockResolvedValue(hit("https://open.spotify.com/album/xyz"));
     const outcome = await lookupSecondaryLinkForItem(9, deps);
     expect(outcome).toMatchObject({
       kind: "result",
@@ -155,7 +197,7 @@ describe("lookupSecondaryLinkForItem", () => {
 describe("enrichSecondaryLink", () => {
   test("unwraps a hit to the URL", async () => {
     fetchItem.mockResolvedValue(item());
-    search.mockResolvedValue("https://music.apple.com/gb/album/blue-lines/456");
+    search.mockResolvedValue(hit("https://music.apple.com/gb/album/blue-lines/456"));
     expect(await enrichSecondaryLink(5, deps)).toBe(
       "https://music.apple.com/gb/album/blue-lines/456",
     );


### PR DESCRIPTION
## Problem

When we resolve a release through the Apple Music Catalog API, we pulled its catalogue URL but threw away the `artwork` field the API returns in the same response — so cover art from that path was never captured. The iTunes fallback had the same gap. Result: releases resolved via Apple Music came in without artwork.

## What changed

The Apple Music searches now return a `ServiceSearchResult` (`{ url, artworkUrl }`) instead of a bare URL string:

- **`server/apple-music-catalog.ts`** — resolves the artwork template URL (`…/{w}x{h}bb.{f}`) into a concrete 1200×1200 cover.
- **`server/scraper.ts`** — `searchAppleMusic`, the iTunes fallback (upscaling `artworkUrl100` the same way), and the Spotify stub all return the richer result; re-exports the `ServiceSearchResult` type.
- **`server/secondary-link-enrichment.ts`** and **`server/apple-music-backfill.ts`** — the two paths that run when an item is created. When the resolved release carries artwork **and the item has none of its own**, the cover is saved to `artworkUrl`. The save is a `SET … WHERE artwork_url IS NULL` update, so art the user set (or an earlier lookup found) is never overwritten, even under concurrent enrichment.
- **`docs/areas/integrations/apple-music.md`** — updated to describe the artwork flow.

## Scope note

This fills artwork on item creation/enrichment going forward. Existing items that already recorded a "lookup attempted" marker won't be re-queried (that guard predates this change). A one-shot backfill for pre-existing Apple-Music-linked items without a cover could be added separately if wanted.

## Testing

- All **532 unit tests pass**, including new coverage for artwork template resolution / `artworkUrl100` upscaling and the "fill only when missing" persistence rule in both the enrichment and backfill paths.
- `typecheck` clean; formatting clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL6uhaQQzoEfGYtAcx6XVx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL6uhaQQzoEfGYtAcx6XVx)_