### PR TITLE
Fix stack bar tab layout to flow left-to-right across rows

### DIFF
--- a/src/lib/components/StackBar.svelte
+++ b/src/lib/components/StackBar.svelte
@@ -36,6 +36,14 @@
   );
   const selectedStack = $derived(stacks.find((stack) => stack.id === currentStack));
 
+  // The bar is a two-row grid that flows left-to-right, so tabs read in
+  // alphabetical order along the top row before wrapping onto the second one.
+  // Row-wise flow needs an explicit column count: the first column is pinned to
+  // "All" (row 1) and the manage cog (row 2), and the remaining tabs — the
+  // stacks plus the delete tab while it is showing — split across both rows.
+  const flowingTabCount = $derived(visibleStacks.length + (selectedStack ? 1 : 0));
+  const columnCount = $derived(1 + Math.ceil(flowingTabCount / 2));
+
   // Keep the active tab visible when the selection changes.
   $effect(() => {
     void currentStack;
@@ -56,7 +64,12 @@
 </script>
 
 <div class="stack-bar-shell">
-  <div id="stack-bar" class="stack-bar" bind:this={barEl}>
+  <div
+    id="stack-bar"
+    class="stack-bar"
+    style="--stack-bar-columns: {columnCount}"
+    bind:this={barEl}
+  >
     <button
       class="stack-tab{currentStack === null ? ' active' : ''}"
       data-stack="all"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -703,8 +703,10 @@ select.input {
 .stack-bar {
   display: grid;
   grid-template-rows: repeat(2, auto);
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
+  /* Row-wise flow so tabs read left-to-right across the top row before
+     wrapping onto the second. StackBar sets the column count. */
+  grid-auto-flow: row;
+  grid-template-columns: repeat(var(--stack-bar-columns, 1), max-content);
   align-items: end;
   align-content: end;
   justify-content: start;


### PR DESCRIPTION
## Summary
Changed the stack bar grid layout from column-wise to row-wise flow, ensuring tabs read in left-to-right order across the top row before wrapping to the second row, improving readability and accessibility.

## Key Changes
- Modified grid layout in `.stack-bar` from `grid-auto-flow: column` to `grid-auto-flow: row`
- Replaced `grid-auto-columns: max-content` with explicit `grid-template-columns` using a CSS custom property `--stack-bar-columns`
- Added dynamic column count calculation in StackBar.svelte that accounts for:
  - The pinned "All" tab and manage cog (first column)
  - Visible stacks and the delete tab (when shown), split across both rows
- Updated the stack-bar div to apply the calculated column count via inline style

## Implementation Details
The layout is a two-row grid where:
- Column 1 is pinned to contain "All" (row 1) and the manage cog (row 2)
- Remaining tabs flow row-wise, filling the top row left-to-right before wrapping to the second row
- The column count is calculated as: `1 + Math.ceil((visibleStacks.length + (selectedStack ? 1 : 0)) / 2)`
- This ensures proper tab ordering for screen readers and visual consistency

https://claude.ai/code/session_019RNYZrCMganNQWXaqQBfa2