### PR TITLE
Fix image upload failing on the release page for large photos

### DIFF
--- a/src/lib/components/AddForm.svelte
+++ b/src/lib/components/AddForm.svelte
@@ -3,9 +3,9 @@
   import type { StackWithCount } from "../../types";
   import type { AddFormValues } from "../../ui/domain/add-form";
   import { getCoverScanErrorMessage, toListSearchQuery } from "../../ui/domain/add-form";
-  import { constrainDimensions } from "../../ui/domain/scan";
   import { addFormMachine, RECORD_DURATION_MS } from "../../ui/state/add-form-machine";
   import { api } from "../api";
+  import { encodeImageFile } from "../encode-image";
   import type { MachineHandle } from "../use-machine.svelte";
   import StackDropdown from "./StackDropdown.svelte";
 
@@ -123,59 +123,9 @@
   async function onScanFileChange(): Promise<void> {
     const file = scanInputEl?.files?.[0];
     if (!file || !scanInputEl) return;
-    const imageBase64 = await encodeScanImage(file);
+    const imageBase64 = await encodeImageFile(file);
     form.send({ type: "SCAN_FILE_SELECTED", imageBase64 });
     scanInputEl.value = "";
-  }
-
-  async function encodeScanImage(file: File): Promise<string> {
-    const imageDataUrl = await readFileAsDataUrl(file);
-    const image = await loadImage(imageDataUrl);
-    const { width, height } = constrainDimensions(image.width, image.height, 1024);
-
-    const canvas = document.createElement("canvas");
-    canvas.width = width;
-    canvas.height = height;
-
-    const context = canvas.getContext("2d");
-    if (!context) {
-      throw new Error("Canvas context unavailable");
-    }
-
-    context.drawImage(image, 0, 0, width, height);
-    const encoded = canvas.toDataURL("image/jpeg", 0.85);
-    const parts = encoded.split(",", 2);
-    if (parts.length !== 2 || !parts[1]) {
-      throw new Error("Failed to encode scan image");
-    }
-
-    return parts[1];
-  }
-
-  function readFileAsDataUrl(file: Blob): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (typeof reader.result !== "string") {
-          reject(new Error("Failed to read image file"));
-          return;
-        }
-        resolve(reader.result);
-      };
-      reader.onerror = () => {
-        reject(reader.error ?? new Error("Failed to read image file"));
-      };
-      reader.readAsDataURL(file);
-    });
-  }
-
-  function loadImage(dataUrl: string): Promise<HTMLImageElement> {
-    return new Promise((resolve, reject) => {
-      const image = new Image();
-      image.onload = () => resolve(image);
-      image.onerror = () => reject(new Error("Failed to load image"));
-      image.src = dataUrl;
-    });
   }
 
   // ── Recognize ("Listen") ───────────────────────────────────────────────────

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -6,6 +6,7 @@
   import type { ItemSuggestion, ListenStatus } from "../../types";
   import { parseAppleMusicCatalogUrl } from "../../../shared/apple-music";
   import { api, apiFetch } from "../api";
+  import { encodeImageFile } from "../encode-image";
   import { player } from "../player.svelte";
   import StarRating from "./StarRating.svelte";
   import SuggestionPickerModal from "./SuggestionPickerModal.svelte";
@@ -226,13 +227,7 @@
     const previousUrl = editArtworkUrl;
 
     try {
-      const dataUrl = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-      });
-      const base64 = dataUrl.split(",")[1];
+      const base64 = await encodeImageFile(file);
       const { artworkUrl } = await api.uploadReleaseImage(base64);
       editArtworkUrl = artworkUrl;
     } catch (err) {

--- a/src/lib/encode-image.ts
+++ b/src/lib/encode-image.ts
@@ -1,0 +1,66 @@
+import { constrainDimensions } from "../ui/domain/scan";
+
+const DEFAULT_MAX_EDGE = 1024;
+const DEFAULT_QUALITY = 0.85;
+
+function readFileAsDataUrl(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error("Failed to read image file"));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read image file"));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Failed to load image"));
+    image.src = dataUrl;
+  });
+}
+
+/**
+ * Read an image file, downscale it so its longest edge is at most `maxEdge`,
+ * and re-encode it as a JPEG. Returns the base64 payload (no data-URL prefix).
+ *
+ * Downscaling keeps the upload comfortably under the server's size limit
+ * (see `MAX_IMAGE_BASE64_LENGTH` in server/uploads.ts); full-resolution phone
+ * photos would otherwise be rejected.
+ */
+export async function encodeImageFile(
+  file: Blob,
+  maxEdge: number = DEFAULT_MAX_EDGE,
+  quality: number = DEFAULT_QUALITY,
+): Promise<string> {
+  const imageDataUrl = await readFileAsDataUrl(file);
+  const image = await loadImage(imageDataUrl);
+  const { width, height } = constrainDimensions(image.width, image.height, maxEdge);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Canvas context unavailable");
+  }
+
+  context.drawImage(image, 0, 0, width, height);
+  const encoded = canvas.toDataURL("image/jpeg", quality);
+  const parts = encoded.split(",", 2);
+  if (parts.length !== 2 || !parts[1]) {
+    throw new Error("Failed to encode image");
+  }
+
+  return parts[1];
+}


### PR DESCRIPTION
The release page's "Replace image" upload sent the raw, full-resolution
file to /api/release/image. The server caps uploads at ~1.5 MB
(MAX_IMAGE_BASE64_LENGTH), so any normal phone photo or hi-res cover was
rejected with 400 "imageBase64 is too large" and surfaced as "Failed to
upload image."

The add-form scan flow already downscaled images to 1024px JPEG before
uploading, which is why only the release page was affected. Extract that
encoding into a shared encodeImageFile() helper and use it in both places
so uploads stay under the server limit consistently.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJnFHtL69BXvKUKQM2x3wX