### PR TITLE
Keep list browsing state in the URL so back returns to the list

### DIFF
--- a/playwright/list-nav-state.spec.ts
+++ b/playwright/list-nav-state.spec.ts
@@ -1,0 +1,120 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "./fixtures/parallel-test";
+
+/**
+ * Seed a release directly through the API — no link, so nothing here depends on
+ * an external service being reachable.
+ */
+async function seedRelease(
+  request: APIRequestContext,
+  title: string,
+  artist: string,
+): Promise<number> {
+  const res = await request.post("/api/music-items", {
+    data: { title, artist, itemType: "album" },
+  });
+  expect(res.ok()).toBe(true);
+  return (await res.json()).id as number;
+}
+
+async function seedStack(
+  request: APIRequestContext,
+  name: string,
+  itemId: number,
+): Promise<number> {
+  const res = await request.post("/api/stacks", { data: { name } });
+  expect(res.ok()).toBe(true);
+  const stackId = (await res.json()).id as number;
+  const assign = await request.post(`/api/stacks/items/${itemId}`, {
+    data: { stackIds: [stackId] },
+  });
+  expect(assign.ok()).toBe(true);
+  return stackId;
+}
+
+test.describe("List view state in the URL", () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post("/api/__test__/reset");
+  });
+
+  test("back from a release returns to the stack it was opened from", async ({ page, request }) => {
+    const itemId = await seedRelease(request, "Stack Release", "Stack Artist");
+    const stackId = await seedStack(request, "Ambient", itemId);
+
+    await page.goto(`/s/${stackId}/ambient`);
+    await expect(page.locator(".music-card").first()).toBeVisible();
+
+    await page.locator(".music-card").first().locator("a.music-card__link").click();
+    await expect(page).toHaveURL(new RegExp(`/r/${itemId}\\?from=`));
+
+    // The in-app back button lands back on the stack, not the home list.
+    await page.locator(".release-page__nav a").click();
+    await expect(page).toHaveURL(new RegExp(`/s/${stackId}/ambient$`));
+    await expect(page.locator(".stack-tab.active", { hasText: "Ambient" })).toBeVisible();
+  });
+
+  test("browser back from a release returns to the stack it was opened from", async ({
+    page,
+    request,
+  }) => {
+    const itemId = await seedRelease(request, "Back Release", "Back Artist");
+    const stackId = await seedStack(request, "Dub Techno", itemId);
+
+    // Reach the stack the way the app does: shallow-pushed from the home list.
+    await page.goto("/");
+    await expect(page.locator(".stack-tab", { hasText: "Dub Techno" })).toBeVisible();
+    await page.locator(".stack-tab", { hasText: "Dub Techno" }).click();
+    await expect(page).toHaveURL(new RegExp(`/s/${stackId}/dub-techno$`));
+
+    await page.locator(".music-card").first().locator("a.music-card__link").click();
+    await expect(page).toHaveURL(new RegExp(`/r/${itemId}\\?from=`));
+
+    await page.goBack();
+    await expect(page).toHaveURL(new RegExp(`/s/${stackId}/dub-techno$`));
+    await expect(page.locator(".stack-tab.active", { hasText: "Dub Techno" })).toBeVisible();
+  });
+
+  test("filter and sort choices live in the URL and survive a release visit", async ({
+    page,
+    request,
+  }) => {
+    const itemId = await seedRelease(request, "Sorted Release", "Sorted Artist");
+
+    await page.goto("/");
+    await page.locator('.filter-btn[data-filter="all"]').click();
+    await expect(page).toHaveURL(/\/\?filter=all$/);
+
+    await page.locator("#browse-sort").selectOption("artist-name");
+    await expect(page).toHaveURL(/filter=all/);
+    await expect(page).toHaveURL(/sort=artist-name/);
+
+    await page.locator(".music-card").first().locator("a.music-card__link").click();
+    await expect(page).toHaveURL(new RegExp(`/r/${itemId}\\?from=`));
+
+    await page.locator(".release-page__nav a").click();
+    await expect(page).toHaveURL(/filter=all/);
+    await expect(page).toHaveURL(/sort=artist-name/);
+    await expect(page.locator('.filter-btn[data-filter="all"]')).toHaveClass(/active/);
+    await expect(page.locator("#browse-sort")).toHaveValue("artist-name");
+  });
+
+  test("a list URL with browsing state renders that view on a cold load", async ({
+    page,
+    request,
+  }) => {
+    await seedRelease(request, "Queued Release", "Queued Artist");
+
+    await page.goto("/?filter=listened");
+    await expect(page.locator('.filter-btn[data-filter="listened"]')).toHaveClass(/active/);
+    // The seeded release is still to-listen, so the listened view is empty.
+    await expect(page.locator(".music-card")).toHaveCount(0);
+    await expect(page).toHaveURL(/\/\?filter=listened$/);
+  });
+
+  test("a tampered back target falls back to the home list", async ({ page, request }) => {
+    const itemId = await seedRelease(request, "Tampered Release", "Tampered Artist");
+
+    await page.goto(`/r/${itemId}?from=https://example.com/`);
+    await expect(page.locator(".release-page__nav a")).toHaveAttribute("href", "/");
+  });
+});

--- a/src/lib/components/MainPage.svelte
+++ b/src/lib/components/MainPage.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-  import { goto, pushState } from "$app/navigation";
+  import { goto } from "$app/navigation";
   import { page } from "$app/state";
-  import { onMount, untrack } from "svelte";
+  import { onMount } from "svelte";
   import type { ItemSuggestion, ListenStatus, MusicItemFull, StackWithCount } from "../../types";
   import { buildContextKey, buildMusicItemFilters } from "../../ui/domain/music-list";
+  import {
+    buildListHref,
+    buildReleaseHref,
+    buildStackPath,
+    isDefaultListViewState,
+    parseListViewState,
+    stackIdFromListPath,
+    type ListViewState,
+  } from "../../ui/domain/list-url";
   import { normalizeStarRating } from "../../ui/components/star-rating";
   import { addFormMachine } from "../../ui/state/add-form-machine";
   import { appMachine } from "../../ui/state/app-machine";
@@ -31,11 +40,30 @@
     data: { items: MusicItemFull[]; stacks: StackWithCount[]; stackId: number | null };
   } = $props();
 
-  // The machine is seeded from the SSR payload once per page instance; from
-  // then on machine context is the source of truth (matching the old shell).
+  // The machine is seeded from the URL once per page instance; from then on
+  // machine context is the source of truth and the URL follows it (see the sync
+  // effects below). The URL is read in full — scope *and* browsing state — so
+  // that arriving from anywhere (a back button, a shared link, a cold load)
+  // reproduces the same view.
+  // svelte-ignore state_referenced_locally
+  const initialStackId = stackIdFromListPath(page.url.pathname);
+  // svelte-ignore state_referenced_locally
+  const initialView = parseListViewState(page.url.searchParams, initialStackId);
+
   // svelte-ignore state_referenced_locally
   const app = useMachine(appMachine, {
-    input: { stacks: data.stacks, currentStack: data.stackId },
+    input: {
+      stacks: data.stacks,
+      currentStack: initialStackId,
+      currentFilter: initialView.filter,
+      searchQuery: initialView.search,
+      currentSort: initialView.sort,
+      currentSortDirection: initialView.sortDirection,
+      // The payload only covers the default view of the scope it was loaded
+      // for, so anything else needs a refetch as soon as we hydrate.
+      needsListRefresh:
+        initialStackId !== data.stackId || !isDefaultListViewState(initialView, initialStackId),
+    },
   });
   const form = useMachine(addFormMachine, { input: { api } });
 
@@ -125,38 +153,95 @@
   }
 
   // ── Stack selection & URL sync ─────────────────────────────────────────────
-  function slugify(name: string): string {
-    return name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
+  //
+  // The full browsing view (stack, filter, search, sort) lives in the URL so it
+  // survives a trip to a release page and back. `syncedHref` is the last href
+  // this component wrote; it tells the two effects below which side moved —
+  // it is deliberately a plain `let` so writing it can't retrigger them.
+  let syncedHref = page.url.pathname + page.url.search;
+
+  const currentView = $derived<ListViewState>({
+    filter: ctx.currentFilter,
+    search: ctx.searchQuery,
+    sort: ctx.currentSort,
+    sortDirection: ctx.currentSortDirection,
+  });
+
+  /** The list path for the machine's stack scope, or null if we can't name it yet. */
+  function listPathFor(stackId: number | null): string | null {
+    if (stackId === null) return "/";
+    const stack = ctx.stacks.find((s) => s.id === stackId);
+    if (stack) return buildStackPath(stack.id, stack.name);
+    // Stacks haven't loaded yet — only reuse the address bar if it already
+    // points at this stack, otherwise we'd invent a wrong slug.
+    return stackIdFromListPath(page.url.pathname) === stackId ? page.url.pathname : null;
+  }
+
+  const listPath = $derived(listPathFor(ctx.currentStack));
+
+  /** The current view as a URL — what the release page links back to. */
+  const listHref = $derived(
+    listPath === null ? null : buildListHref(listPath, currentView, ctx.currentStack),
+  );
+
+  /**
+   * Point the address bar at `href`.
+   *
+   * These are real navigations rather than shallow routing (`pushState`/
+   * `replaceState`): a shallow entry comes back from a release page carrying the
+   * *old* URL and payload, which is exactly how back used to land on the home
+   * list. Neither list load reads the query string, so SvelteKit skips re-running
+   * it when only the browsing state changes — a filter or keystroke costs no
+   * server round trip.
+   */
+  function navigateTo(href: string, options: { replace: boolean }): void {
+    syncedHref = href;
+    void goto(href, { replaceState: options.replace, noScroll: true, keepFocus: true });
+  }
+
+  /** Move to another stack scope — a real move between views, so back can undo it. */
+  function navigateToScope(): void {
+    if (listHref === null) return;
+    navigateTo(listHref, { replace: false });
   }
 
   function selectStack(stackId: number): void {
+    // Send first: the machine's post-event context is the view we navigate to.
     app.send({ type: "STACK_SELECTED", stackId });
-    const stack = ctx.stacks.find((s) => s.id === stackId);
-    if (stack) {
-      pushState(`/s/${stack.id}/${slugify(stack.name)}`, {});
-    }
+    navigateToScope();
   }
 
   function selectAllStacks(): void {
     app.send({ type: "STACK_SELECTED_ALL" });
-    pushState("/", {});
+    navigateToScope();
   }
 
-  // Back/forward across shallow-pushed stack URLs: keep the machine in sync
-  // with the address bar.
+  // Machine → URL: keep the address bar describing the current view. Filter,
+  // search and sort changes replace the history entry so back doesn't have to
+  // step through every keystroke.
   $effect(() => {
-    const match = page.url.pathname.match(/^\/s\/(\d+)\//);
-    const urlStackId = match ? Number(match[1]) : null;
-    const currentStack = untrack(() => ctx.currentStack);
-    if (urlStackId === currentStack) return;
-    if (urlStackId !== null) {
-      app.send({ type: "STACK_SELECTED", stackId: urlStackId });
-    } else {
-      app.send({ type: "STACK_SELECTED_ALL" });
-    }
+    const href = listHref;
+    if (href === null || href === syncedHref) return;
+    navigateTo(href, { replace: true });
+  });
+
+  // URL → machine: the address bar moved without us (browser back/forward, or a
+  // link into another list view), so adopt whatever view it now describes.
+  $effect(() => {
+    const href = page.url.pathname + page.url.search;
+    if (href === syncedHref) return;
+    syncedHref = href;
+
+    const stackId = stackIdFromListPath(page.url.pathname);
+    const view = parseListViewState(page.url.searchParams, stackId);
+    app.send({
+      type: "VIEW_RESTORED",
+      stackId,
+      filter: view.filter,
+      searchQuery: view.search,
+      sort: view.sort,
+      sortDirection: view.sortDirection,
+    });
   });
 
   function buildBreadcrumbTrail(
@@ -266,7 +351,7 @@
     }
     const picked = pool[Math.floor(Math.random() * pool.length)];
     await rouletteToCard(picked.id);
-    await goto(`/r/${picked.id}`);
+    await goto(buildReleaseHref(picked.id, listHref));
     return picked;
   }
 </script>
@@ -334,6 +419,7 @@
     currentStack={ctx.currentStack}
     currentFilter={ctx.currentFilter}
     searchQuery={ctx.searchQuery}
+    backHref={listHref}
     {orderLocked}
     onSelectStack={selectStack}
     onRefreshList={() => app.send({ type: "LIST_REFRESH" })}

--- a/src/lib/components/MusicCard.svelte
+++ b/src/lib/components/MusicCard.svelte
@@ -2,6 +2,7 @@
   import Case from "case";
   import { tick } from "svelte";
   import type { ListenStatus, MusicItemFull, StackWithCount } from "../../types";
+  import { buildReleaseHref } from "../../ui/domain/list-url";
   import { STATUS_LABELS } from "../../ui/domain/status";
   import { api } from "../api";
   import { registerOpenPopover, unregisterPopover } from "../popover-registry";
@@ -11,12 +12,15 @@
 
   let {
     item,
+    backHref,
     onStatusChanged,
     onDelete,
     onStacksChanged,
     onStackDropdownClosed,
   }: {
     item: MusicItemFull;
+    /** The list view to return to from the release page. */
+    backHref: string | null;
     onStatusChanged: (itemId: number, status: ListenStatus) => Promise<void>;
     onDelete: (itemId: number) => Promise<void>;
     /** A stack was created or the item's stack memberships changed. */
@@ -25,7 +29,7 @@
     onStackDropdownClosed: () => void;
   } = $props();
 
-  const releaseHref = $derived(`/r/${item.id}`);
+  const releaseHref = $derived(buildReleaseHref(item.id, backHref));
 
   // ── Action menu ────────────────────────────────────────────────────────────
   let menuOpen = $state(false);

--- a/src/lib/components/MusicList.svelte
+++ b/src/lib/components/MusicList.svelte
@@ -17,6 +17,7 @@
     currentStack,
     currentFilter,
     searchQuery,
+    backHref,
     orderLocked,
     onSelectStack,
     onRefreshList,
@@ -32,6 +33,8 @@
     currentStack: number | null;
     currentFilter: FilterSelection;
     searchQuery: string;
+    /** The list URL release links point back to; null until it's resolvable. */
+    backHref: string | null;
     orderLocked: boolean;
     onSelectStack: (stackId: number) => void;
     onRefreshList: () => void;
@@ -254,6 +257,7 @@
         {#each items as item (item.id)}
           <MusicCard
             {item}
+            {backHref}
             {onStatusChanged}
             {onDelete}
             {onStacksChanged}

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -212,7 +212,7 @@
   async function deleteItem(): Promise<void> {
     if (!confirm("Delete this release?")) return;
     const ok = await api.deleteMusicItem(item.id).catch(() => false);
-    if (ok) await goto("/");
+    if (ok) await goto(data.backHref);
   }
 
   // ── Artwork upload ─────────────────────────────────────────────────────────
@@ -381,7 +381,7 @@
 <main class="main">
   <div class="release-page">
     <div class="release-page__nav">
-      <a href="/" class="btn">◄</a>
+      <a href={data.backHref} class="btn">◄</a>
     </div>
 
     <div class="release-page__body">

--- a/src/routes/r/[id]/+page.server.ts
+++ b/src/routes/r/[id]/+page.server.ts
@@ -9,6 +9,7 @@ import {
   extractYouTubePlaylistId,
 } from "../../../../server/utils";
 import { parseAppleMusicCatalogUrl, type AppleMusicResource } from "../../../../shared/apple-music";
+import { sanitizeListHref } from "../../../ui/domain/list-url";
 import type { MusicItemFull } from "../../../types";
 
 const SOURCE_DISPLAY_NAMES: Record<string, string> = {
@@ -158,7 +159,7 @@ function mixcloudWidgetSrc(item: MusicItemFull): string | null {
   return `https://www.mixcloud.com/widget/iframe/?hide_cover=1&feed=${encodeURIComponent(pathname)}`;
 }
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, url }) => {
   const id = Number(params.id);
   if (!Number.isInteger(id) || id <= 0) {
     error(400, "Invalid ID");
@@ -181,6 +182,10 @@ export const load: PageServerLoad = async ({ params }) => {
 
   return {
     item,
+    // Where the back button goes. List pages carry their browsing state in the
+    // URL and pass it along as `from`, so back returns to the exact view the
+    // release was opened from instead of dumping the user on the home list.
+    backHref: sanitizeListHref(url.searchParams.get("from")) ?? "/",
     backdropUrl: safeArtworkUrl(item.artwork_url ?? ""),
     artworkUrl: safeArtworkUrl(item.artwork_url ?? ""),
     sourceLink,

--- a/src/ui/domain/list-url.ts
+++ b/src/ui/domain/list-url.ts
@@ -1,0 +1,140 @@
+import type { MusicItemSort, MusicItemSortDirection } from "../../types";
+import type { FilterSelection } from "./music-list";
+
+/**
+ * How a list page (`/` or `/s/:id/:name`) is being browsed.
+ *
+ * This lives in the query string rather than only in the app machine so that
+ * leaving the list — most often to a release page — and coming back restores
+ * the same view, and so a list URL can be reloaded or shared as-is.
+ */
+export interface ListViewState {
+  filter: FilterSelection;
+  search: string;
+  sort: MusicItemSort;
+  sortDirection: MusicItemSortDirection;
+}
+
+const FILTERS: readonly FilterSelection[] = ["all", "to-listen", "listened", "scheduled"];
+
+const SORTS: readonly MusicItemSort[] = [
+  "date-added",
+  "date-listened",
+  "artist-name",
+  "release-name",
+  "star-rating",
+];
+
+/** What a list page shows before the user touches any browse control. */
+export function defaultListViewState(stackId: number | null): ListViewState {
+  return {
+    // Stack pages show everything in the stack; the home list is the queue.
+    filter: stackId === null ? "to-listen" : "all",
+    search: "",
+    sort: "date-added",
+    sortDirection: "desc",
+  };
+}
+
+/** True when the state matches what the server renders without any query params. */
+export function isDefaultListViewState(state: ListViewState, stackId: number | null): boolean {
+  const defaults = defaultListViewState(stackId);
+  return (
+    state.filter === defaults.filter &&
+    state.search.trim() === "" &&
+    state.sort === defaults.sort &&
+    state.sortDirection === defaults.sortDirection
+  );
+}
+
+/** Read browsing state out of a list URL, falling back to defaults for junk. */
+export function parseListViewState(params: URLSearchParams, stackId: number | null): ListViewState {
+  const defaults = defaultListViewState(stackId);
+  const filter = params.get("filter");
+  const sort = params.get("sort");
+  const direction = params.get("dir");
+
+  return {
+    filter: FILTERS.includes(filter as FilterSelection)
+      ? (filter as FilterSelection)
+      : defaults.filter,
+    search: params.get("q") ?? "",
+    sort: SORTS.includes(sort as MusicItemSort) ? (sort as MusicItemSort) : defaults.sort,
+    sortDirection: direction === "asc" || direction === "desc" ? direction : defaults.sortDirection,
+  };
+}
+
+/** Serialise browsing state, omitting anything still at its default. */
+export function buildListSearch(state: ListViewState, stackId: number | null): string {
+  const defaults = defaultListViewState(stackId);
+  const params = new URLSearchParams();
+
+  if (state.filter !== defaults.filter) params.set("filter", state.filter);
+  const search = state.search.trim();
+  if (search) params.set("q", search);
+  if (state.sort !== defaults.sort) params.set("sort", state.sort);
+  if (state.sortDirection !== defaults.sortDirection) params.set("dir", state.sortDirection);
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export function slugifyStackName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function buildStackPath(stackId: number, name: string): string {
+  return `/s/${stackId}/${slugifyStackName(name)}`;
+}
+
+/** The stack a list pathname is scoped to, or null for the home list. */
+export function stackIdFromListPath(pathname: string): number | null {
+  const match = pathname.match(/^\/s\/(\d+)(?:\/|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+export function buildListHref(path: string, state: ListViewState, stackId: number | null): string {
+  return `${path}${buildListSearch(state, stackId)}`;
+}
+
+/**
+ * Validate a `?from=` value into a list href we're willing to link back to.
+ *
+ * Only same-origin list routes survive, and the query string is rebuilt from
+ * the recognised params — so a hand-edited link can't turn the release page's
+ * back button into an off-site redirect or smuggle unknown params along.
+ */
+export function sanitizeListHref(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  // Reject anything that isn't a plain absolute path — in particular the
+  // protocol-relative forms (`//evil.test`, `/\evil.test`) browsers follow.
+  if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw, "http://list.invalid");
+  } catch {
+    return null;
+  }
+
+  const stackMatch = url.pathname.match(/^\/s\/(\d+)\/[a-z0-9-]*$/);
+  if (url.pathname !== "/" && !stackMatch) return null;
+
+  const stackId = stackMatch ? Number(stackMatch[1]) : null;
+  return buildListHref(url.pathname, parseListViewState(url.searchParams, stackId), stackId);
+}
+
+/**
+ * Link to a release, remembering the list it was opened from so the release
+ * page's back button returns to that exact view.
+ */
+export function buildReleaseHref(itemId: number, backHref: string | null): string {
+  const base = `/r/${itemId}`;
+  const sanitized = sanitizeListHref(backHref);
+  // "/" is the fallback the release page already uses — no need to spell it out.
+  if (!sanitized || sanitized === "/") return base;
+  return `${base}?from=${encodeURIComponent(sanitized)}`;
+}

--- a/src/ui/state/app-machine.ts
+++ b/src/ui/state/app-machine.ts
@@ -37,28 +37,47 @@ export type AppEvent =
   | { type: "BROWSE_PANELS_CLOSED" }
   | { type: "ITEM_CREATED" }
   | { type: "LIST_REFRESH" }
+  | {
+      type: "VIEW_RESTORED";
+      stackId: number | null;
+      filter: ListenStatus | "all" | "scheduled";
+      searchQuery: string;
+      sort: MusicItemSort;
+      sortDirection: MusicItemSortDirection;
+    }
   | { type: "REMINDERS_READY"; itemIds: number[] };
 
-/** Seed for server-rendered pages (stack scope comes from the URL). */
+/** Seed for server-rendered pages (the whole browsing view comes from the URL). */
 export interface AppInput {
   stacks?: StackWithCount[];
   currentStack?: number | null;
+  currentFilter?: ListenStatus | "all" | "scheduled";
+  searchQuery?: string;
+  currentSort?: MusicItemSort;
+  currentSortDirection?: MusicItemSortDirection;
+  /**
+   * Set when the seeded view differs from what the server rendered, so the
+   * client refetches the list on mount instead of showing the default one.
+   */
+  needsListRefresh?: boolean;
 }
 
 export const appMachine = createMachine({
   types: {} as { context: AppContext; events: AppEvent; input: AppInput },
   context: ({ input }) => ({
-    currentFilter: input?.currentStack != null ? ("all" as const) : ("to-listen" as const),
+    currentFilter:
+      input?.currentFilter ??
+      (input?.currentStack != null ? ("all" as const) : ("to-listen" as const)),
     currentStack: input?.currentStack ?? null,
-    searchQuery: "",
-    currentSort: "date-added" as const,
-    currentSortDirection: "desc" as const,
+    searchQuery: input?.searchQuery ?? "",
+    currentSort: input?.currentSort ?? ("date-added" as const),
+    currentSortDirection: input?.currentSortDirection ?? ("desc" as const),
     stacks: input?.stacks ?? [],
     isReady: false,
     stackManageOpen: false,
     searchPanelOpen: false,
     sortPanelOpen: false,
-    listVersion: 0,
+    listVersion: input?.needsListRefresh ? 1 : 0,
     stackBarVersion: 0,
   }),
   on: {
@@ -145,6 +164,19 @@ export const appMachine = createMachine({
     },
     LIST_REFRESH: {
       actions: assign(({ context }) => ({ listVersion: context.listVersion + 1 })),
+    },
+    // The address bar moved under us (browser back/forward across list URLs):
+    // adopt the whole view it describes rather than just the stack scope.
+    VIEW_RESTORED: {
+      actions: assign(({ context, event }) => ({
+        currentStack: event.stackId,
+        currentFilter: event.filter,
+        searchQuery: event.searchQuery,
+        currentSort: event.sort,
+        currentSortDirection: event.sortDirection,
+        listVersion: context.listVersion + 1,
+        stackBarVersion: context.stackBarVersion + 1,
+      })),
     },
     REMINDERS_READY: {},
   },

--- a/tests/unit/app-state-machines.test.ts
+++ b/tests/unit/app-state-machines.test.ts
@@ -49,6 +49,59 @@ describe("app state machine", () => {
     expect(actor.getSnapshot().context.currentStack).toBeNull();
   });
 
+  it("seeds the whole browsing view from input", () => {
+    const actor = createActor(appMachine, {
+      input: {
+        currentStack: 4,
+        currentFilter: "listened",
+        searchQuery: "dub",
+        currentSort: "star-rating",
+        currentSortDirection: "asc",
+        needsListRefresh: true,
+      },
+    }).start();
+
+    const ctx = actor.getSnapshot().context;
+    expect(ctx.currentStack).toBe(4);
+    expect(ctx.currentFilter).toBe("listened");
+    expect(ctx.searchQuery).toBe("dub");
+    expect(ctx.currentSort).toBe("star-rating");
+    expect(ctx.currentSortDirection).toBe("asc");
+    // Non-zero so the mounted list refetches past the server-rendered default.
+    expect(ctx.listVersion).toBe(1);
+  });
+
+  it("starts at listVersion 0 when the seeded view is the default one", () => {
+    const actor = createActor(appMachine, { input: { currentStack: 4 } }).start();
+
+    expect(actor.getSnapshot().context.listVersion).toBe(0);
+  });
+
+  it("adopts the whole view on VIEW_RESTORED", () => {
+    const actor = createActor(appMachine, { input: {} }).start();
+
+    actor.send({ type: "STACK_SELECTED", stackId: 4 });
+    actor.send({ type: "SEARCH_UPDATED", query: "dub" });
+    const before = actor.getSnapshot().context.listVersion;
+
+    actor.send({
+      type: "VIEW_RESTORED",
+      stackId: null,
+      filter: "listened",
+      searchQuery: "",
+      sort: "date-listened",
+      sortDirection: "asc",
+    });
+
+    const ctx = actor.getSnapshot().context;
+    expect(ctx.currentStack).toBeNull();
+    expect(ctx.currentFilter).toBe("listened");
+    expect(ctx.searchQuery).toBe("");
+    expect(ctx.currentSort).toBe("date-listened");
+    expect(ctx.currentSortDirection).toBe("asc");
+    expect(ctx.listVersion).toBe(before + 1);
+  });
+
   it("resets active stack when deleted", () => {
     const actor = createActor(appMachine, { input: {} }).start();
 

--- a/tests/unit/list-url.test.ts
+++ b/tests/unit/list-url.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildListHref,
+  buildListSearch,
+  buildReleaseHref,
+  buildStackPath,
+  defaultListViewState,
+  isDefaultListViewState,
+  parseListViewState,
+  sanitizeListHref,
+  slugifyStackName,
+  stackIdFromListPath,
+  type ListViewState,
+} from "../../src/ui/domain/list-url";
+
+function params(query: string): URLSearchParams {
+  return new URLSearchParams(query);
+}
+
+describe("defaultListViewState", () => {
+  test("home defaults to the to-listen queue", () => {
+    expect(defaultListViewState(null)).toEqual({
+      filter: "to-listen",
+      search: "",
+      sort: "date-added",
+      sortDirection: "desc",
+    });
+  });
+
+  test("stack pages default to showing everything in the stack", () => {
+    expect(defaultListViewState(7).filter).toBe("all");
+  });
+});
+
+describe("parseListViewState", () => {
+  test("reads every control out of the query string", () => {
+    expect(
+      parseListViewState(params("filter=listened&q=aphex&sort=star-rating&dir=asc"), null),
+    ).toEqual({
+      filter: "listened",
+      search: "aphex",
+      sort: "star-rating",
+      sortDirection: "asc",
+    });
+  });
+
+  test("falls back to defaults for unknown values", () => {
+    expect(parseListViewState(params("filter=nope&sort=bogus&dir=sideways"), null)).toEqual(
+      defaultListViewState(null),
+    );
+  });
+
+  test("falls back to the stack default filter on stack pages", () => {
+    expect(parseListViewState(params(""), 3).filter).toBe("all");
+  });
+});
+
+describe("buildListSearch", () => {
+  const state: ListViewState = {
+    filter: "listened",
+    search: "  boards of canada  ",
+    sort: "artist-name",
+    sortDirection: "asc",
+  };
+
+  test("serialises non-default controls and trims the search", () => {
+    expect(buildListSearch(state, null)).toBe(
+      "?filter=listened&q=boards+of+canada&sort=artist-name&dir=asc",
+    );
+  });
+
+  test("omits everything left at its default", () => {
+    expect(buildListSearch(defaultListViewState(null), null)).toBe("");
+    expect(buildListSearch(defaultListViewState(4), 4)).toBe("");
+  });
+
+  test("the same filter is default on a stack page but not on home", () => {
+    const allFilter: ListViewState = { ...defaultListViewState(null), filter: "all" };
+    expect(buildListSearch(allFilter, null)).toBe("?filter=all");
+    expect(buildListSearch(allFilter, 4)).toBe("");
+  });
+
+  test("round-trips through parseListViewState", () => {
+    const query = buildListSearch(state, null);
+    expect(parseListViewState(params(query.slice(1)), null)).toEqual({
+      ...state,
+      search: "boards of canada",
+    });
+  });
+});
+
+describe("isDefaultListViewState", () => {
+  test("treats a whitespace-only search as unset", () => {
+    expect(isDefaultListViewState({ ...defaultListViewState(null), search: "   " }, null)).toBe(
+      true,
+    );
+  });
+
+  test("is false once a control moves", () => {
+    expect(
+      isDefaultListViewState({ ...defaultListViewState(null), sortDirection: "asc" }, null),
+    ).toBe(false);
+  });
+});
+
+describe("slugifyStackName / buildStackPath", () => {
+  test("slugifies punctuation and casing", () => {
+    expect(slugifyStackName("Dub Techno & Ambient!")).toBe("dub-techno-ambient");
+  });
+
+  test("builds the stack list path", () => {
+    expect(buildStackPath(12, "Dub Techno")).toBe("/s/12/dub-techno");
+  });
+});
+
+describe("stackIdFromListPath", () => {
+  test("extracts the stack id", () => {
+    expect(stackIdFromListPath("/s/12/dub-techno")).toBe(12);
+  });
+
+  test("returns null for the home list and other routes", () => {
+    expect(stackIdFromListPath("/")).toBeNull();
+    expect(stackIdFromListPath("/r/5")).toBeNull();
+  });
+});
+
+describe("buildListHref", () => {
+  test("joins path and query", () => {
+    const state: ListViewState = { ...defaultListViewState(9), filter: "listened" };
+    expect(buildListHref("/s/9/ambient", state, 9)).toBe("/s/9/ambient?filter=listened");
+  });
+});
+
+describe("sanitizeListHref", () => {
+  test("accepts the home list", () => {
+    expect(sanitizeListHref("/")).toBe("/");
+  });
+
+  test("accepts a stack list with its browsing state", () => {
+    expect(sanitizeListHref("/s/9/ambient?filter=listened&q=aphex")).toBe(
+      "/s/9/ambient?filter=listened&q=aphex",
+    );
+  });
+
+  test("drops unknown query params and normalises junk values", () => {
+    expect(sanitizeListHref("/s/9/ambient?filter=bogus&evil=1")).toBe("/s/9/ambient");
+  });
+
+  test("rejects off-site and protocol-relative targets", () => {
+    expect(sanitizeListHref("https://evil.test/")).toBeNull();
+    expect(sanitizeListHref("//evil.test/")).toBeNull();
+    expect(sanitizeListHref("/\\evil.test/")).toBeNull();
+  });
+
+  test("rejects non-list routes", () => {
+    expect(sanitizeListHref("/r/5")).toBeNull();
+    expect(sanitizeListHref("/settings")).toBeNull();
+    expect(sanitizeListHref("/s/9/ambient/extra")).toBeNull();
+  });
+
+  test("rejects empty and missing values", () => {
+    expect(sanitizeListHref(null)).toBeNull();
+    expect(sanitizeListHref(undefined)).toBeNull();
+    expect(sanitizeListHref("")).toBeNull();
+  });
+});
+
+describe("buildReleaseHref", () => {
+  test("remembers the list view it was opened from", () => {
+    expect(buildReleaseHref(42, "/s/9/ambient?filter=listened")).toBe(
+      "/r/42?from=%2Fs%2F9%2Fambient%3Ffilter%3Dlistened",
+    );
+  });
+
+  test("stays clean for the plain home list", () => {
+    expect(buildReleaseHref(42, "/")).toBe("/r/42");
+    expect(buildReleaseHref(42, null)).toBe("/r/42");
+  });
+
+  test("keeps home-list browsing state", () => {
+    expect(buildReleaseHref(42, "/?filter=all")).toBe("/r/42?from=%2F%3Ffilter%3Dall");
+  });
+
+  test("drops a back href that isn't a list route", () => {
+    expect(buildReleaseHref(42, "https://evil.test/")).toBe("/r/42");
+  });
+
+  test("round-trips back through sanitizeListHref", () => {
+    const href = buildReleaseHref(42, "/s/9/ambient?filter=listened");
+    const from = new URL(href, "http://list.invalid").searchParams.get("from");
+    expect(sanitizeListHref(from)).toBe("/s/9/ambient?filter=listened");
+  });
+});


### PR DESCRIPTION
Opening a release from a stack or a filtered list and hitting back
dropped you on the home list: the release page's back button was a
hardcoded `href="/"`, and the list's filter/search/sort lived only in
the app machine, so nothing about the view you came from survived.

The browsing view — stack scope, filter, search, sort and direction —
now lives in the list URL (`/s/12/ambient?filter=listened&q=aphex`).
Release links carry that URL along as `?from=`, and the release page's
back button (and post-delete redirect) return to it. `from` is
validated server-side against the list routes and re-serialised from
the recognised params, so a hand-edited link can't turn the back button
into an off-site redirect.

Stack selection and browse-control changes now use real navigations
instead of shallow `pushState`/`replaceState`. Shallow entries came
back from a release page carrying the previous route's URL and payload,
which is what left the address bar on a stack URL while the page
rendered the home list. Neither list load reads the query string, so
SvelteKit skips re-running it when only browsing state changes — the
filter buttons and search box still cost no server round trip.

The app machine seeds its whole view from the URL and refetches on
mount when that view differs from the server-rendered default.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0178vCuLgs954kS2VzMsbozM