### PR TITLE
Model playback as a state machine so starting one release stops another

### DIFF
--- a/src/lib/player.svelte.ts
+++ b/src/lib/player.svelte.ts
@@ -4,104 +4,93 @@
  * survives SvelteKit client-side navigation (the player window itself is
  * rendered by the root layout, which never unmounts).
  *
+ * The actual state — idle / iframe / apple_music, and the "stop whatever is
+ * playing before starting the next release" rule — lives in `playerMachine`
+ * (see src/ui/state/player-machine.ts). This module owns the single client-side
+ * actor, injects the browser side effects (MusicKit start/stop), and exposes a
+ * reactive facade the components bind to. See docs/areas/frontend/state-machines.md.
+ *
  * Two playback modes:
  *  - "iframe": Bandcamp / YouTube / Mixcloud (and the Apple Music preview
  *    embed used as a fallback) render an <iframe> from `src`.
  *  - "apple_music": full-track playback driven by MusicKit (see musickit.svelte.ts).
  */
+import { browser } from "$app/environment";
+import { createActor } from "xstate";
 import type { AppleMusicKind } from "../../shared/apple-music";
 import { playResource, stop as stopMusicKit } from "./musickit.svelte";
+import { playerMachine, type PlayerType } from "../ui/state/player-machine";
 
-export type PlayerType = "audio" | "video";
-export type PlayerMode = "iframe" | "apple_music";
+export type { PlayerType };
 
-interface AppleMusicTarget {
-  kind: AppleMusicKind;
-  id: string;
-}
-
-interface PlayerState {
-  mode: PlayerMode;
-  src: string | null;
-  apple: AppleMusicTarget | null;
-  label: string;
-  playerType: PlayerType;
-  minimized: boolean;
-}
-
-const state = $state<PlayerState>({
-  mode: "iframe",
-  src: null,
-  apple: null,
-  label: "",
-  playerType: "audio",
-  minimized: false,
+// One actor for the whole client session. During SSR it is never started — the
+// initial (idle) snapshot renders and the machine comes alive on the client,
+// matching `useMachine`.
+const actor = createActor(playerMachine, {
+  input: {
+    playAppleMusic: (kind, id) => {
+      void playResource(kind, id);
+    },
+    stopAppleMusic: () => {
+      void stopMusicKit();
+    },
+  },
 });
 
+let snapshot = $state.raw(actor.getSnapshot());
+if (browser) {
+  actor.subscribe((next) => {
+    snapshot = next;
+  });
+  actor.start();
+}
+
+function toLabel(title: string, artist: string): string {
+  return artist ? `${artist} — ${title}` : title;
+}
+
 export const player = {
-  get mode() {
-    return state.mode;
-  },
   get src() {
-    return state.src;
+    return snapshot.context.src;
   },
   get label() {
-    return state.label;
+    return snapshot.context.label;
   },
   get playerType() {
-    return state.playerType;
+    return snapshot.context.playerType;
   },
   get isAppleMusic() {
-    return state.mode === "apple_music";
+    return snapshot.matches("appleMusic");
   },
   get minimized() {
-    return state.minimized;
+    return snapshot.context.minimized;
   },
   get active() {
-    return state.mode === "apple_music" ? state.apple !== null : state.src !== null;
+    return !snapshot.matches("idle");
   },
   get windowVisible() {
-    return this.active && !state.minimized;
+    return !snapshot.matches("idle") && !snapshot.context.minimized;
   },
 
   /** Play an iframe-embedded source (Bandcamp, YouTube, Mixcloud, AM preview). */
   load(src: string, title: string, artist: string, playerType: PlayerType = "audio"): void {
-    state.mode = "iframe";
-    state.src = src;
-    state.apple = null;
-    state.label = artist ? `${artist} — ${title}` : title;
-    state.playerType = playerType;
-    state.minimized = false;
+    actor.send({ type: "LOAD_IFRAME", src, label: toLabel(title, artist), playerType });
   },
 
   /** Play a full Apple Music catalogue resource via MusicKit. */
   loadAppleMusic(kind: AppleMusicKind, id: string, title: string, artist: string): void {
-    state.mode = "apple_music";
-    state.src = null;
-    state.apple = { kind, id };
-    state.label = artist ? `${artist} — ${title}` : title;
-    state.playerType = "audio";
-    state.minimized = false;
-    void playResource(kind, id);
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind, id, label: toLabel(title, artist) });
   },
 
   stop(): void {
-    if (state.mode === "apple_music") {
-      void stopMusicKit();
-    }
-    state.mode = "iframe";
-    state.src = null;
-    state.apple = null;
-    state.label = "";
-    state.playerType = "audio";
-    state.minimized = false;
+    actor.send({ type: "STOP" });
   },
 
   minimize(): void {
-    state.minimized = true;
+    actor.send({ type: "MINIMIZE" });
   },
 
   toggleWindow(): void {
-    state.minimized = !state.minimized;
+    actor.send({ type: "TOGGLE_WINDOW" });
   },
 };

--- a/src/ui/state/player-machine.ts
+++ b/src/ui/state/player-machine.ts
@@ -1,0 +1,132 @@
+import { assign, setup } from "xstate";
+import type { AppleMusicKind } from "../../../shared/apple-music";
+
+export type PlayerType = "audio" | "video";
+
+export interface AppleMusicTarget {
+  kind: AppleMusicKind;
+  id: string;
+}
+
+/**
+ * Side effects the machine drives on transitions. Injected via `input` so the
+ * machine itself stays free of any browser / MusicKit dependency and can be
+ * unit-tested in isolation (mirrors how `add-form-machine` injects its `api`).
+ */
+export interface PlayerEffects {
+  /** Start full-track Apple Music playback for a catalogue resource. */
+  playAppleMusic: (kind: AppleMusicKind, id: string) => void;
+  /** Tear down any in-progress Apple Music playback. */
+  stopAppleMusic: () => void;
+}
+
+export interface PlayerContext extends PlayerEffects {
+  /** Source URL for iframe playback (Bandcamp / YouTube / Mixcloud / AM preview). */
+  src: string | null;
+  /** Target catalogue resource when playing through MusicKit. */
+  apple: AppleMusicTarget | null;
+  /** "{artist} — {title}" (or just the title) shown in the window/taskbar. */
+  label: string;
+  playerType: PlayerType;
+  minimized: boolean;
+}
+
+export type PlayerEvent =
+  | { type: "LOAD_IFRAME"; src: string; label: string; playerType: PlayerType }
+  | { type: "LOAD_APPLE_MUSIC"; kind: AppleMusicKind; id: string; label: string }
+  | { type: "STOP" }
+  | { type: "MINIMIZE" }
+  | { type: "TOGGLE_WINDOW" };
+
+export type PlayerInput = Partial<PlayerEffects>;
+
+const noop = (): void => {};
+
+/**
+ * Now-playing state machine.
+ *
+ * Playback has three positions — `idle`, `iframe`, and `appleMusic` — and the
+ * app only ever plays one release at a time. Because every "start playback"
+ * event targets a concrete state, the outgoing state's `exit` action always
+ * runs first: leaving `appleMusic` stops MusicKit, and leaving `iframe` drops
+ * the `src` so the embed unmounts. That is what guarantees a currently playing
+ * release stops when another is started — including when moving between Apple
+ * Music and Bandcamp in either direction — without every caller having to
+ * remember to tear the previous one down.
+ */
+export const playerMachine = setup({
+  types: {} as {
+    context: PlayerContext;
+    events: PlayerEvent;
+    input: PlayerInput;
+  },
+  actions: {
+    startAppleMusic: ({ context }) => {
+      if (context.apple) context.playAppleMusic(context.apple.kind, context.apple.id);
+    },
+    stopAppleMusic: ({ context }) => {
+      context.stopAppleMusic();
+    },
+  },
+}).createMachine({
+  context: ({ input }) => ({
+    src: null,
+    apple: null,
+    label: "",
+    playerType: "audio",
+    minimized: false,
+    playAppleMusic: input?.playAppleMusic ?? noop,
+    stopAppleMusic: input?.stopAppleMusic ?? noop,
+  }),
+  initial: "idle",
+  on: {
+    // Starting playback supersedes whatever is currently playing. Targeting a
+    // concrete state (rather than an internal transition) forces the active
+    // state's `exit` action to run first — re-entering `appleMusic` from itself
+    // likewise stops the old track before queuing the new one.
+    LOAD_IFRAME: {
+      target: ".iframe",
+      actions: assign(({ event }) => ({
+        src: event.src,
+        apple: null,
+        label: event.label,
+        playerType: event.playerType,
+        minimized: false,
+      })),
+    },
+    LOAD_APPLE_MUSIC: {
+      target: ".appleMusic",
+      actions: assign(({ event }) => ({
+        src: null,
+        apple: { kind: event.kind, id: event.id },
+        label: event.label,
+        playerType: "audio" as const,
+        minimized: false,
+      })),
+    },
+    STOP: {
+      target: ".idle",
+      actions: assign({
+        src: null,
+        apple: null,
+        label: "",
+        playerType: "audio" as const,
+        minimized: false,
+      }),
+    },
+    MINIMIZE: {
+      actions: assign({ minimized: true }),
+    },
+    TOGGLE_WINDOW: {
+      actions: assign(({ context }) => ({ minimized: !context.minimized })),
+    },
+  },
+  states: {
+    idle: {},
+    iframe: {},
+    appleMusic: {
+      entry: "startAppleMusic",
+      exit: "stopAppleMusic",
+    },
+  },
+});

--- a/tests/unit/app-state-machines.test.ts
+++ b/tests/unit/app-state-machines.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { addFormMachine } from "../../src/ui/state/add-form-machine";
 import { appMachine } from "../../src/ui/state/app-machine";
+import { playerMachine } from "../../src/ui/state/player-machine";
 import {
   initialRatingState,
   resolveRatingClick,
@@ -655,5 +656,109 @@ describe("rating state machine", () => {
     const clearResult = resolveRatingClick(state, 9, 4);
     expect(clearResult.shouldClear).toBe(false);
     expect(clearResult.state.clearCandidate).toBeNull();
+  });
+});
+
+describe("player state machine", () => {
+  function makePlayer() {
+    const calls: string[] = [];
+    const actor = createActor(playerMachine, {
+      input: {
+        playAppleMusic: (kind: string, id: string) => calls.push(`play:${kind}:${id}`),
+        stopAppleMusic: () => calls.push("stop"),
+      },
+    }).start();
+    return { actor, calls };
+  }
+
+  it("starts idle with nothing playing", () => {
+    const { actor } = makePlayer();
+    expect(actor.getSnapshot().matches("idle")).toBe(true);
+    expect(actor.getSnapshot().context.src).toBeNull();
+    expect(actor.getSnapshot().context.apple).toBeNull();
+  });
+
+  it("plays an iframe source", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({
+      type: "LOAD_IFRAME",
+      src: "https://bandcamp/x",
+      label: "A — B",
+      playerType: "audio",
+    });
+    const snap = actor.getSnapshot();
+    expect(snap.matches("iframe")).toBe(true);
+    expect(snap.context.src).toBe("https://bandcamp/x");
+    expect(snap.context.apple).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  it("starts Apple Music playback on entry", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "123", label: "A — B" });
+    const snap = actor.getSnapshot();
+    expect(snap.matches("appleMusic")).toBe(true);
+    expect(snap.context.src).toBeNull();
+    expect(snap.context.apple).toEqual({ kind: "albums", id: "123" });
+    expect(calls).toEqual(["play:albums:123"]);
+  });
+
+  it("stops Apple Music when switching to a Bandcamp iframe", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "123", label: "A" });
+    actor.send({ type: "LOAD_IFRAME", src: "https://bandcamp/x", label: "B", playerType: "audio" });
+    expect(actor.getSnapshot().matches("iframe")).toBe(true);
+    expect(actor.getSnapshot().context.apple).toBeNull();
+    // Apple Music was started, then stopped before the iframe took over.
+    expect(calls).toEqual(["play:albums:123", "stop"]);
+  });
+
+  it("does not touch Apple Music when switching between iframe sources", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_IFRAME", src: "https://bandcamp/x", label: "A", playerType: "audio" });
+    actor.send({ type: "LOAD_IFRAME", src: "https://youtube/y", label: "B", playerType: "video" });
+    expect(actor.getSnapshot().context.src).toBe("https://youtube/y");
+    expect(actor.getSnapshot().context.playerType).toBe("video");
+    expect(calls).toEqual([]);
+  });
+
+  it("stops the old track and plays the new one when switching Apple Music releases", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "1", label: "A" });
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "2", label: "B" });
+    expect(actor.getSnapshot().context.apple).toEqual({ kind: "albums", id: "2" });
+    expect(calls).toEqual(["play:albums:1", "stop", "play:albums:2"]);
+  });
+
+  it("stops Apple Music and returns to idle on STOP", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "123", label: "A" });
+    actor.send({ type: "STOP" });
+    const snap = actor.getSnapshot();
+    expect(snap.matches("idle")).toBe(true);
+    expect(snap.context.src).toBeNull();
+    expect(snap.context.apple).toBeNull();
+    expect(snap.context.label).toBe("");
+    expect(calls).toEqual(["play:albums:123", "stop"]);
+  });
+
+  it("tracks minimize and window toggling without affecting playback", () => {
+    const { actor, calls } = makePlayer();
+    actor.send({ type: "LOAD_IFRAME", src: "https://bandcamp/x", label: "A", playerType: "audio" });
+    actor.send({ type: "MINIMIZE" });
+    expect(actor.getSnapshot().context.minimized).toBe(true);
+    actor.send({ type: "TOGGLE_WINDOW" });
+    expect(actor.getSnapshot().context.minimized).toBe(false);
+    expect(actor.getSnapshot().matches("iframe")).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("clears a minimized flag when new playback starts", () => {
+    const { actor } = makePlayer();
+    actor.send({ type: "LOAD_IFRAME", src: "https://bandcamp/x", label: "A", playerType: "audio" });
+    actor.send({ type: "MINIMIZE" });
+    expect(actor.getSnapshot().context.minimized).toBe(true);
+    actor.send({ type: "LOAD_APPLE_MUSIC", kind: "albums", id: "1", label: "B" });
+    expect(actor.getSnapshot().context.minimized).toBe(false);
   });
 });


### PR DESCRIPTION
Playback could leave two releases sounding at once: player.load() switched
the now-playing window to a Bandcamp/YouTube iframe but never stopped an
in-progress Apple Music (MusicKit) stream, so going Apple Music -> Bandcamp
played both simultaneously. Only the explicit Stop button tore MusicKit down.

Capture the now-playing state as an XState machine (idle / iframe /
appleMusic) under src/ui/state/, following the codebase's state-machine
convention. Every "start playback" event targets a concrete state, so the
outgoing state's exit action runs first — leaving appleMusic stops MusicKit,
and re-entering appleMusic stops the old track before queuing the new one.
This makes "stop whatever is playing before starting the next release"
structural rather than something each call site has to remember, and covers
switching in both directions between Apple Music and Bandcamp.

player.svelte.ts now owns a single client-side actor, injects the browser
side effects (MusicKit start/stop), and keeps the same reactive facade the
window/taskbar bind to. Adds unit coverage for the new machine.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XMojPT8XUCEtPZnpFY8AWv