### PR TITLE
Raise BODY_SIZE_LIMIT so uncompressed photo uploads stop 413ing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  # "Test" completes twice for a merge — once for the pull_request run and once
+  # for the push to main — so this workflow fires twice. Only the push one gets
+  # past the job's `if`; the other skips. Keyed on `github.ref` alone both land
+  # in the same group, and the skipped run's arrival cancels the real deploy
+  # mid-flight — which is why two merges in a row left the version at 1.0.197
+  # with no bump commit. Including the triggering run's event keeps them apart.
+  group: deploy-${{ github.workflow }}-${{ github.event.workflow_run.event || github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ ENV PORT=3000
 ENV UPLOADS_DIR=/app/uploads
 # Madrid local time for the app process and the log timestamps below (CET/CEST).
 ENV TZ=Europe/Madrid
+# adapter-node rejects a body over this with a 413 before any route runs, and
+# its 512KB default is smaller than a shared record sleeve: clients that can't
+# compress first (iPhone Shortcuts, an app build predating the compression
+# ladder) had their photo uploads bounced. 4M clears the server's own
+# `MAX_IMAGE_BASE64_LENGTH` cap of 2,000,000 chars, which now does the
+# rejecting — with a readable JSON error instead of an HTML error page.
+ENV BODY_SIZE_LIMIT=4M
 EXPOSE 3000
 
 # The adapter-node output is self-contained; migrations in drizzle/ are applied

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Open http://localhost:3000.
 | `DATABASE_PATH`           | No       | `on_the_beach.db`      | Path to the SQLite database file                                                                                                                 |
 | `PORT`                    | No       | `3000`                 | HTTP server port                                                                                                                                 |
 | `UPLOADS_DIR`             | No       | `uploads`              | Directory for uploaded cover images                                                                                                              |
+| `BODY_SIZE_LIMIT`         | No       | `512K` (adapter-node)  | Max request body. The default is smaller than a shared record sleeve, so photo uploads 413 before the route runs — the Docker image sets `4M`.   |
 | `MISTRAL_API_KEY`         | No       | —                      | Enables AI cover scanning and unsupported music-link extraction                                                                                  |
 | `MISTRAL_LINK_MODEL`      | No       | `mistral-small-latest` | Model for unsupported music-link extraction via chat completions.                                                                                |
 | `MISTRAL_SCAN_MODEL`      | No       | `mistral-ocr-latest`   | Model for cover scanning. Non-OCR models use chat-completions mode.                                                                              |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       NODE_ENV: production
       # Madrid local time for the process and the log timestamps (see Dockerfile).
       TZ: Europe/Madrid
+      # Photo uploads exceed adapter-node's 512KB default; see the Dockerfile.
+      BODY_SIZE_LIMIT: 4M
     volumes:
       - app-data:/app/data
       - app-uploads:/app/uploads


### PR DESCRIPTION
Follow-up to #270 — a shared sleeve is still failing with the same 413.

## Why compression alone didn't fix it

The ladder in #270 only helps clients running our code. Two that reach `/api/ingest/photo` don't:

- **The iOS share extension already installed on a device.** The ladder is compiled into the app binary, so an install predating #270 still sends a single 1024px / q0.85 encode. Deploying the server changes nothing for it — it needs `bun run ios` and a reinstall.
- **iPhone Shortcuts**, which posts the file it was handed, at full resolution.

Both are rejected by adapter-node's 512KB default, which is what the production log shows: `Content-length … exceeds limit of 524288 bytes`, thrown from `get_raw_body` once the route reads the body. That the request got that far means it passed the `Bearer` check — so the failing client holds an ingest key, i.e. the extension or a Shortcut, not the web add-form (which posts to `/api/release/*` with cookie + CSRF).

Verified the deployed bundle *does* serve the compression ladder — `const be=46e4` alongside the minified `imageCompressionAttempts` — so the web path is fixed and live. This is only about the clients that can't run it.

`BODY_SIZE_LIMIT=4M` (Dockerfile + compose, documented in the README env table) lets those bodies reach the route, where the server's own `MAX_IMAGE_BASE64_LENGTH` (2,000,000 chars) does the rejecting — with a readable JSON error instead of an HTML error page. Clients that do compress are unaffected: same 460,000-char budget, same bytes on the wire.

## The deploy concurrency race

Separate, and smaller than I first described: **Test** completes twice for a merge (the `pull_request` run and the push to `main`), so **Deploy** fires twice, but only the push one passes the job's `if`. Both landed in the same concurrency group keyed on `github.ref`, so the skipped run cancelled the real one mid-flight.

This never left production stale — Coolify builds from `main` HEAD on push regardless. What it costs is the **version bump**, which is why `main` sat at 1.0.197 across two merges with no `chore: bump version` commit. Keying the group on the triggering run's event keeps the two apart.

## Testing

`bun test tests/unit` — 567 pass. `docker compose config` validates and the workflow YAML parses. No application code changed; the deploy-workflow change can only be verified by the next merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrmGbtxvSxg1eoCQWy83Xd