### PR TITLE
Support submitting images via the share sheet

### DIFF
--- a/docs/areas/server/routes.md
+++ b/docs/areas/server/routes.md
@@ -6,7 +6,7 @@
 - `server/routes/music-items.ts` owns listing, create/update/delete, filtering, sorting, stack-aware queries, and saved ordering.
 - `server/routes/stacks.ts` owns stack CRUD, item membership, and parent/child stack hierarchy rules.
 - `server/routes/release.ts` owns image upload, cover scanning, MusicBrainz lookup, and Apple Music enrichment.
-- `server/routes/ingest.ts` owns authenticated email and single-link ingestion endpoints.
+- `server/routes/ingest.ts` owns authenticated email, single-link, and photo ingestion endpoints (the share sheet posts links to `/link` and images to `/photo`, both of which can file the item into lists and set a reminder).
 - `server/routes/rss.ts` exposes the feed surfaces.
 
 ## Page data (SvelteKit)

--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -34,6 +34,15 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
   name. On **Add** it `POST`s the URL — plus `notes` and `listName` when set — to
   `POST /api/ingest/link` with a `Bearer` token. The extension talks to the server
   directly, so a share works even when the app isn't running.
+- **Sharing an image** works the same way. When the payload is a photo rather than a
+  link (e.g. a record cover shared from Photos), the extension shows the same compose
+  form — with an image preview in place of the URL line — and the same note, list,
+  and reminder controls. The image is downscaled to a 1024px JPEG (mirroring the web
+  add-form, so it stays under the server's upload size cap) and `POST`ed as base64 to
+  `POST /api/ingest/photo`, which saves the artwork, scans it for release metadata,
+  and files the created item into the chosen lists / reminder just like a link. A
+  link is preferred when the share carries both (a shared web page often includes a
+  thumbnail image we don't want).
 - Posting is **synchronous**: the form stays on screen showing an "Adding…" spinner
   until the request finishes. On success it flashes a brief checkmark toast built
   from the server's response — "Added", "Added to Jazz, Chill", or "Already saved"
@@ -44,8 +53,10 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
   always a live controller to present the toast and alert on.
 
 ```
-iOS share sheet ──► ShareExtension compose form ──► POST /api/ingest/link ──► item created
-        (note + list picker)          GET /api/ingest/stacks ──┘  (filed into list)
+iOS share sheet ──► ShareExtension compose form ──┬─► POST /api/ingest/link  ──► item created
+        (note + list picker)  GET /api/ingest/stacks┘   (a link)                  (filed into list)
+                                                    └─► POST /api/ingest/photo ──► item created
+                                                        (an image)                (scanned + filed)
 ```
 
 ## What lives in the repo vs. what's generated
@@ -291,15 +302,16 @@ consider rotating `INGEST_API_KEY`.
 ## Troubleshooting
 
 - **Extension doesn't appear in the share sheet** — make sure you shared a web
-  URL or page (the activation rule in `Info.plist` targets web URLs, web pages,
-  and text). Reboot the device once after first install; iOS caches extension
-  registrations.
+  URL, text, or an image (the activation rule in `Info.plist` targets web URLs,
+  text, and images). Reboot the device once after first install; iOS caches
+  extension registrations.
 - **"Missing ingest API key in build config."** — `Secrets.xcconfig` isn't wired
   as the target's configuration file, or `OTB_INGEST_API_KEY` is empty.
 - **401 Unauthorized** — the key in `Secrets.xcconfig` doesn't match the
   server's `INGEST_API_KEY`, or ingest is disabled (`INGEST_ENABLED=false`).
 - **Add failed (4xx/5xx)** — the alert includes the server's response body;
-  check the server logs for `POST /api/ingest/link`.
+  check the server logs for `POST /api/ingest/link` (a shared link) or
+  `POST /api/ingest/photo` (a shared image).
 - **"ios platform already exists"** on `cap add` — a leftover `ios/` directory
   is present. It's fully generated and gitignored, so just `rm -rf ios` and run
   `bun run cap:add` again. (The hand-authored sources live in `native/`, not

--- a/native/ShareExtension/Info.plist
+++ b/native/ShareExtension/Info.plist
@@ -35,17 +35,21 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<!-- Offer the extension whenever the share payload contains a web
-			     URL or text that may embed a URL. NSExtensionActivationSupportsWebPage
-			     is intentionally NOT used: it requires an NSExtensionJavaScriptPreprocessingFile,
-			     and without one the whole activation rule is malformed and iOS silently
-			     drops the extension from the share sheet. We only need the URL, which
-			     WebURL/Text already cover. -->
+			     URL, text that may embed a URL, or an image (a shared photo, e.g.
+			     a record cover). NSExtensionActivationSupportsWebPage is
+			     intentionally NOT used: it requires an
+			     NSExtensionJavaScriptPreprocessingFile, and without one the whole
+			     activation rule is malformed and iOS silently drops the extension
+			     from the share sheet. We only need the URL, which WebURL/Text
+			     already cover. -->
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
 		</dict>
 	</dict>

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -57,7 +57,16 @@ final class ShareViewController: UIViewController {
         case failure(String)
     }
 
-    private var sharedURL: URL?
+    /// What the user is sharing: a link (posted to `/api/ingest/link`) or an
+    /// image (posted to `/api/ingest/photo`). The compose form, note, list
+    /// picker, and reminder are identical either way — only the endpoint and
+    /// payload differ.
+    private enum SharedContent {
+        case link(URL)
+        case image(Data)
+    }
+
+    private var sharedContent: SharedContent?
     private var stackNames: [String] = []
     private var selectedListNames: [String] = []
 
@@ -100,10 +109,17 @@ final class ShareViewController: UIViewController {
         compose.onPickList = { [weak self] in self?.pushListPicker() }
         compose.onSubmit = { [weak self] note, remindAt in self?.submit(note: note, remindAt: remindAt) }
 
-        extractSharedURL { [weak self] url in
+        extractSharedContent { [weak self] content in
             guard let self else { return }
-            self.sharedURL = url
-            self.compose.setURL(url)
+            self.sharedContent = content
+            switch content {
+            case .link(let url):
+                self.compose.setURL(url)
+            case .image(let data):
+                self.compose.setImage(UIImage(data: data))
+            case nil:
+                self.compose.setURL(nil)
+            }
         }
         fetchStacks()
     }
@@ -129,12 +145,12 @@ final class ShareViewController: UIViewController {
     // MARK: - Submit / cancel
 
     private func submit(note: String, remindAt: Date?) {
-        guard let url = sharedURL else {
+        guard let sharedContent else {
             cancel()
             return
         }
-        compose.setPosting(true)
-        postLink(url: url, note: note, listNames: selectedListNames, remindAt: remindAt) { [weak self] result in
+
+        let handle: (PostResult) -> Void = { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let message):
@@ -143,6 +159,26 @@ final class ShareViewController: UIViewController {
                 self.compose.setPosting(false)
                 self.presentError(message)
             }
+        }
+
+        compose.setPosting(true)
+        switch sharedContent {
+        case .link(let url):
+            postLink(
+                url: url,
+                note: note,
+                listNames: selectedListNames,
+                remindAt: remindAt,
+                completion: handle
+            )
+        case .image(let data):
+            postPhoto(
+                imageData: data,
+                note: note,
+                listNames: selectedListNames,
+                remindAt: remindAt,
+                completion: handle
+            )
         }
     }
 
@@ -217,37 +253,56 @@ final class ShareViewController: UIViewController {
         extensionContext?.cancelRequest(withError: error)
     }
 
-    // MARK: - Extracting the shared URL
+    // MARK: - Extracting the shared content
 
-    /// Walks the extension's input items looking for a URL. Handles the shapes
-    /// the system delivers: a real `public.url` attachment (most apps) and a
-    /// `public.plain-text` blob that contains a URL somewhere in it (Safari
-    /// often shares "Page Title\nhttps://…"). If neither attachment yields a
-    /// URL, falls back to the item's attributed text — some apps (e.g. Apple
-    /// Music) carry the link there rather than as an attachment.
+    /// Walks the extension's input items to work out what's being shared: a
+    /// link or an image.
     ///
-    /// Whatever the branch, `url(from:)` does the decoding, because the loaded
-    /// item is not always a `URL`: on macOS a `public.url` item arrives as
-    /// `Data` holding the URL string (see below), and text branches arrive as
+    /// A **link** is preferred when present — the common case is a music URL,
+    /// and a shared web page often carries a thumbnail image we don't want. So
+    /// we look for a URL first (a real `public.url` attachment, most apps),
+    /// then a `public.plain-text` blob that embeds a URL (Safari often shares
+    /// "Page Title\nhttps://…"), and only if neither yields a link do we fall
+    /// back to an **image** attachment (a shared photo, e.g. a record cover).
+    /// The very last resort is a URL recovered from the item's attributed text
+    /// — some apps (e.g. Apple Music) carry the link there rather than as an
+    /// attachment.
+    ///
+    /// For links, `url(from:)` does the decoding, because the loaded item is
+    /// not always a `URL`: on macOS a `public.url` item arrives as `Data`
+    /// holding the URL string (see below), and text branches arrive as
     /// `String`. Getting that coercion wrong is what left the Add button
     /// permanently disabled when sharing from Apple Music on macOS.
-    private func extractSharedURL(completion: @escaping (URL?) -> Void) {
+    private func extractSharedContent(completion: @escaping (SharedContent?) -> Void) {
         let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
         let providers = items.flatMap { $0.attachments ?? [] }
 
         let urlType = UTType.url.identifier
         let textType = UTType.plainText.identifier
+        let imageType = UTType.image.identifier
 
-        // Last resort: recover a link from the item's attributed text.
+        let imageProvider = providers.first { $0.hasItemConformingToTypeIdentifier(imageType) }
+
+        // No link found: use a shared image if there is one, otherwise recover a
+        // link from the item's attributed text as a final fallback.
         let fallback: () -> Void = {
-            let text = items.compactMap { $0.attributedContentText?.string }.joined(separator: "\n")
-            completion(Self.firstURL(in: text))
+            if let imageProvider {
+                self.loadImage(from: imageProvider) { data in
+                    if let data {
+                        completion(.image(data))
+                    } else {
+                        completion(Self.linkFromText(items))
+                    }
+                }
+            } else {
+                completion(Self.linkFromText(items))
+            }
         }
 
         if let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(urlType) }) {
             provider.loadItem(forTypeIdentifier: urlType, options: nil) { item, _ in
                 DispatchQueue.main.async {
-                    if let url = Self.url(from: item) { completion(url) } else { fallback() }
+                    if let url = Self.url(from: item) { completion(.link(url)) } else { fallback() }
                 }
             }
             return
@@ -256,13 +311,66 @@ final class ShareViewController: UIViewController {
         if let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(textType) }) {
             provider.loadItem(forTypeIdentifier: textType, options: nil) { item, _ in
                 DispatchQueue.main.async {
-                    if let url = Self.url(from: item) { completion(url) } else { fallback() }
+                    if let url = Self.url(from: item) { completion(.link(url)) } else { fallback() }
                 }
             }
             return
         }
 
         fallback()
+    }
+
+    /// Recovers a `.link` from the input items' attributed text, or `nil`.
+    private nonisolated static func linkFromText(_ items: [NSExtensionItem]) -> SharedContent? {
+        let text = items.compactMap { $0.attributedContentText?.string }.joined(separator: "\n")
+        return firstURL(in: text).map { .link($0) }
+    }
+
+    /// Loads an image attachment and hands back downscaled JPEG bytes on the
+    /// main queue, or `nil` if it couldn't be decoded.
+    private func loadImage(from provider: NSItemProvider, completion: @escaping (Data?) -> Void) {
+        provider.loadItem(forTypeIdentifier: UTType.image.identifier, options: nil) { item, _ in
+            let data = Self.imageData(from: item)
+            DispatchQueue.main.async { completion(data) }
+        }
+    }
+
+    /// Coerces whatever `loadItem` hands back for an image into downscaled JPEG
+    /// bytes. Depending on the source app the item is a file `URL`, raw `Data`,
+    /// or a `UIImage`. We normalise to a `UIImage`, then re-encode via
+    /// `downscaledJPEG(_:)` so the upload stays under the server's size cap
+    /// (see `MAX_IMAGE_BASE64_LENGTH` in server/uploads.ts); a full-resolution
+    /// phone photo would otherwise be rejected as too large.
+    private nonisolated static func imageData(from item: NSSecureCoding?) -> Data? {
+        let image: UIImage?
+        if let uiImage = item as? UIImage {
+            image = uiImage
+        } else if let url = item as? URL, let data = try? Data(contentsOf: url) {
+            image = UIImage(data: data)
+        } else if let data = item as? Data {
+            image = UIImage(data: data)
+        } else {
+            image = nil
+        }
+        return image.flatMap(downscaledJPEG)
+    }
+
+    /// Downscales an image so its longest edge is at most 1024px and encodes it
+    /// as JPEG — mirroring the web app's `encodeImageFile` (src/lib/encode-image.ts)
+    /// so both share paths produce uploads comfortably under the server limit.
+    private nonisolated static func downscaledJPEG(_ image: UIImage) -> Data? {
+        let maxEdge: CGFloat = 1024
+        let longest = max(image.size.width, image.size.height)
+        let scale = longest > maxEdge ? maxEdge / longest : 1
+        let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: target, format: format)
+        let resized = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: target))
+        }
+        return resized.jpegData(compressionQuality: 0.85)
     }
 
     /// Coerces whatever `NSItemProvider.loadItem` hands back into a URL.
@@ -369,6 +477,59 @@ final class ShareViewController: UIViewController {
         }.resume()
     }
 
+    /// Posts a shared image to `/api/ingest/photo`. The image is sent as base64
+    /// JSON — the same shape the web add-form's scan flow uses — alongside the
+    /// same note, lists, and reminder the link path sends, so the server files
+    /// and schedules the created item identically. The response is decoded by
+    /// the shared `successMessage(from:)`, so the confirmation toast ("Added to
+    /// Jazz, Chill") reads the same for a photo as for a link.
+    private func postPhoto(
+        imageData: Data,
+        note: String,
+        listNames: [String],
+        remindAt: Date?,
+        completion: @escaping (PostResult) -> Void
+    ) {
+        guard let endpoint = URL(string: baseURL + "/api/ingest/photo") else {
+            completion(.failure("Misconfigured server URL."))
+            return
+        }
+        guard !apiKey.isEmpty else {
+            completion(.failure("Missing ingest API key in build config."))
+            return
+        }
+
+        var payload: [String: Any] = ["imageBase64": imageData.base64EncodedString()]
+        if !note.isEmpty { payload["notes"] = note }
+        if !listNames.isEmpty { payload["listNames"] = listNames }
+        if let remindAt { payload["remindAt"] = Self.scheduleFormatter.string(from: remindAt) }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+        request.timeoutInterval = 30
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            let result: PostResult
+            if let error {
+                result = .failure("Couldn't reach On The Beach: \(error.localizedDescription)")
+            } else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                if (200...299).contains(status) {
+                    result = .success(Self.successMessage(from: data))
+                } else if status == 401 {
+                    result = .failure("Unauthorized — check the ingest API key.")
+                } else {
+                    let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                    result = .failure("Add failed (\(status)). \(body)")
+                }
+            }
+            DispatchQueue.main.async { completion(result) }
+        }.resume()
+    }
+
     /// Builds the confirmation toast text from the ingest response: "Added",
     /// "Added to Jazz, Chill", or "Already saved" when the link was a duplicate
     /// (still worth confirming — a re-share still files it into lists and sets
@@ -401,6 +562,8 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
     var onPickList: (() -> Void)?
 
     private let urlLabel = UILabel()
+    private let imagePreview = UIImageView()
+    private let imageWell = BeveledView(style: .field, fill: OTBTheme.chromeWhite)
     private let noteView = UITextView()
     private let notePlaceholder = UILabel()
     private let listValueLabel = UILabel()
@@ -428,6 +591,15 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         urlLabel.textColor = OTBTheme.navy
         urlLabel.numberOfLines = 2
         urlLabel.lineBreakMode = .byTruncatingMiddle
+
+        // A shared image gets a sunken white well preview, seated inside the 2px
+        // bevel like the note field. Hidden until an image is actually shared.
+        imagePreview.contentMode = .scaleAspectFit
+        imagePreview.clipsToBounds = true
+        imagePreview.translatesAutoresizingMaskIntoConstraints = false
+        imageWell.translatesAutoresizingMaskIntoConstraints = false
+        imageWell.addSubview(imagePreview)
+        imageWell.isHidden = true
 
         // A sunken white well for the note, matching the app's --bevel-field inputs.
         noteView.font = OTBTheme.ui(14)
@@ -461,7 +633,7 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         let listRow = makeListRow()
         let scheduleRow = makeScheduleRow()
 
-        let stack = UIStackView(arrangedSubviews: [urlLabel, noteField, listRow, scheduleRow, datePicker])
+        let stack = UIStackView(arrangedSubviews: [urlLabel, imageWell, noteField, listRow, scheduleRow, datePicker])
         stack.axis = .vertical
         stack.spacing = 12
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -472,6 +644,11 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
             stack.topAnchor.constraint(equalTo: guide.topAnchor, constant: 16),
             stack.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 16),
             stack.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: -16),
+            imageWell.heightAnchor.constraint(equalToConstant: 140),
+            imagePreview.topAnchor.constraint(equalTo: imageWell.topAnchor, constant: 2),
+            imagePreview.bottomAnchor.constraint(equalTo: imageWell.bottomAnchor, constant: -2),
+            imagePreview.leadingAnchor.constraint(equalTo: imageWell.leadingAnchor, constant: 2),
+            imagePreview.trailingAnchor.constraint(equalTo: imageWell.trailingAnchor, constant: -2),
             noteField.heightAnchor.constraint(equalToConstant: 96),
             noteView.topAnchor.constraint(equalTo: noteField.topAnchor, constant: 2),
             noteView.bottomAnchor.constraint(equalTo: noteField.bottomAnchor, constant: -2),
@@ -559,7 +736,26 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
 
     func setURL(_ url: URL?) {
         urlLabel.text = url?.absoluteString
-        addButton.isEnabled = (url != nil) && !isPosting
+        urlLabel.isHidden = url == nil
+        imageWell.isHidden = true
+        setHasContent(url != nil)
+    }
+
+    /// Shows the shared image in the preview well and enables Add. Called
+    /// instead of `setURL` when the share payload is a photo rather than a link.
+    func setImage(_ image: UIImage?) {
+        imagePreview.image = image
+        imageWell.isHidden = image == nil
+        urlLabel.isHidden = true
+        setHasContent(image != nil)
+    }
+
+    /// Tracks whether there's anything to post (a URL or an image), so both the
+    /// initial extraction and `setPosting` gate the Add button off the same flag.
+    private var hasContent = false
+    private func setHasContent(_ value: Bool) {
+        hasContent = value
+        addButton.isEnabled = value && !isPosting
     }
 
     /// Reflects the chosen lists in the "List" row: "None", the single name, or
@@ -580,7 +776,7 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         } else {
             spinner.stopAnimating()
             navigationItem.rightBarButtonItem = addButton
-            addButton.isEnabled = urlLabel.text != nil
+            addButton.isEnabled = hasContent
         }
     }
 

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -398,28 +398,46 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
     let imageBase64: unknown;
     let notes: unknown;
     let from: unknown;
+    // Lists and an optional reminder date the item should be filed with — the
+    // share sheet sends these for a photo just as it does for a link, so a
+    // shared image lands in the same lists (and gets the same "Remind me" date)
+    // as a shared URL would.
+    let listNames: string[] = [];
+    let remindAtRaw: unknown;
 
     const contentType = c.req.header("Content-Type") ?? "";
 
     if (contentType.includes("multipart/form-data")) {
       // iPhone Shortcuts and other clients send the photo as a file field.
-      let form: Record<string, string | File>;
+      // `all: true` collects repeated fields (e.g. several `listNames`) into an
+      // array while leaving single-valued fields untouched.
+      let form: Record<string, string | File | (string | File)[]>;
       try {
-        form = (await c.req.parseBody()) as Record<string, string | File>;
+        form = await c.req.parseBody({ all: true });
       } catch (err) {
         console.error("[api] POST /api/ingest/photo invalid form data:", err);
         return c.json({ error: "Invalid form data" }, 400);
       }
 
-      const file = form.photo ?? form.image ?? form.file;
+      const fileField = form.photo ?? form.image ?? form.file;
+      const file = Array.isArray(fileField) ? fileField[0] : fileField;
       if (!(file instanceof File)) {
         return c.json({ error: "photo file is required" }, 400);
       }
 
       const buffer = Buffer.from(await file.arrayBuffer());
       imageBase64 = buffer.toString("base64");
-      notes = form.notes;
-      from = form.from;
+      notes = Array.isArray(form.notes) ? form.notes[0] : form.notes;
+      from = Array.isArray(form.from) ? form.from[0] : form.from;
+      listNames = collectListNames({
+        listName: Array.isArray(form.listName) ? form.listName[0] : form.listName,
+        listNames: Array.isArray(form.listNames)
+          ? form.listNames
+          : form.listNames !== undefined
+            ? [form.listNames]
+            : [],
+      });
+      remindAtRaw = Array.isArray(form.remindAt) ? form.remindAt[0] : form.remindAt;
     } else {
       let body: unknown;
       try {
@@ -433,13 +451,24 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
         return c.json({ error: "Invalid JSON payload" }, 400);
       }
 
-      ({ imageBase64, notes, from } = body as Record<string, unknown>);
+      const record = body as Record<string, unknown>;
+      ({ imageBase64, notes, from } = record);
+      listNames = collectListNames(record);
+      remindAtRaw = record.remindAt;
     }
 
     const validation = validateImageBase64(imageBase64);
     if (!validation.ok) {
       return c.json({ error: validation.error }, 400);
     }
+
+    // Validate the reminder before saving anything, so a mis-formatted date
+    // fails cleanly instead of leaving an orphaned upload behind.
+    const remindAtResult = parseRemindAt({ remindAt: remindAtRaw });
+    if ("error" in remindAtResult) {
+      return c.json({ error: remindAtResult.error }, 400);
+    }
+    const remindAt = remindAtResult.date;
 
     let artworkUrl: string;
     try {
@@ -474,6 +503,17 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
         notes: noteParts.length ? noteParts.join(" — ") : undefined,
       });
 
+      // File the new item into every chosen list (creating any that are new),
+      // then apply the reminder — mirroring the /link path so the share sheet's
+      // list and "Remind me" controls behave the same for a photo.
+      const lists = await Promise.all(listNames.map((name) => resolveOrCreateStack(name)));
+      for (const list of lists) {
+        await attachItemToStack(result.item.id, list.id);
+      }
+      if (remindAt) {
+        await setItemReminder(result.item.id, remindAt);
+      }
+
       scheduleAppleMusicBackfill(result.item.id);
 
       return c.json({
@@ -487,6 +527,7 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
             artworkUrl,
           },
         ],
+        lists,
         scan: scan
           ? {
               artist: scan.artist,

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -801,6 +801,9 @@ describe("POST /api/ingest/photo", () => {
     mockSaveImage.mockResolvedValue("/uploads/abc.jpg");
     mockScan.mockReset();
     mockScan.mockResolvedValue(null);
+    mockResolveOrCreateStack.mockReset();
+    mockAttachItemToStack.mockReset();
+    mockSetItemReminder.mockReset();
   });
 
   afterEach(() => {
@@ -1082,5 +1085,123 @@ describe("POST /api/ingest/photo", () => {
     const body = await res.json();
     expect(body.error).toContain("photo");
     expect(mockSaveImage).not.toHaveBeenCalled();
+  });
+
+  it("files the created item into the chosen lists", async () => {
+    mockCreateDirect.mockResolvedValue({ item: { id: 42, title: "Untitled" }, created: true });
+    mockResolveOrCreateStack.mockImplementation(
+      async (name: string) => ({ "Jazz finds": { id: 3, name }, Wishlist: { id: 5, name } })[name],
+    );
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64, listNames: ["Jazz finds", "Wishlist"] },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(mockResolveOrCreateStack).toHaveBeenCalledWith("Jazz finds");
+    expect(mockResolveOrCreateStack).toHaveBeenCalledWith("Wishlist");
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(42, 3);
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(42, 5);
+    expect(body.lists).toEqual([
+      { id: 3, name: "Jazz finds" },
+      { id: 5, name: "Wishlist" },
+    ]);
+  });
+
+  it("accepts the legacy single listName", async () => {
+    mockCreateDirect.mockResolvedValue({ item: { id: 7, title: "Untitled" }, created: true });
+    mockResolveOrCreateStack.mockResolvedValue({ id: 3, name: "Jazz finds" });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64, listName: "Jazz finds" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(7, 3);
+    expect(body.lists).toEqual([{ id: 3, name: "Jazz finds" }]);
+  });
+
+  it("does not touch lists when none are given", async () => {
+    mockCreateDirect.mockResolvedValue({ item: { id: 1, title: "Untitled" }, created: true });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(app, { imageBase64: validBase64 }, { apiKey: "test-secret" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(mockResolveOrCreateStack).not.toHaveBeenCalled();
+    expect(mockAttachItemToStack).not.toHaveBeenCalled();
+    expect(body.lists).toEqual([]);
+  });
+
+  it("sets a reminder on the created item", async () => {
+    mockCreateDirect.mockResolvedValue({ item: { id: 8, title: "Untitled" }, created: true });
+
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64, remindAt: "2026-08-01" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSetItemReminder).toHaveBeenCalledTimes(1);
+    const [itemId, date] = mockSetItemReminder.mock.calls[0];
+    expect(itemId).toBe(8);
+    expect((date as Date).toISOString()).toBe(new Date("2026-08-01").toISOString());
+  });
+
+  it("returns 400 for an invalid reminder date and saves nothing", async () => {
+    const app = makeApp();
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64, remindAt: "not-a-date" },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("remindAt");
+    expect(mockSaveImage).not.toHaveBeenCalled();
+    expect(mockCreateDirect).not.toHaveBeenCalled();
+  });
+
+  it("files a multipart upload into lists and sets a reminder", async () => {
+    mockCreateDirect.mockResolvedValue({ item: { id: 5, title: "Untitled" }, created: true });
+    mockResolveOrCreateStack.mockImplementation(
+      async (name: string) => ({ "Jazz finds": { id: 3, name }, Wishlist: { id: 5, name } })[name],
+    );
+
+    const imageBytes = new Uint8Array([1, 2, 3, 4]);
+    const form = new FormData();
+    form.append("photo", new File([imageBytes], "cover.jpg", { type: "image/jpeg" }));
+    form.append("listNames", "Jazz finds");
+    form.append("listNames", "Wishlist");
+    form.append("remindAt", "2026-08-01");
+
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/ingest/photo", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret" },
+      body: form,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(5, 3);
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(5, 5);
+    expect(mockSetItemReminder).toHaveBeenCalledWith(5, expect.any(Date));
+    expect(body.lists).toEqual([
+      { id: 3, name: "Jazz finds" },
+      { id: 5, name: "Wishlist" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Lets users submit **images** through the iOS/macOS share sheet, not just links.

The server already had a `POST /api/ingest/photo` endpoint (saves the image, scans it for release metadata, creates an item), but the Share Extension only handled links — it wasn't even offered in the share sheet for a photo. So sharing a record cover from Photos did nothing. This wires up the missing image path end to end.

## Changes

**Extension (`native/ShareExtension/`)**
- **Info.plist**: added `NSExtensionActivationSupportsImageWithMaxCount`, so On The Beach appears in the share sheet when sharing a photo.
- **ShareViewController.swift**: models the shared payload as `.link` or `.image`. A link still wins when the share carries both (a shared web page often includes a thumbnail we don't want); otherwise it loads the image attachment (file `URL`, `Data`, or `UIImage`), downscales it to a 1024px JPEG — mirroring the web add-form's `encodeImageFile` so the upload stays under the server's ~1.5 MB cap — and posts it as base64 to `/api/ingest/photo`. The compose form shows an image preview in place of the URL line and reuses the same note, list picker, reminder, and confirmation toast.

**Server (`server/routes/ingest.ts`)**
- Extended `POST /api/ingest/photo` to accept `listNames`/`listName` and `remindAt` (both JSON and multipart), file the created item into those lists, set the reminder, and return `lists` — matching the `/link` path so a shared image lands in the same lists and schedule as a shared URL. The reminder is validated before the image is saved, so a bad date can't leave an orphaned upload.

**Docs & tests**
- Updated the native-app guide (`docs/ios-native-app.md`) and server-routes doc.
- Added 6 unit tests for the photo endpoint's new list/reminder behaviour across JSON and multipart.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean (the 3 warnings are pre-existing in untouched files)
- `bun run test:unit` — 547 pass
- Swift wasn't compiled locally (no toolchain in the dev environment); the `ios-build` GitHub Actions workflow builds the extension on every PR and will confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011nvidYV7iL9ci2cooyPcDk)_