### PR TITLE
Make scrollbar track clicks jump to the clicked position

### DIFF
--- a/src/lib/components/HorizontalScrollbar.svelte
+++ b/src/lib/components/HorizontalScrollbar.svelte
@@ -98,13 +98,30 @@
     if (!target || !trackEl) return;
     if ((event.target as HTMLElement).id === thumbId) return;
 
+    const scrollRange = target.scrollWidth - target.clientWidth;
+    if (scrollRange <= 0) return;
+
+    const maxThumbLeft = Math.max(trackEl.clientWidth - thumbWidth, 0);
+    if (maxThumbLeft <= 0) return;
+
+    // Jump the thumb so its centre sits under the pointer, then scroll there,
+    // rather than paging by a fixed step. This makes a click travel to the
+    // clicked region instead of hopping around.
+    event.preventDefault();
     const trackRect = trackEl.getBoundingClientRect();
     const clickOffset = event.clientX - trackRect.left;
-    const direction = clickOffset < thumbLeft ? -1 : 1;
-    target.scrollBy({
-      left: direction * Math.max(80, target.clientWidth * 0.8),
-      behavior: "auto",
-    });
+    const nextLeft = Math.max(0, Math.min(maxThumbLeft, clickOffset - thumbWidth / 2));
+    target.scrollLeft = (nextLeft / maxThumbLeft) * scrollRange;
+
+    // Hand off to the drag logic so the thumb sticks to the pointer if the
+    // user keeps dragging after the initial click.
+    if (event.pointerId !== undefined && typeof trackEl.setPointerCapture === "function") {
+      trackEl.setPointerCapture(event.pointerId);
+    }
+    drag = { startX: event.clientX, startLeft: nextLeft };
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
   }
 
   function onDragMove(event: PointerEvent): void {

--- a/src/lib/components/VerticalScrollbar.svelte
+++ b/src/lib/components/VerticalScrollbar.svelte
@@ -102,13 +102,30 @@
     if (!target || !trackEl) return;
     if ((event.target as HTMLElement).id === thumbId) return;
 
+    const scrollRange = target.scrollHeight - target.clientHeight;
+    if (scrollRange <= 0) return;
+
+    const maxThumbTop = Math.max(trackEl.clientHeight - thumbHeight, 0);
+    if (maxThumbTop <= 0) return;
+
+    // Jump the thumb so its centre sits under the pointer, then scroll there,
+    // rather than paging by a fixed step. This makes a click travel to the
+    // clicked region instead of hopping around.
+    event.preventDefault();
     const trackRect = trackEl.getBoundingClientRect();
     const clickOffset = event.clientY - trackRect.top;
-    const direction = clickOffset < thumbTop ? -1 : 1;
-    target.scrollBy({
-      top: direction * Math.max(80, target.clientHeight * 0.8),
-      behavior: "auto",
-    });
+    const nextTop = Math.max(0, Math.min(maxThumbTop, clickOffset - thumbHeight / 2));
+    target.scrollTop = (nextTop / maxThumbTop) * scrollRange;
+
+    // Hand off to the drag logic so the thumb sticks to the pointer if the
+    // user keeps dragging after the initial click.
+    if (event.pointerId !== undefined && typeof trackEl.setPointerCapture === "function") {
+      trackEl.setPointerCapture(event.pointerId);
+    }
+    drag = { startY: event.clientY, startTop: nextTop };
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
   }
 
   function onDragMove(event: PointerEvent): void {


### PR DESCRIPTION
## What

Clicking the retro scrollbar track now jumps the thumb to the clicked position and scrolls straight there, instead of paging by a fixed step in the click direction.

## Why

The stacks scrollbar (and the main list scrollbar) handled a track click by *paging* — scrolling a fixed ~80% of the width/height toward the click. So a click never landed where you tapped; the thumb hopped by a fixed step each time, reading as "jumping around." This was especially noticeable on the stacks bar and on mobile, where the track is short.

## How

`onTrackPointerDown` in both `HorizontalScrollbar.svelte` and `VerticalScrollbar.svelte` now:

- Centres the thumb under the pointer and scrolls to that region:
  `nextLeft = clamp(clickOffset - thumbWidth/2, 0, maxThumbLeft)` → `scrollLeft = (nextLeft / maxThumbLeft) * scrollRange`
- Hands off to the existing drag logic (with pointer capture), so if you keep dragging after the click the thumb sticks to the pointer.

Dragging the thumb directly, the step buttons, and press-and-hold repeat are all unchanged.

## Testing

- `bun run typecheck` passes (0 errors).
- Could not run the app visually in this environment (`sharp`, a transitive dependency of `@capacitor/assets`, fails to fetch its prebuilt binary behind the proxy). The new code path mirrors the existing, proven thumb-drag logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPiHfC3o9eHSx6JqY9b79Q)_