### PR TITLE
Show half stars live while hovering the rating control

### DIFF
--- a/playwright/rating.spec.ts
+++ b/playwright/rating.spec.ts
@@ -43,3 +43,28 @@ test("star rating appears on to-listen items and persists", async ({ page }) => 
   ]);
   await expect(reloadedCard.locator('[data-rating-star="3"]')).not.toHaveClass(/is-active/);
 });
+
+test("half stars preview live while hovering, before any click", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.locator('input[name="title"]').fill("Hover Release");
+  await page.getByRole("button", { name: "Add" }).click();
+  const star = page.locator(".music-card").first().locator('[data-rating-star="4"]');
+  await expect(star).toBeVisible({ timeout: 10_000 });
+
+  // Hover the LEFT half of the 4th star: it should paint as a half live, with
+  // no click and nothing committed yet.
+  const box = await star.boundingBox();
+  if (!box) throw new Error("star has no bounding box");
+  await page.mouse.move(box.x + box.width * 0.25, box.y + box.height / 2);
+  await expect(star).toHaveClass(/is-active-half/);
+
+  // Sweep to the right half of the same star: it fills whole, still no click.
+  await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2);
+  await expect(star).toHaveClass(/is-active-full/);
+
+  // Moving the pointer away drops the preview entirely (nothing was committed).
+  await page.mouse.move(box.x, box.y - 100);
+  await expect(star).not.toHaveClass(/is-active/);
+});

--- a/src/lib/components/StarRating.svelte
+++ b/src/lib/components/StarRating.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { normalizeStarRating } from "../../ui/components/star-rating";
-
-  const MAX_RATING = 5;
-  const HALF_STEP = 0.5;
+  import {
+    MAX_STARS,
+    normalizeStarRating,
+    ratingForPointer,
+    starFill,
+  } from "../../ui/components/star-rating-model";
 
   let {
     itemId,
@@ -17,54 +19,42 @@
     onRate: (next: number | null) => Promise<void>;
   } = $props();
 
+  // The committed rating, mirrored from props (optimistically updated on click).
   let selected = $state<number | null>(null);
   $effect.pre(() => {
     selected = normalizeStarRating(rating);
   });
 
+  // The live hover value; null when the pointer is away. Never persisted.
   let preview = $state<number | null>(null);
   let pending = $state(false);
 
+  // What the stars actually paint: hover wins over the committed selection.
   const effective = $derived(preview ?? selected);
 
-  type Fill = "empty" | "half" | "full";
+  // Descending so DOM order is 5..1; `row-reverse` paints them left-to-right.
+  const stars = Array.from({ length: MAX_STARS }, (_, i) => MAX_STARS - i);
 
-  function fillFor(value: number | null, starValue: number): Fill {
-    if (value === null) return "empty";
-    if (value >= starValue) return "full";
-    if (Math.abs(value - (starValue - HALF_STEP)) < 0.001) return "half";
-    return "empty";
-  }
-
-  function resolveValueFromPointer(starValue: number, event: MouseEvent): number | null {
-    // Keyboard-triggered click events select the whole star.
-    if (event.detail === 0) return starValue;
-
-    const button = (event.currentTarget ?? event.target) as HTMLElement;
-    const rect = button.getBoundingClientRect();
-    if (rect.width <= 0) return starValue;
-
-    const isLeftHalf = event.clientX - rect.left < rect.width / 2;
-    return normalizeStarRating(isLeftHalf ? starValue - HALF_STEP : starValue);
+  /** Fraction (0..1) of how far across a star button the pointer sits. */
+  function pointerFraction(event: PointerEvent | MouseEvent): number {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    if (rect.width <= 0) return 1;
+    const x = event.clientX - rect.left;
+    return Math.min(1, Math.max(0, x / rect.width));
   }
 
   function onPointerMove(starValue: number, event: PointerEvent): void {
     if (pending) return;
-    preview = resolveValueFromPointer(starValue, event);
+    // A hover is purely positional — always derive the half from where we are.
+    preview = ratingForPointer(starValue, pointerFraction(event));
   }
 
   function onPointerLeave(): void {
     preview = null;
   }
 
-  async function onClick(starValue: number, event: MouseEvent): Promise<void> {
-    if (pending) return;
-    const value = resolveValueFromPointer(starValue, event);
-    if (value === null) return;
-
+  async function commit(next: number | null): Promise<void> {
     const previous = selected;
-    const next = previous === value ? null : value;
-
     preview = null;
     selected = next;
     pending = true;
@@ -78,6 +68,17 @@
       pending = false;
     }
   }
+
+  async function onClick(starValue: number, event: MouseEvent): Promise<void> {
+    if (pending) return;
+    // Keyboard activation (Enter/Space) reports detail 0 and has no position —
+    // it means "the whole star". A mouse click uses the pointer geometry.
+    const value =
+      event.detail === 0 ? starValue : ratingForPointer(starValue, pointerFraction(event));
+    if (value === null) return;
+    // Clicking the already-selected value clears the rating.
+    await commit(selected === value ? null : value);
+  }
 </script>
 
 <div
@@ -90,9 +91,9 @@
   aria-label="Rating"
   onpointerleave={onPointerLeave}
 >
-  {#each Array.from({ length: MAX_RATING }, (_, index) => MAX_RATING - index) as value (value)}
-    {@const fill = fillFor(effective, value)}
-    {@const selectedFill = fillFor(selected, value)}
+  {#each stars as value (value)}
+    {@const fill = starFill(effective, value)}
+    {@const selectedFill = starFill(selected, value)}
     <button
       type="button"
       class="rating-stars__star"

--- a/src/ui/components/star-rating-model.ts
+++ b/src/ui/components/star-rating-model.ts
@@ -1,0 +1,45 @@
+import { normalizeStarRating } from "./star-rating";
+
+export const MAX_STARS = 5;
+export const HALF_STEP = 0.5;
+
+export type StarFill = "empty" | "half" | "full";
+
+export { normalizeStarRating };
+
+/**
+ * How much of a single star glyph should be painted, given the effective
+ * rating (either the committed selection or the live hover preview).
+ */
+export function starFill(rating: number | null, starValue: number): StarFill {
+  if (rating === null) return "empty";
+  if (rating >= starValue) return "full";
+  if (Math.abs(rating - (starValue - HALF_STEP)) < 0.001) return "half";
+  return "empty";
+}
+
+/**
+ * Map a pointer's horizontal position over a star to a rating value.
+ *
+ * `fraction` is how far across the star the pointer sits, 0 (left edge) to 1
+ * (right edge). This is pure geometry — no DOM, no events — so the component
+ * can call it from pointermove and it's trivially unit-testable.
+ *
+ * TODO(you): implement the half-vs-full decision.
+ *
+ * DESIGN DECISION — where does the "half star" boundary sit, and how forgiving
+ * is it? The obvious rule is: left half of the glyph → `starValue - 0.5`, right
+ * half → `starValue`. But you might decide the half-zone should be wider (easier
+ * to land a half on small 24px targets) or that touch should always snap to the
+ * whole star. Whatever you pick, run the result through `normalizeStarRating`
+ * so it stays a valid half-step in range, and return that.
+ *
+ * @param starValue  the whole-star value this glyph represents (1..5)
+ * @param fraction   pointer position across the glyph, clamped to [0, 1]
+ */
+export function ratingForPointer(starValue: number, fraction: number): number | null {
+  // Simple midpoint: the left half of the glyph is a half-star, the right half
+  // is the whole star. Predictable and matches the painted 50/50 gradient.
+  const value = fraction < 0.5 ? starValue - HALF_STEP : starValue;
+  return normalizeStarRating(value);
+}

--- a/tests/unit/star-rating-model.test.ts
+++ b/tests/unit/star-rating-model.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+
+import { ratingForPointer, starFill } from "../../src/ui/components/star-rating-model";
+
+describe("starFill", () => {
+  it("paints stars at or below the rating as full", () => {
+    expect(starFill(3, 1)).toBe("full");
+    expect(starFill(3, 3)).toBe("full");
+  });
+
+  it("paints the boundary star as half on a half-step rating", () => {
+    expect(starFill(3.5, 4)).toBe("half");
+    expect(starFill(3.5, 3)).toBe("full");
+    expect(starFill(3.5, 5)).toBe("empty");
+  });
+
+  it("paints nothing when there is no rating", () => {
+    expect(starFill(null, 1)).toBe("empty");
+  });
+});
+
+describe("ratingForPointer", () => {
+  it("returns a half star when the pointer is in the left half", () => {
+    expect(ratingForPointer(4, 0)).toBe(3.5);
+    expect(ratingForPointer(4, 0.3)).toBe(3.5);
+    expect(ratingForPointer(4, 0.49)).toBe(3.5);
+  });
+
+  it("returns the whole star when the pointer is in the right half", () => {
+    expect(ratingForPointer(4, 0.5)).toBe(4);
+    expect(ratingForPointer(4, 0.8)).toBe(4);
+    expect(ratingForPointer(4, 1)).toBe(4);
+  });
+
+  it("keeps the lowest half-star in range on the first star", () => {
+    expect(ratingForPointer(1, 0)).toBe(0.5);
+    expect(ratingForPointer(1, 1)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The star rating widget only rendered half stars **after** a value was committed — never during hover. Hovering the left half of a star showed a full star, and the half only appeared once you clicked.

**Root cause:** `StarRating.svelte` shared one resolver between hover and click that short-circuited on `event.detail === 0` to detect keyboard activation. But `pointermove` events *also* report `detail: 0`, so every hover snapped to the whole star. A real mouse click reports `detail: 1`, so the geometry only ran on commit.

## Change

Remodel into a clean split of concerns:

- **New pure model** `src/ui/components/star-rating-model.ts` — holds the fill state (`starFill`) and the pointer→rating geometry (`ratingForPointer`), decoupled from the DOM so it's unit-testable directly.
- **`StarRating.svelte`** now treats hover as *purely positional* (derives the half from pointer X on every `pointermove`) and keyboard click as *semantic* (`detail === 0` = the whole star). Public props are unchanged (`itemId`, `rating`, `className`, `onRate`), so both call sites (`MusicCard`, `ReleasePage`) are untouched.

## Tests

- Unit tests for `starFill` + `ratingForPointer`.
- Playwright regression asserting a half paints **live on left-half hover before any click**, sweeps to full on the right half, and clears on pointer-leave — directly guarding the reported bug.

All green locally: unit, `typecheck`, `oxlint`, and the rating e2e spec.