### PR TITLE
Add Lock Screen variants of the "To Listen" widget

### DIFF
--- a/native/Widget/OTBWidget.swift
+++ b/native/Widget/OTBWidget.swift
@@ -103,6 +103,11 @@ struct OTBProvider: TimelineProvider {
 // MARK: - View
 
 struct OTBWidgetEntryView: View {
+    // Which family this instance is rendering — drives the per-surface layout.
+    // The Home Screen family keeps the full app look; the Lock Screen accessory
+    // families use compact layouts the system draws in monochrome (custom colors
+    // are ignored there), so they carry the app's *type* and wording instead.
+    @Environment(\.widgetFamily) private var family
     var entry: OTBEntry
 
     private var countText: String {
@@ -110,7 +115,56 @@ struct OTBWidgetEntryView: View {
         return "\(n)"
     }
 
+    private var releaseWord: String {
+        entry.toListen == 1 ? "release" : "releases"
+    }
+
     var body: some View {
+        switch family {
+        case .accessoryInline:
+            // A single line beside the Lock Screen clock, e.g. "12 to listen".
+            Text("\(countText) to listen")
+                .font(OTBTheme.mono(11))
+
+        case .accessoryCircular:
+            // Circular Lock Screen slot: the glanceable number over the standard
+            // translucent accessory background.
+            ZStack {
+                AccessoryWidgetBackground()
+                VStack(spacing: 0) {
+                    Text(countText)
+                        .font(OTBTheme.number(22))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.4)
+                    Text("QUEUED")
+                        .font(OTBTheme.mono(8))
+                }
+            }
+            .containerBackground(for: .widget) { Color.clear }
+
+        case .accessoryRectangular:
+            // Wide Lock Screen slot: number + the same TO LISTEN / releases lines
+            // the Home Screen widget uses, so it reads as the same app.
+            HStack(spacing: 10) {
+                Text(countText)
+                    .font(OTBTheme.number(34))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.4)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("TO LISTEN").font(OTBTheme.mono(11))
+                    Text(releaseWord).font(OTBTheme.ui(11))
+                }
+            }
+            .containerBackground(for: .widget) { Color.clear }
+
+        default:
+            homeScreen
+        }
+    }
+
+    // The original Home Screen (systemSmall) layout — the full app aesthetic:
+    // black playlist well, electric-blue count, Verdana/Courier chrome.
+    private var homeScreen: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("TO LISTEN")
                 .font(OTBTheme.mono(11))
@@ -126,7 +180,7 @@ struct OTBWidgetEntryView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.4)
 
-            Text(entry.toListen == 1 ? "release" : "releases")
+            Text(releaseWord)
                 .font(OTBTheme.ui(11))
                 .foregroundStyle(OTBTheme.playlistText.opacity(0.7))
                 .lineLimit(1)
@@ -150,7 +204,14 @@ struct OTBWidget: Widget {
         }
         .configurationDisplayName("To Listen")
         .description("How many releases are queued to listen to.")
-        .supportedFamilies([.systemSmall])
+        // Home Screen (systemSmall) keeps the full app look; the accessory
+        // families put the same count on the Lock Screen (rendered monochrome).
+        .supportedFamilies([
+            .systemSmall,
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+        ])
     }
 }
 


### PR DESCRIPTION
## What

Adds Lock Screen support to the existing **To Listen** home-screen widget. The widget previously vended only `.systemSmall` (Home Screen); it now also offers the three Lock Screen accessory families:

- **Circular** — the count in a round slot
- **Rectangular** — the count next to `TO LISTEN` / releases
- **Inline** — a single line beside the clock ("12 to listen")

The Home Screen widget is unchanged.

## How

`OTBWidgetEntryView` now branches on `@Environment(\.widgetFamily)`, with a dedicated compact layout per accessory family and the original layout preserved as `homeScreen`. `supportedFamilies` gains the three accessory families.

All families share the same `OTBProvider` timeline (`GET /api/ingest/stats`), so the count stays in sync across every placement.

## Aesthetic note

iOS renders Lock Screen accessory widgets in forced **vibrant monochrome** — custom colors (the black playlist well / electric-blue accent) are ignored there by the system. The accessory layouts therefore carry the app's identity through **typography and wording** (Verdana number, Courier `TO LISTEN` label) rather than color. The Home Screen widget keeps the full app palette.

## Testing

Built + installed on a physical iPhone via `bun run ios`; both `ShareExtension.appex` and `OTBWidget.appex` sign and embed. CI (`ios-build.yml`) rebuilds the widget target on this PR.