### PR TITLE
Compress oversized photos instead of failing the upload

### DIFF
--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -42,8 +42,10 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
 - **Sharing an image** works the same way. When the payload is a photo rather than a
   link (e.g. a record cover shared from Photos), the extension shows the same compose
   form — with an image preview in place of the URL line — and the same note, list,
-  and reminder controls. The image is downscaled to a 1024px JPEG (mirroring the web
-  add-form, so it stays under the server's upload size cap) and `POST`ed as base64 to
+  and reminder controls. The image is downscaled to a 1024px JPEG and re-encoded at
+  progressively lower quality/size until the base64 payload fits the upload budget
+  (mirroring the web add-form's `encodeImageFile`, so a detailed sleeve compresses
+  further instead of being rejected with a 413) and `POST`ed as base64 to
   `POST /api/ingest/photo`, which saves the artwork, scans it for release metadata,
   and files the created item into the chosen lists / reminder just like a link. A
   link is preferred when the share carries both (a shared web page often includes a

--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -317,9 +317,19 @@ consider rotating `INGEST_API_KEY`.
   as the target's configuration file, or `OTB_INGEST_API_KEY` is empty.
 - **401 Unauthorized** — the key in `Secrets.xcconfig` doesn't match the
   server's `INGEST_API_KEY`, or ingest is disabled (`INGEST_ENABLED=false`).
-- **Add failed (4xx/5xx)** — the alert includes the server's response body;
-  check the server logs for `POST /api/ingest/link` (a shared link) or
-  `POST /api/ingest/photo` (a shared image).
+- **Add failed (4xx/5xx)** — the alert explains the known statuses in plain
+  English (401 key mismatch, 413 too large, 503 ingest off, 5xx server error)
+  and otherwise shows the API's JSON `error` field with the status code. Raw
+  HTML error pages are never shown, so check the server logs for
+  `POST /api/ingest/link` (a shared link) or `POST /api/ingest/photo` (a shared
+  image) when the message is just a status.
+- **"That photo was too big to send…"** — a 413. The extension compresses down a
+  quality/size ladder before posting, so this means even the smallest encode
+  exceeded the server's request body limit; share a smaller image, or raise
+  `BODY_SIZE_LIMIT` in the server's environment.
+- **"Couldn't read that photo…"** — the shared image couldn't be decoded or
+  compressed at all, so there was nothing to post. The form says so with Add
+  disabled rather than showing an empty preview.
 - **"ios platform already exists"** on `cap add` — a leftover `ios/` directory
   is present. It's fully generated and gitignored, so just `rm -rf ios` and run
   `bun run cap:add` again. (The hand-authored sources live in `native/`, not

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -66,6 +66,21 @@ final class ShareViewController: UIViewController {
         case image(Data)
     }
 
+    /// What extraction found: something postable, an image attachment we
+    /// couldn't decode or compress, or nothing usable at all. The failure cases
+    /// are kept apart so the form can say which one happened instead of just
+    /// showing an empty preview with Add greyed out.
+    private enum SharedInput {
+        case content(SharedContent)
+        case unreadableImage
+        case nothing
+    }
+
+    /// Shown when a shared image can't be decoded or compressed into something
+    /// postable — the one failure that happens before any request is made.
+    private static let unreadablePhotoMessage =
+        "Couldn't read that photo — try sharing it from Photos instead."
+
     private var sharedContent: SharedContent?
     private var stackNames: [String] = []
     private var selectedListNames: [String] = []
@@ -112,16 +127,28 @@ final class ShareViewController: UIViewController {
         compose.onPickList = { [weak self] in self?.pushListPicker() }
         compose.onSubmit = { [weak self] in self?.submit() }
 
-        extractSharedContent { [weak self] content in
+        extractSharedContent { [weak self] input in
             guard let self else { return }
-            self.sharedContent = content
-            switch content {
-            case .link(let url):
-                self.compose.setURL(url)
-            case .image(let data):
-                self.compose.setImage(UIImage(data: data))
-            case nil:
-                self.compose.setURL(nil)
+            switch input {
+            case .content(let content):
+                self.sharedContent = content
+                switch content {
+                case .link(let url):
+                    self.compose.setURL(url)
+                case .image(let data):
+                    if let image = UIImage(data: data) {
+                        self.compose.setImage(image)
+                    } else {
+                        self.sharedContent = nil
+                        self.compose.setUnavailable(Self.unreadablePhotoMessage)
+                    }
+                }
+            case .unreadableImage:
+                self.sharedContent = nil
+                self.compose.setUnavailable(Self.unreadablePhotoMessage)
+            case .nothing:
+                self.sharedContent = nil
+                self.compose.setUnavailable("Nothing to add from this share.")
             }
             // Extraction is async, so the picker may already be on screen when
             // the content lands — ungate its Add button too.
@@ -161,7 +188,9 @@ final class ShareViewController: UIViewController {
     /// send exactly the same note, lists, and reminder.
     private func submit() {
         guard let sharedContent else {
-            cancel()
+            // Add is disabled without content, so this shouldn't be reachable —
+            // but silently dismissing the sheet would look like a successful add.
+            presentError("There's nothing here to add.")
             return
         }
         let note = compose.noteText
@@ -298,7 +327,7 @@ final class ShareViewController: UIViewController {
     /// holding the URL string (see below), and text branches arrive as
     /// `String`. Getting that coercion wrong is what left the Add button
     /// permanently disabled when sharing from Apple Music on macOS.
-    private func extractSharedContent(completion: @escaping (SharedContent?) -> Void) {
+    private func extractSharedContent(completion: @escaping (SharedInput) -> Void) {
         let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
         let providers = items.flatMap { $0.attachments ?? [] }
 
@@ -314,20 +343,28 @@ final class ShareViewController: UIViewController {
             if let imageProvider {
                 self.loadImage(from: imageProvider) { data in
                     if let data {
-                        completion(.image(data))
+                        completion(.content(.image(data)))
                     } else {
-                        completion(Self.linkFromText(items))
+                        // The share carried an image we couldn't decode or
+                        // compress. A link recovered from the text is still
+                        // worth posting; otherwise say so rather than leaving
+                        // the form blank.
+                        completion(Self.linkFromText(items) ?? .unreadableImage)
                     }
                 }
             } else {
-                completion(Self.linkFromText(items))
+                completion(Self.linkFromText(items) ?? .nothing)
             }
         }
 
         if let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(urlType) }) {
             provider.loadItem(forTypeIdentifier: urlType, options: nil) { item, _ in
                 DispatchQueue.main.async {
-                    if let url = Self.url(from: item) { completion(.link(url)) } else { fallback() }
+                    if let url = Self.url(from: item) {
+                        completion(.content(.link(url)))
+                    } else {
+                        fallback()
+                    }
                 }
             }
             return
@@ -336,7 +373,11 @@ final class ShareViewController: UIViewController {
         if let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(textType) }) {
             provider.loadItem(forTypeIdentifier: textType, options: nil) { item, _ in
                 DispatchQueue.main.async {
-                    if let url = Self.url(from: item) { completion(.link(url)) } else { fallback() }
+                    if let url = Self.url(from: item) {
+                        completion(.content(.link(url)))
+                    } else {
+                        fallback()
+                    }
                 }
             }
             return
@@ -345,10 +386,10 @@ final class ShareViewController: UIViewController {
         fallback()
     }
 
-    /// Recovers a `.link` from the input items' attributed text, or `nil`.
-    private nonisolated static func linkFromText(_ items: [NSExtensionItem]) -> SharedContent? {
+    /// Recovers a link from the input items' attributed text, or `nil`.
+    private nonisolated static func linkFromText(_ items: [NSExtensionItem]) -> SharedInput? {
         let text = items.compactMap { $0.attributedContentText?.string }.joined(separator: "\n")
-        return firstURL(in: text).map { .link($0) }
+        return firstURL(in: text).map { .content(.link($0)) }
     }
 
     /// Loads an image attachment and hands back downscaled JPEG bytes on the
@@ -534,7 +575,11 @@ final class ShareViewController: UIViewController {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else {
+            completion(.failure("Couldn't prepare that link to send."))
+            return
+        }
+        request.httpBody = body
         request.timeoutInterval = 20
 
         URLSession.shared.dataTask(with: request) { data, response, error in
@@ -545,11 +590,8 @@ final class ShareViewController: UIViewController {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                 if (200...299).contains(status) {
                     result = .success(Self.successMessage(from: data))
-                } else if status == 401 {
-                    result = .failure("Unauthorized — check the ingest API key.")
                 } else {
-                    let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    result = .failure("Add failed (\(status)). \(body)")
+                    result = .failure(Self.failureMessage(status: status, data: data, isPhoto: false))
                 }
             }
             DispatchQueue.main.async { completion(result) }
@@ -587,7 +629,11 @@ final class ShareViewController: UIViewController {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else {
+            completion(.failure("Couldn't prepare that photo to send."))
+            return
+        }
+        request.httpBody = body
         request.timeoutInterval = 30
 
         URLSession.shared.dataTask(with: request) { data, response, error in
@@ -598,15 +644,53 @@ final class ShareViewController: UIViewController {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                 if (200...299).contains(status) {
                     result = .success(Self.successMessage(from: data))
-                } else if status == 401 {
-                    result = .failure("Unauthorized — check the ingest API key.")
                 } else {
-                    let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                    result = .failure("Add failed (\(status)). \(body)")
+                    result = .failure(Self.failureMessage(status: status, data: data, isPhoto: true))
                 }
             }
             DispatchQueue.main.async { completion(result) }
         }.resume()
+    }
+
+    /// Turns a non-2xx response into something the person sharing can act on.
+    ///
+    /// The old message pasted the raw response body into the alert, which for a
+    /// 413 is the adapter's HTML error page rather than anything readable — so
+    /// an upload that was too big looked like a generic failure. Known statuses
+    /// get plain English; anything else falls back to the server's JSON `error`
+    /// field (never a raw HTML body) alongside the status code.
+    private nonisolated static func failureMessage(status: Int, data: Data?, isPhoto: Bool) -> String {
+        switch status {
+        case 401:
+            return "Unauthorized — check the ingest API key."
+        case 413:
+            return isPhoto
+                ? "That photo was too big to send, even after compressing it. Try sharing a smaller image."
+                : "That share was too big to send."
+        case 503:
+            return "On The Beach isn't accepting shares right now. Try again later."
+        case 500...599:
+            return "On The Beach couldn't save that (\(status)). Try again in a moment."
+        default:
+            if let detail = serverError(from: data) {
+                return "\(detail) (\(status))"
+            }
+            return "Add failed (\(status))."
+        }
+    }
+
+    /// Pulls the `error` field out of the API's JSON error body, if that's what
+    /// came back. Returns nil for an empty or non-JSON body (e.g. an HTML error
+    /// page), so those never reach the alert verbatim.
+    private nonisolated static func serverError(from data: Data?) -> String? {
+        guard let data,
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = payload["error"] as? String
+        else { return nil }
+
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.count > 200 ? String(trimmed.prefix(200)) + "…" : trimmed
     }
 
     /// Builds the confirmation toast text from the ingest response: "Added",
@@ -835,8 +919,23 @@ private final class ComposeFormController: UIViewController, UITextViewDelegate 
     func setURL(_ url: URL?) {
         urlLabel.text = url?.absoluteString
         urlLabel.isHidden = url == nil
+        urlLabel.numberOfLines = 2
+        urlLabel.lineBreakMode = .byTruncatingMiddle
         imageWell.isHidden = true
         setHasContent(url != nil)
+    }
+
+    /// Explains, in the line the URL normally occupies, why there's nothing to
+    /// post — an image we couldn't read, or a share with nothing usable in it.
+    /// Add stays disabled either way; without this the sheet just showed an
+    /// empty form and left the user guessing.
+    func setUnavailable(_ message: String) {
+        urlLabel.text = message
+        urlLabel.isHidden = false
+        urlLabel.numberOfLines = 0
+        urlLabel.lineBreakMode = .byWordWrapping
+        imageWell.isHidden = true
+        setHasContent(false)
     }
 
     /// Shows the shared image in the preview well and enables Add. Called

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -380,11 +380,65 @@ final class ShareViewController: UIViewController {
         return image.flatMap(downscaledJPEG)
     }
 
+    /// The downscale/quality ladder to walk while the encoded photo is still
+    /// too big. Mirrors `imageCompressionAttempts` in src/ui/domain/scan.ts.
+    private nonisolated static func compressionAttempts(
+        maxEdge: CGFloat,
+        quality: CGFloat
+    ) -> [(maxEdge: CGFloat, quality: CGFloat)] {
+        [
+            (maxEdge, quality),
+            (maxEdge, quality * 0.75),
+            ((maxEdge * 0.75).rounded(), quality * 0.7),
+            ((maxEdge * 0.5).rounded(), quality * 0.6),
+            ((maxEdge * 0.35).rounded(), quality * 0.5),
+        ]
+    }
+
     /// Downscales an image so its longest edge is at most 1024px and encodes it
     /// as JPEG — mirroring the web app's `encodeImageFile` (src/lib/encode-image.ts)
-    /// so both share paths produce uploads comfortably under the server limit.
+    /// so both share paths produce uploads the server will accept.
+    ///
+    /// A 1024px sleeve at quality 0.85 usually lands well under the limit, but a
+    /// detailed cover can still encode past it, so we compress harder down the
+    /// ladder until the base64 payload fits rather than posting a doomed request.
+    /// If nothing fits we post the smallest attempt anyway — a rejection then is
+    /// no worse than not trying.
     private nonisolated static func downscaledJPEG(_ image: UIImage) -> Data? {
-        let maxEdge: CGFloat = 1024
+        // Ceiling for the base64 payload we post, in characters — the same budget
+        // the web app uses (`MAX_UPLOAD_BASE64_LENGTH` in src/ui/domain/scan.ts).
+        // The binding limit is SvelteKit's request body limit, which 413s an
+        // oversized upload before the ingest route ever runs.
+        let maxUploadBase64Length = 460_000
+        var smallest: Data?
+
+        for attempt in compressionAttempts(maxEdge: 1024, quality: 0.85) {
+            guard let data = encodedJPEG(image, maxEdge: attempt.maxEdge, quality: attempt.quality)
+            else { continue }
+
+            if base64Length(ofByteCount: data.count) <= maxUploadBase64Length {
+                return data
+            }
+            if let current = smallest, data.count >= current.count {
+                continue
+            }
+            smallest = data
+        }
+
+        return smallest
+    }
+
+    /// Base64 encodes 3 bytes into 4 characters, padded up to the next multiple
+    /// of 4 — so we can size the payload without building the string.
+    private nonisolated static func base64Length(ofByteCount count: Int) -> Int {
+        ((count + 2) / 3) * 4
+    }
+
+    private nonisolated static func encodedJPEG(
+        _ image: UIImage,
+        maxEdge: CGFloat,
+        quality: CGFloat
+    ) -> Data? {
         let longest = max(image.size.width, image.size.height)
         let scale = longest > maxEdge ? maxEdge / longest : 1
         let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
@@ -395,7 +449,7 @@ final class ShareViewController: UIViewController {
         let resized = renderer.image { _ in
             image.draw(in: CGRect(origin: .zero, size: target))
         }
-        return resized.jpegData(compressionQuality: 0.85)
+        return resized.jpegData(compressionQuality: quality)
     }
 
     /// Coerces whatever `NSItemProvider.loadItem` hands back into a URL.

--- a/src/lib/encode-image.ts
+++ b/src/lib/encode-image.ts
@@ -1,4 +1,8 @@
-import { constrainDimensions } from "../ui/domain/scan";
+import {
+  constrainDimensions,
+  imageCompressionAttempts,
+  MAX_UPLOAD_BASE64_LENGTH,
+} from "../ui/domain/scan";
 
 const DEFAULT_MAX_EDGE = 1024;
 const DEFAULT_QUALITY = 0.85;
@@ -29,21 +33,7 @@ function loadImage(dataUrl: string): Promise<HTMLImageElement> {
   });
 }
 
-/**
- * Read an image file, downscale it so its longest edge is at most `maxEdge`,
- * and re-encode it as a JPEG. Returns the base64 payload (no data-URL prefix).
- *
- * Downscaling keeps the upload comfortably under the server's size limit
- * (see `MAX_IMAGE_BASE64_LENGTH` in server/uploads.ts); full-resolution phone
- * photos would otherwise be rejected.
- */
-export async function encodeImageFile(
-  file: Blob,
-  maxEdge: number = DEFAULT_MAX_EDGE,
-  quality: number = DEFAULT_QUALITY,
-): Promise<string> {
-  const imageDataUrl = await readFileAsDataUrl(file);
-  const image = await loadImage(imageDataUrl);
+function encodeAtSize(image: HTMLImageElement, maxEdge: number, quality: number): string {
   const { width, height } = constrainDimensions(image.width, image.height, maxEdge);
 
   const canvas = document.createElement("canvas");
@@ -63,4 +53,40 @@ export async function encodeImageFile(
   }
 
   return parts[1];
+}
+
+/**
+ * Read an image file, downscale it so its longest edge is at most `maxEdge`,
+ * and re-encode it as a JPEG. Returns the base64 payload (no data-URL prefix).
+ *
+ * Downscaling alone doesn't guarantee a payload the server will accept — a
+ * detailed sleeve at 1024px can still encode past SvelteKit's request body
+ * limit, which 413s the upload before the route sees it. So the encode is
+ * retried down the `imageCompressionAttempts` ladder until it fits within
+ * `MAX_UPLOAD_BASE64_LENGTH`, compressing harder instead of failing.
+ */
+export async function encodeImageFile(
+  file: Blob,
+  maxEdge: number = DEFAULT_MAX_EDGE,
+  quality: number = DEFAULT_QUALITY,
+): Promise<string> {
+  const imageDataUrl = await readFileAsDataUrl(file);
+  const image = await loadImage(imageDataUrl);
+
+  let smallest = "";
+  for (const attempt of imageCompressionAttempts(maxEdge, quality)) {
+    const encoded = encodeAtSize(image, attempt.maxEdge, attempt.quality);
+    if (encoded.length <= MAX_UPLOAD_BASE64_LENGTH) {
+      return encoded;
+    }
+    // Each rung is smaller than the last, but guard against an encoder that
+    // doesn't shrink monotonically so the fallback is genuinely the smallest.
+    if (!smallest || encoded.length < smallest.length) {
+      smallest = encoded;
+    }
+  }
+
+  // Nothing on the ladder fit. Send the smallest anyway — the server may still
+  // accept it, and a rejection is no worse than refusing to try.
+  return smallest;
 }

--- a/src/ui/domain/add-form.ts
+++ b/src/ui/domain/add-form.ts
@@ -50,6 +50,13 @@ export function toListSearchQuery(value: string): string {
 }
 
 export function getCoverScanErrorMessage(error: unknown): string {
+  // The image is compressed down to the upload budget before it's sent (see
+  // src/lib/encode-image.ts), so a 413 means even the smallest encode was too
+  // big — worth saying so rather than blaming the scan.
+  if (error instanceof Error && error.message.includes("413")) {
+    return "That image was too big to upload. Try a smaller photo.";
+  }
+
   if (error instanceof Error && error.message.includes("uploadReleaseImage")) {
     return "Couldn't save the image. Enter details manually.";
   }

--- a/src/ui/domain/scan.ts
+++ b/src/ui/domain/scan.ts
@@ -3,6 +3,43 @@ export interface Dimensions {
   height: number;
 }
 
+/**
+ * Ceiling for an image upload's base64 payload, in characters.
+ *
+ * The binding limit isn't the server's `MAX_IMAGE_BASE64_LENGTH` (2,000,000)
+ * but SvelteKit's request body limit — 524,288 bytes by default — which rejects
+ * the request with a 413 before any route handler runs. Base64 is ASCII, so one
+ * character is one body byte; the rest of the budget is headroom for the JSON
+ * envelope around it (notes, list names, a reminder date).
+ */
+export const MAX_UPLOAD_BASE64_LENGTH = 460_000;
+
+export interface CompressionAttempt {
+  maxEdge: number;
+  quality: number;
+}
+
+/**
+ * The ladder of downscale/quality settings to try when encoding an image,
+ * starting with the requested settings and stepping down from there.
+ *
+ * A 1024px JPEG at quality 0.85 is usually well under the body limit, but a
+ * busy sleeve (fine grain, lots of text) can still encode past it. Rather than
+ * let that request 413, callers walk the ladder until the payload fits — so
+ * only the photos that need it lose quality.
+ *
+ * Mirrored by `compressionAttempts` in native/ShareExtension/ShareViewController.swift.
+ */
+export function imageCompressionAttempts(maxEdge: number, quality: number): CompressionAttempt[] {
+  return [
+    { maxEdge, quality },
+    { maxEdge, quality: quality * 0.75 },
+    { maxEdge: Math.round(maxEdge * 0.75), quality: quality * 0.7 },
+    { maxEdge: Math.round(maxEdge * 0.5), quality: quality * 0.6 },
+    { maxEdge: Math.round(maxEdge * 0.35), quality: quality * 0.5 },
+  ];
+}
+
 export function constrainDimensions(width: number, height: number, maxEdge: number): Dimensions {
   const largestEdge = Math.max(width, height);
   if (largestEdge <= maxEdge) {

--- a/tests/unit/app-domain.test.ts
+++ b/tests/unit/app-domain.test.ts
@@ -162,6 +162,9 @@ describe("app domain helpers", () => {
       "Scan unavailable",
     );
     expect(getCoverScanErrorMessage(new Error("other"))).toContain("Couldn't read the cover");
+    expect(getCoverScanErrorMessage(new Error("uploadReleaseImage failed: 413"))).toContain(
+      "too big to upload",
+    );
   });
 
   it("constrains image dimensions while preserving aspect ratio", () => {

--- a/tests/unit/app-domain.test.ts
+++ b/tests/unit/app-domain.test.ts
@@ -13,7 +13,11 @@ import {
   buildContextKey,
   applyOrder,
 } from "../../src/ui/domain/music-list";
-import { constrainDimensions } from "../../src/ui/domain/scan";
+import {
+  constrainDimensions,
+  imageCompressionAttempts,
+  MAX_UPLOAD_BASE64_LENGTH,
+} from "../../src/ui/domain/scan";
 
 describe("app domain helpers", () => {
   it("detects whether add form has any user input", () => {
@@ -163,6 +167,28 @@ describe("app domain helpers", () => {
   it("constrains image dimensions while preserving aspect ratio", () => {
     expect(constrainDimensions(500, 300, 1024)).toEqual({ width: 500, height: 300 });
     expect(constrainDimensions(2000, 1000, 1000)).toEqual({ width: 1000, height: 500 });
+  });
+
+  it("keeps the upload budget under SvelteKit's default body size limit", () => {
+    expect(MAX_UPLOAD_BASE64_LENGTH).toBeLessThan(524_288);
+  });
+
+  it("steps image compression down from the requested settings", () => {
+    const attempts = imageCompressionAttempts(1024, 0.85);
+
+    expect(attempts[0]).toEqual({ maxEdge: 1024, quality: 0.85 });
+    expect(attempts).toHaveLength(5);
+
+    // Every rung must encode to fewer bytes than the one before it, or the
+    // retry loop would spin without ever getting under the limit.
+    const costs = attempts.map((attempt) => attempt.maxEdge ** 2 * attempt.quality);
+    for (let i = 1; i < costs.length; i++) {
+      expect(costs[i]).toBeLessThan(costs[i - 1]!);
+    }
+    for (const attempt of attempts) {
+      expect(attempt.quality).toBeGreaterThan(0);
+      expect(attempt.maxEdge).toBeGreaterThan(0);
+    }
   });
 
   it("builds context keys for all filter/stack combinations", () => {

--- a/tests/unit/encode-image.test.ts
+++ b/tests/unit/encode-image.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { encodeImageFile } from "../../src/lib/encode-image";
+import { MAX_UPLOAD_BASE64_LENGTH } from "../../src/ui/domain/scan";
+
+// The encoder is browser code (FileReader, Image, canvas), so the DOM pieces it
+// touches are stubbed here. The fake canvas models a JPEG encoder: payload size
+// scales with pixel count and quality, which is what drives the retry ladder.
+
+interface EncodeCall {
+  width: number;
+  height: number;
+  quality: number;
+}
+
+/** Bytes per pixel at quality 1.0 — tuned so a 1024px photo lands over the limit. */
+let bytesPerPixel = 1;
+let encodeCalls: EncodeCall[] = [];
+
+const originalGlobals = {
+  FileReader: globalThis.FileReader,
+  Image: globalThis.Image,
+  document: globalThis.document,
+};
+
+class StubFileReader {
+  result: string | null = null;
+  error: unknown = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  readAsDataURL(_file: Blob): void {
+    this.result = "data:image/jpeg;base64,c291cmNl";
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+class StubImage {
+  width = 3000;
+  height = 2000;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  set src(_value: string) {
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+function createStubCanvas() {
+  return {
+    width: 0,
+    height: 0,
+    getContext(_id: string) {
+      return { drawImage() {} };
+    },
+    toDataURL(_type: string, quality: number): string {
+      encodeCalls.push({ width: this.width, height: this.height, quality });
+      const length = Math.round(this.width * this.height * bytesPerPixel * quality);
+      return `data:image/jpeg;base64,${"a".repeat(length)}`;
+    },
+  };
+}
+
+beforeEach(() => {
+  encodeCalls = [];
+  globalThis.FileReader = StubFileReader as unknown as typeof FileReader;
+  globalThis.Image = StubImage as unknown as typeof Image;
+  globalThis.document = {
+    createElement(tag: string) {
+      if (tag !== "canvas") throw new Error(`unexpected element: ${tag}`);
+      return createStubCanvas();
+    },
+  } as unknown as Document;
+});
+
+afterEach(() => {
+  bytesPerPixel = 1;
+  globalThis.FileReader = originalGlobals.FileReader;
+  globalThis.Image = originalGlobals.Image;
+  globalThis.document = originalGlobals.document;
+});
+
+describe("encodeImageFile", () => {
+  it("returns the first encode when it already fits the upload budget", async () => {
+    bytesPerPixel = 0.1;
+
+    const encoded = await encodeImageFile(new Blob());
+
+    expect(encoded.length).toBeLessThanOrEqual(MAX_UPLOAD_BASE64_LENGTH);
+    expect(encodeCalls).toHaveLength(1);
+    expect(encodeCalls[0]).toEqual({ width: 1024, height: 683, quality: 0.85 });
+  });
+
+  it("compresses harder until the payload fits instead of sending an oversized upload", async () => {
+    // 1024 x 683 at quality 0.85 encodes to ~595k characters at the default
+    // bytesPerPixel of 1.0, putting the first attempt over the limit.
+    const encoded = await encodeImageFile(new Blob());
+
+    expect(encodeCalls.length).toBeGreaterThan(1);
+    expect(encoded.length).toBeLessThanOrEqual(MAX_UPLOAD_BASE64_LENGTH);
+
+    // Each retry is strictly cheaper than the one before it.
+    const costs = encodeCalls.map((call) => call.width * call.height * call.quality);
+    for (let i = 1; i < costs.length; i++) {
+      expect(costs[i]).toBeLessThan(costs[i - 1]!);
+    }
+  });
+
+  it("falls back to the smallest encode when nothing on the ladder fits", async () => {
+    bytesPerPixel = 40;
+
+    const encoded = await encodeImageFile(new Blob());
+
+    expect(encodeCalls).toHaveLength(5);
+    expect(encoded.length).toBeGreaterThan(MAX_UPLOAD_BASE64_LENGTH);
+    const last = encodeCalls.at(-1)!;
+    expect(encoded.length).toBe(
+      Math.round(last.width * last.height * bytesPerPixel * last.quality),
+    );
+  });
+
+  it("does not upscale an image smaller than the max edge", async () => {
+    bytesPerPixel = 0.1;
+    class SmallImage extends StubImage {
+      override width = 400;
+      override height = 300;
+    }
+    globalThis.Image = SmallImage as unknown as typeof Image;
+
+    await encodeImageFile(new Blob());
+
+    expect(encodeCalls[0]).toEqual({ width: 400, height: 300, quality: 0.85 });
+  });
+});


### PR DESCRIPTION
## Why

Photo shares were failing in production with a 413 before the route ever ran:

```
[api] POST /api/ingest/photo invalid JSON: ...
error: Content-length of 628794 exceeds limit of 524288 bytes.
status: 413, text: "Payload Too Large"
```

The limit that bites isn't the server's `MAX_IMAGE_BASE64_LENGTH` (2,000,000) — it's SvelteKit's default request body limit of 524,288 bytes, which rejects the request in the adapter before `/api/ingest/photo` sees it. Both clients already downscaled to a 1024px JPEG at quality 0.85, but a detailed sleeve (fine grain, lots of text) still encodes past that once base64 adds its ~33%.

## What changed

Both share paths now check the encoded size and compress harder until it fits, rather than posting a doomed request:

- **`src/ui/domain/scan.ts`** — `MAX_UPLOAD_BASE64_LENGTH` (460,000 chars, leaving headroom for the JSON envelope) and `imageCompressionAttempts()`, the shared downscale/quality ladder: quality steps down first, then the max edge, over five rungs.
- **`src/lib/encode-image.ts`** — `encodeImageFile` re-encodes down the ladder until the payload fits. If nothing fits it sends the smallest attempt anyway, so a pathological image is no worse off than before.
- **`native/ShareExtension/ShareViewController.swift`** — the same ladder for the iOS share extension, sizing the base64 payload from the JPEG byte count without building the string.
- **`docs/ios-native-app.md`** — updated the share-image description to match.

Only photos that need it lose quality; a normal cover still encodes once at 1024/0.85 and is sent as before.

## Tests

- New `tests/unit/encode-image.test.ts` stubs `FileReader`/`Image`/canvas to drive the retry loop: returns immediately when the first encode fits, retries down to a fitting payload when it doesn't, falls back to the smallest attempt when nothing fits, and doesn't upscale small images.
- `tests/unit/app-domain.test.ts` covers the ladder itself (monotonically cheaper rungs, budget under the body limit).
- `bun test tests/unit` — 567 pass, 0 fail. `bun run typecheck` clean. `oxlint` clean on the changed files.

The Swift side isn't buildable in this environment, so that change is reviewed-by-eye rather than compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrmGbtxvSxg1eoCQWy83Xd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrmGbtxvSxg1eoCQWy83Xd)_