### PR TITLE
Share extension: add an Add button to the list picker

### DIFF
--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -34,6 +34,11 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
   name. On **Add** it `POST`s the URL — plus `notes` and `listName` when set — to
   `POST /api/ingest/link` with a `Bearer` token. The extension talks to the server
   directly, so a share works even when the app isn't running.
+- The list picker carries **its own Add button** in the top right, doing exactly what
+  the compose form's does. Picking a list is usually the last decision, so this saves
+  a trip back to the first screen just to post. Whichever Add you tap, the same note,
+  lists, and reminder are sent, and the in-flight spinner / error alert appear on the
+  screen you're on.
 - **Sharing an image** works the same way. When the payload is a photo rather than a
   link (e.g. a record cover shared from Photos), the extension shows the same compose
   form — with an image preview in place of the URL line — and the same note, list,
@@ -256,7 +261,8 @@ suggests this automatically.
 Plug in an iPhone (share-sheet testing is best on a device), select the **App**
 scheme, and run. To use the extension: open Safari, tap **Share**, and pick
 **On The Beach**. You should see the compose form — type a note if you like, tap
-**List** to file it into a list (existing or new), then tap **Add**.
+**List** to file it into a list (existing or new), then tap **Add** — either the
+one on the compose form or the one in the list picker's top right.
 
 ### 6. Enable macOS (Mac Catalyst)
 

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -81,6 +81,9 @@ final class ShareViewController: UIViewController {
 
     private let compose = ComposeFormController()
     private lazy var navController = UINavigationController(rootViewController: compose)
+    /// The list picker while it's on screen, so posting state and the Add gate
+    /// can be kept in step with the compose form's.
+    private weak var listPicker: ListPickerViewController?
 
     // Read from the extension's Info.plist. `OTBBaseURL` is committed; the API
     // key is injected from a gitignored xcconfig at build time (see
@@ -107,7 +110,7 @@ final class ShareViewController: UIViewController {
 
         compose.onCancel = { [weak self] in self?.cancel() }
         compose.onPickList = { [weak self] in self?.pushListPicker() }
-        compose.onSubmit = { [weak self] note, remindAt in self?.submit(note: note, remindAt: remindAt) }
+        compose.onSubmit = { [weak self] in self?.submit() }
 
         extractSharedContent { [weak self] content in
             guard let self else { return }
@@ -120,6 +123,9 @@ final class ShareViewController: UIViewController {
             case nil:
                 self.compose.setURL(nil)
             }
+            // Extraction is async, so the picker may already be on screen when
+            // the content lands — ungate its Add button too.
+            self.listPicker?.canAdd = self.compose.canSubmit
         }
         fetchStacks()
     }
@@ -139,16 +145,27 @@ final class ShareViewController: UIViewController {
             }
             self.compose.setListNames(names)
         }
+        // Picking a list is usually the last thing the user does, so the picker
+        // carries its own Add button: post from here rather than making them
+        // walk back to the compose form just to tap the same button.
+        picker.canAdd = compose.canSubmit
+        picker.onAdd = { [weak self] in self?.submit() }
+        listPicker = picker
         navController.pushViewController(picker, animated: true)
     }
 
     // MARK: - Submit / cancel
 
-    private func submit(note: String, remindAt: Date?) {
+    /// Posts the shared content with whatever the compose form currently holds.
+    /// Called from the form's Add button and from the list picker's, so both
+    /// send exactly the same note, lists, and reminder.
+    private func submit() {
         guard let sharedContent else {
             cancel()
             return
         }
+        let note = compose.noteText
+        let remindAt = compose.remindAt
 
         let handle: (PostResult) -> Void = { [weak self] result in
             guard let self else { return }
@@ -156,12 +173,12 @@ final class ShareViewController: UIViewController {
             case .success(let message):
                 self.presentSuccess(message)
             case .failure(let message):
-                self.compose.setPosting(false)
+                self.setPosting(false)
                 self.presentError(message)
             }
         }
 
-        compose.setPosting(true)
+        setPosting(true)
         switch sharedContent {
         case .link(let url):
             postLink(
@@ -180,6 +197,14 @@ final class ShareViewController: UIViewController {
                 completion: handle
             )
         }
+    }
+
+    /// Applies the "Adding…" state to every screen in the stack, so whichever
+    /// one the user submitted from shows the spinner and is locked against
+    /// re-entry (including navigating between them mid-request).
+    private func setPosting(_ posting: Bool) {
+        compose.setPosting(posting)
+        listPicker?.setPosting(posting)
     }
 
     /// Flashes a checkmark toast over the form, then closes the sheet. Completing
@@ -558,8 +583,24 @@ final class ShareViewController: UIViewController {
 /// container via closures.
 private final class ComposeFormController: UIViewController, UITextViewDelegate {
     var onCancel: (() -> Void)?
-    var onSubmit: ((String, Date?) -> Void)?
+    var onSubmit: (() -> Void)?
     var onPickList: (() -> Void)?
+
+    /// The note as typed, trimmed. Read by the container on submit — from this
+    /// screen's Add button or the list picker's — so the form stays the single
+    /// source of truth for what gets posted.
+    var noteText: String {
+        noteView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The chosen reminder day, or `nil` when "Remind me" is off.
+    var remindAt: Date? {
+        scheduleSwitch.isOn ? datePicker.date : nil
+    }
+
+    /// Whether there's anything to post yet — mirrored onto the list picker's
+    /// Add button so both are gated on the same condition.
+    var canSubmit: Bool { hasContent && !isPosting }
 
     private let urlLabel = UILabel()
     private let imagePreview = UIImageView()
@@ -585,6 +626,9 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         navigationItem.rightBarButtonItem = addButton
         // Nothing to post until a URL is extracted.
         addButton.isEnabled = false
+        // The bar is the blue title-bar gradient, so a default grey spinner all
+        // but disappears on it.
+        spinner.color = .white
 
         // The shared URL reads like a terminal line: mono type, navy on chrome.
         urlLabel.font = OTBTheme.mono(11)
@@ -791,11 +835,7 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
         }
     }
 
-    @objc private func didTapAdd() {
-        let note = noteView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let remindAt = scheduleSwitch.isOn ? datePicker.date : nil
-        onSubmit?(note, remindAt)
-    }
+    @objc private func didTapAdd() { onSubmit?() }
 
     // MARK: - UITextViewDelegate
 
@@ -810,14 +850,30 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
 /// plus a "New list…" row that prompts for a name. Tapping a list toggles it; an
 /// item can belong to any number of lists (or none). The full selection is
 /// reported via `onSelectionChanged` after every change — the server resolves the
-/// names (creating any new), so no id round-trip is needed. The user commits by
-/// tapping back out of the picker.
+/// names (creating any new), so no id round-trip is needed.
+///
+/// There's also an **Add** button in the top right, mirroring the compose form's:
+/// choosing a list is normally the last decision, so the user can post from here
+/// and close the sheet without first navigating back.
 private final class ListPickerViewController: UITableViewController {
     var onSelectionChanged: (([String]) -> Void)?
+    var onAdd: (() -> Void)?
+
+    /// Mirrors the compose form's Add gate — there's nothing to post until the
+    /// shared link or image has been extracted.
+    var canAdd = false {
+        didSet { addButton.isEnabled = canAdd && !isPosting }
+    }
 
     private var names: [String]
     // Selection order is preserved so the compose row and payload stay stable.
     private var selected: [String]
+
+    private lazy var addButton = UIBarButtonItem(
+        title: "Add", style: .done, target: self, action: #selector(didTapAdd)
+    )
+    private let spinner = UIActivityIndicatorView(style: .medium)
+    private var isPosting = false
 
     init(stacks: [String], selected: [String]) {
         self.names = stacks
@@ -837,7 +893,32 @@ private final class ListPickerViewController: UITableViewController {
         tableView.backgroundColor = OTBTheme.playlistBg
         tableView.separatorColor = OTBTheme.navyBorder
         tableView.tintColor = OTBTheme.accent // checkmark colour
+
+        navigationItem.rightBarButtonItem = addButton
+        addButton.isEnabled = canAdd
+        // The bar is the blue title-bar gradient, so a default grey spinner all
+        // but disappears on it.
+        spinner.color = .white
     }
+
+    /// While a post is in flight, swap Add for a spinner and lock the screen —
+    /// including the back button, so the request can't be re-entered from the
+    /// compose form.
+    func setPosting(_ posting: Bool) {
+        isPosting = posting
+        tableView.isUserInteractionEnabled = !posting
+        navigationItem.hidesBackButton = posting
+        if posting {
+            spinner.startAnimating()
+            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinner)
+        } else {
+            spinner.stopAnimating()
+            navigationItem.rightBarButtonItem = addButton
+            addButton.isEnabled = canAdd
+        }
+    }
+
+    @objc private func didTapAdd() { onAdd?() }
 
     // Section 0: existing lists (checkmark = selected). Section 1: "New list…".
     override func numberOfSections(in tableView: UITableView) -> Int { 2 }


### PR DESCRIPTION
Picking a list is usually the last thing you do before posting, but the share extension's list picker had no way to commit — you had to tap back to the compose form to reach **Add**. The picker now carries its own **Add** button in the top right, doing exactly what the form's does, so you can file the item and close the sheet from the list screen.

## Changes

`native/ShareExtension/ShareViewController.swift`:

- **`ListPickerViewController`** gains an `Add` bar button (`.done` style, so it picks up the same bold Verdana title-bar styling as the compose form's), plus `onAdd`, `canAdd`, and `setPosting(_:)`.
- **Single submit path.** `ComposeFormController.onSubmit` no longer carries the note/date; it and the picker's `onAdd` both call `ShareViewController.submit()`, which reads `compose.noteText` / `compose.remindAt`. The payload is identical whichever button you tap.
- **Posting state covers the whole stack.** `setPosting(_:)` on the container applies to the form *and* the picker, so whichever screen you submitted from swaps Add for a spinner. The picker also hides its back button while in flight, so the form can't be re-entered mid-request. The success toast and error alert already live on the container, so they present correctly over either screen.
- **Add gate mirrored.** The picker's Add is disabled until the shared link/image has been extracted, matching the form — including the case where extraction finishes while the picker is already open.
- Nav-bar spinners are tinted white; the default grey all but vanished against the blue title-bar gradient.

`docs/ios-native-app.md`: documents the second Add button in the extension overview and the run-through instructions.

## Testing

- `bun run test` — 561 pass, 0 fail.
- No Swift toolchain in this environment, so the compile check is the **iOS Build** workflow this PR triggers (it's path-filtered on `native/**`).
- Not yet exercised on a device: worth a manual pass of share → Lists → Add for both a link and a photo, and an offline attempt to see the error alert land on the picker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTpUjGJq7FpFnDG9Xj1AgJ)_