### PR TITLE
Implement artist tracking and new-release alerts

### DIFF
--- a/docs/plans/2026-07-31-artist-release-alerts-design.md
+++ b/docs/plans/2026-07-31-artist-release-alerts-design.md
@@ -27,8 +27,10 @@ Three moving parts:
    `artists`, with a confidence marker, so an artist is the unit of tracking.
 2. **Release snapshot** — per artist, the set of MusicBrainz *release groups* we've seen.
    The first poll is a silent baseline; every later poll diffs against it.
-3. **Alerts** — new release groups become `release_alerts` rows, surfaced in-app, over
-   RSS, and acceptable into the library as a normal `to-listen` item.
+3. **Alerts** — new release groups become `release_alerts` rows, surfaced in-app and over
+   RSS. Accepting one files an item into a New Releases stack; if the record isn't out
+   yet, it's scheduled to arrive in To Listen on release day via the existing reminder
+   cron.
 
 ---
 
@@ -66,8 +68,10 @@ interesting one. But firing an alert for every archival edit is noisy, so the ag
 release is a **filter on presentation**, not on detection:
 
 - Always record the new release group in `artist_releases`.
-- Raise an alert when `first-release-date` is within the freshness window
-  (default 18 months), **or** when the setting `alert_on_catalogue_additions` is on.
+- Raise an alert when `first-release-date` is within the freshness window — the last 18
+  months by default, **and any date in the future** (see [Announced
+  releases](#announced-releases)) — **or** when the setting
+  `alert_on_catalogue_additions` is on.
 
 That way turning the setting on later surfaces history we already captured, rather than
 needing a re-scan.
@@ -87,6 +91,41 @@ would immediately dump 40 alerts. Only rows first seen after the baseline can al
 
 ---
 
+## Announced releases
+
+MusicBrainz routinely carries records with a `first-release-date` in the future —
+announced-but-unreleased albums. These are the most valuable alerts in the system, and they
+have somewhere obvious to go: the existing remind-to-listen machinery.
+
+Accepting an alert for a future-dated release creates the item with `remind_at` set to the
+release date. `processReminders()` (hourly, `server/reminders.ts`) then does the rest — on
+release day it flips the item to `to-listen` and stamps `addedToListenAt`. Until then the
+item sits in the Scheduled bucket, already excluded from the To Listen feeds by the
+`isNull(musicItems.remindAt)` predicate in `server/routes/rss.ts`. No new scheduling code:
+the alert just hands off to a cron that already runs.
+
+**Partial dates.** MB dates are frequently incomplete, and the reminder column is a real
+timestamp, so map them explicitly:
+
+| `first-release-date` | `remind_at` |
+|---|---|
+| `2026-09-18` | that date |
+| `2026-09` | 1st of that month |
+| `2027` (future year) | 1st January of that year |
+| `2026` (current year) | none — add as `to-listen` directly |
+
+A year-only date in the current year can't be scheduled meaningfully — it may already have
+passed — so the item goes straight into To Listen rather than being scheduled into the past.
+
+**Date drift.** Announced dates slip; delayed albums are the norm, not the exception. On
+each poll, compare the stored `first_release_date` against MB's current value, and when it
+has moved, update the snapshot row. If that release group has an accepted item still
+carrying an unfired reminder (join through `release_alerts.music_item_id`, `remind_at` not
+null and `reminder_pending` false), move `remind_at` to match. A delayed record shouldn't
+surface as "out now" three months early — and the user never touched that date manually, so
+overwriting it is safe. Reminders the user set themselves are never touched; only ones this
+system created, which is why the alert → item link matters.
+
 ## Which artists get tracked
 
 Derived, with an explicit override — no separate "follow" action to remember.
@@ -103,9 +142,10 @@ On top of that, `artists.follow_state`:
 `muted` is the important one. Compilation credits, "Various Artists"-alikes, and one-off
 features generate alerts nobody wants, and the only person who can tell is the user.
 
-**Open question for later:** should `to-listen`-only artists be tracked too? Arguably yes —
-the user picked them up somewhere. Starting with `listened` keeps the first sweep small and
-the semantics honest to the request; widening it is a one-line predicate change.
+`to-listen`-only artists are **not** tracked. Having something queued isn't evidence you
+want the artist's whole future output — a record sits in To Listen precisely because you
+haven't formed that opinion yet. Listening is the signal. (The predicate lives in one
+place, so widening it later is a one-line change.)
 
 ---
 
@@ -208,10 +248,19 @@ A new `server/artist-watch.ts`, started from `src/hooks.server.ts` alongside the
 reminder and suggestion intervals, guarded by the same `globalThis` flag pattern and
 no-opping under `OTB_DISABLE_EXTERNAL_LOOKUPS`.
 
-**Cadence.** Sweep wakes every hour; each run drains artists where
-`next_poll_at <= now`, oldest first, throttled at the existing 2.5 s (env-overridable,
-matching `OTB_SUGGESTION_SWEEP_THROTTLE_MS`). MusicBrainz allows ~1 req/s; at 2.5 s that's
-~1,400 artists/hour, which comfortably exceeds any realistic personal library.
+**Cadence.** The sweep runs **daily**; each run drains artists where `next_poll_at <= now`,
+oldest first, throttled at the existing 2.5 s (env-overridable, matching
+`OTB_SUGGESTION_SWEEP_THROTTLE_MS`). MusicBrainz allows ~1 req/s; at 2.5 s that's ~1,400
+artists an hour, so even a large library finishes its due set in minutes.
+
+Daily is the right grain given the per-artist intervals below — an hourly wake would find
+nothing to do 23 times out of 24. It also sets the alert latency floor: a record added to
+MusicBrainz this morning surfaces within a day of its artist next coming due, which is well
+inside the useful window for something that is, at best, news of the week.
+
+Due-ness lives in the database (`next_poll_at`), not in the timer, so a restart never
+double-polls and never skips: the sweep runs on startup and then every 24 h, and both paths
+ask the same question. That matters for a deployment that restarts more than once a day.
 
 Per artist, one request (100 release groups covers all but the most prolific; paginate only
 when the response is full).
@@ -234,7 +283,8 @@ of the run. Reset the counter on success. Errors are logged and never thrown out
 sweep — one bad artist must not stop the queue.
 
 **Sweep budget.** Stop after 200 artists per run so a cold start with a big library spreads
-over hours instead of hammering MB for a solid day.
+across several days instead of hammering MB in one sitting. With baselines raising no
+alerts, that ramp is invisible to the user.
 
 ---
 
@@ -244,17 +294,27 @@ Three surfaces, in build order.
 
 ### 1. In-app: a "New Releases" view
 
-Not a real `stacks` row — alerts aren't music items until accepted. A dedicated view
-reached from the taskbar, showing pending alerts as cards: artwork (Cover Art Archive by
-release-group MBID, already wired for suggestions), artist, title, type, first-release date,
-and the reason it fired ("new release" vs "added to MusicBrainz").
+The queue itself is not a `stacks` row — alerts aren't music items until accepted. A
+dedicated view reached from the taskbar, showing pending alerts as cards: artwork (Cover Art
+Archive by release-group MBID, already wired for suggestions), artist, title, type,
+first-release date, and the reason it fired — "announced", "new release", or "added to
+MusicBrainz".
 
 Actions per card, matching `SuggestionPickerModal`'s vocabulary:
 
-- **Add** → creates a `to-listen` item via `music-item-creator` with the MB metadata
-  prefilled; alert → `added`, `music_item_id` set.
+- **Add** → creates an item via `music-item-creator` with the MB metadata prefilled, files
+  it in the **New Releases** stack, and sets `remind_at` when the release is still
+  announced-only (see [Announced releases](#announced-releases)); alert → `added`,
+  `music_item_id` set.
 - **Dismiss** → alert → `dismissed`. Never re-fires (unique index on the release).
 - **Mute artist** → `follow_state = 'muted'`, dismisses that artist's pending alerts.
+
+**The New Releases stack** is a real stack, created on first accept. Reference it by id in
+`app_settings` (`new_releases_stack_id`) rather than by name — `stacks.name` is unique and
+user-editable, so name-matching would silently create a duplicate the moment the user
+renames it. Recreate only if the stored id no longer resolves. Items land there *in
+addition* to normal status handling, so the stack accumulates as a running record of what
+the watcher has fed the library, and it nests like any other stack.
 
 A count badge on the taskbar entry when any alert is `pending`. Marking the view as viewed
 flips `pending` → `seen` so the badge clears without forcing a decision on each card.
@@ -270,11 +330,21 @@ item shape, which is a worthwhile tidy-up of that module anyway.
 1978 record surfacing today should appear at the top of the reader, which is when the news
 actually happened).
 
-### 3. Later: iOS
+### 3. Out of scope: the notification UI
 
-`native/` has a share extension and a widget but no push plumbing, and a widget listing
-pending alerts is a much smaller job than APNs. Out of scope here; the `release_alerts`
-table is the API either would read.
+A dedicated notification surface — a proper notifications centre, and eventually push —
+is wanted, but not in this work. It is deliberately *not* the New Releases view above:
+that view is the alert queue, a place to go and triage. Notifications are delivery, they'll
+carry more than release alerts (reminders firing, ingest results), and they deserve their
+own design.
+
+Two things here are built to receive it. `release_alerts` is already the queue a
+notification layer would read — status transitions, timestamps and the artist join are all
+there. And `native/` has a share extension and a widget but no push plumbing; a widget
+listing pending alerts would be a far smaller job than APNs if an interim step is wanted.
+
+Until that exists, RSS is the delivery mechanism: the user's reader does the alerting, at
+zero infrastructure cost.
 
 ---
 
@@ -285,9 +355,11 @@ New keys in `app_settings` (existing key/value pattern, single-user app):
 | Key | Default | Effect |
 |---|---|---|
 | `artist_watch_enabled` | `true` | Master switch for the sweep |
-| `alert_freshness_months` | `18` | Age window for "new release" alerts |
+| `alert_freshness_months` | `18` | Age window for "new release" alerts; future dates always qualify |
 | `alert_on_catalogue_additions` | `false` | Also alert on newly-added older records |
 | `alert_excluded_secondary_types` | `compilation,live,remix,dj-mix` | Noise filter |
+| `new_releases_stack_id` | — | Stack accepted alerts are filed into; set on first accept |
+| `schedule_announced_releases` | `true` | Set `remind_at` from a future release date on accept |
 
 Exposed through the existing `GET`/`PUT /api/settings` handlers, plus an artist-management
 panel listing tracked artists with their MBID confidence, last poll, and a mute toggle.
@@ -323,20 +395,23 @@ and 3. Unit tests for the confidence rules, especially the ambiguous-name reject
 
 **Phase 2 — snapshot + poller.** Migrations for `artist_releases` and `release_alerts`.
 `server/musicbrainz.ts` grows `fetchArtistReleaseGroups(mbid)`. `server/artist-watch.ts`
-holds the queue, the diff, the baseline rule and the filters. Wire the interval into
+holds the queue, the diff, the baseline rule and the filters. Wire the daily interval into
 `src/hooks.server.ts`. Tests with a stubbed fetch: baseline silence, new group alerts,
-repeat poll doesn't re-alert, secondary-type filtering, backoff on failure.
+repeat poll doesn't re-alert, secondary-type filtering, future-dated releases alerting
+regardless of the freshness window, backoff on failure.
 
-**Phase 3 — API + RSS.** `server/routes/release-alerts.ts`, mounted in `server/app.ts`;
-generalise the RSS renderer and add the feed. Route tests in the style of
-`tests/unit/release-route.test.ts`.
+**Phase 3 — API + RSS.** `server/routes/release-alerts.ts`, mounted in `server/app.ts`.
+Accept handling — the New Releases stack, and `remind_at` from partial dates — lands here;
+the date-mapping table above is pure logic and wants direct unit tests. Generalise the RSS
+renderer and add the feed. Route tests in the style of `tests/unit/release-route.test.ts`.
 
 **Phase 4 — UI.** New Releases view, taskbar badge with count, artist-management panel in
 settings. Retro chrome throughout (Encarta / Win97), and the alert cards need to hold up at
 mobile width — a Playwright spec alongside the existing visual tests, per `AGENTS.md`.
 
-**Phase 5 — polish.** Adaptive intervals and jitter, per-artist "check now", cover art on
-alert cards, and the settings toggles.
+**Phase 5 — polish.** Adaptive intervals and jitter, date-drift reconciliation for
+scheduled announced releases, per-artist "check now", cover art on alert cards, and the
+settings toggles.
 
 Phases 1–2 alone make the system *correct but invisible* — alerts accumulate in the table.
 That's a deliberate ordering: it lets the poller bake against real data for a week before
@@ -369,13 +444,21 @@ baseline when every page fetched cleanly.
 
 ---
 
-## Open questions
+## Decisions
 
-1. Track `to-listen` artists too, or `listened` only to start?
-2. Should accepting an alert put the item in a specific stack (e.g. "New Releases"), or
-   just the general to-listen list?
-3. Is the RSS feed enough for delivery, or is a real notification path (email via the
-   existing ingest infrastructure, iOS push) wanted sooner than Phase 5?
-4. Should the freshness window default to alerting on *upcoming* releases too —
-   MusicBrainz often lists announced records with future `first-release-date`s, which is
-   arguably the most useful alert of all.
+Settled during design review:
+
+1. **Listened artists only.** `to-listen` is not evidence of wanting an artist's future
+   output.
+2. **Accepted alerts go to a New Releases stack**, referenced by id in settings.
+3. **Poll daily.** Per-artist intervals stay at 7 / 21 / 60 days; the daily sweep just
+   drains whatever is due.
+4. **Announced releases are alerted on and scheduled**, handing off to the existing
+   remind-to-listen cron via `remind_at`.
+5. **A dedicated notification UI is wanted but out of scope.** RSS is the interim delivery
+   mechanism; `release_alerts` is the queue that surface will read.
+
+Still open:
+
+- Whether date-drift reconciliation (Phase 5) should also *un*-schedule a release whose
+  date is removed from MusicBrainz entirely, or leave the reminder standing.

--- a/docs/plans/2026-07-31-artist-release-alerts-design.md
+++ b/docs/plans/2026-07-31-artist-release-alerts-design.md
@@ -126,6 +126,15 @@ surface as "out now" three months early — and the user never touched that date
 overwriting it is safe. Reminders the user set themselves are never touched; only ones this
 system created, which is why the alert → item link matters.
 
+When MusicBrainz drops the date **entirely** — the group still exists, but
+`first-release-date` is gone — clear `remind_at` rather than leaving the old reminder
+standing. A removed date means the release date is now unknown, and a reminder derived from
+a value MusicBrainz has retracted is asserting something nobody stands behind any more.
+Clearing it drops the item out of Scheduled and into To Listen, which does mean surfacing a
+record that may not be out yet — that's the accepted cost. The alternative is holding the
+item in Scheduled forever against a phantom date, which fails silently, and silent is
+worse.
+
 ## Which artists get tracked
 
 Derived, with an explicit override — no separate "follow" action to remember.
@@ -457,8 +466,8 @@ Settled during design review:
    remind-to-listen cron via `remind_at`.
 5. **A dedicated notification UI is wanted but out of scope.** RSS is the interim delivery
    mechanism; `release_alerts` is the queue that surface will read.
+6. **A release whose date is removed from MusicBrainz is un-scheduled** — clear
+   `remind_at` and let the item fall into To Listen, rather than holding it against a date
+   that no longer exists.
 
-Still open:
-
-- Whether date-drift reconciliation (Phase 5) should also *un*-schedule a release whose
-  date is removed from MusicBrainz entirely, or leave the reminder standing.
+No open questions outstanding.

--- a/docs/plans/2026-07-31-artist-release-alerts-design.md
+++ b/docs/plans/2026-07-31-artist-release-alerts-design.md
@@ -1,0 +1,381 @@
+# Artist Tracking & New-Release Alerts — Design
+
+**Goal:** Track every artist the user has listened to, watch MusicBrainz for releases by
+those artists that we haven't seen before, and surface them as alerts the user can accept
+into the library.
+
+**Status:** design only — no code written yet.
+
+---
+
+## Overview
+
+The app already knows the artists: `artists` rows are created for every item, and
+`music_items.listened_at` / `listen_status` say which ones have actually been listened to.
+What's missing is (a) a stable MusicBrainz identity per *artist* rather than per *item*,
+(b) a memory of which releases by that artist we already know about, and (c) a poller that
+diffs the two.
+
+The design deliberately mirrors the existing suggestion prefetch (`server/suggestions.ts`):
+a throttled background sweep started from `src/hooks.server.ts`, writing pending rows into
+a table, surfaced later in the UI with accept/dismiss. Same shape, different lifecycle —
+so it should feel like the codebase it lands in.
+
+Three moving parts:
+
+1. **Artist identity** — promote the MusicBrainz artist ID from `music_items` onto
+   `artists`, with a confidence marker, so an artist is the unit of tracking.
+2. **Release snapshot** — per artist, the set of MusicBrainz *release groups* we've seen.
+   The first poll is a silent baseline; every later poll diffs against it.
+3. **Alerts** — new release groups become `release_alerts` rows, surfaced in-app, over
+   RSS, and acceptable into the library as a normal `to-listen` item.
+
+---
+
+## Why release *groups*, not releases
+
+`server/musicbrainz.ts` currently browses `/artist/{mbid}?inc=releases`, which returns every
+release: each pressing, each country, each reissue. For "is this new?" that's the wrong
+grain — a 2026 Japanese repress of a 1974 album would fire an alert.
+
+Release **groups** are the album-level entity: one per work, with `first-release-date` and
+`primary-type` / `secondary-types`. Poll:
+
+```
+GET /ws/2/release-group?artist={mbid}&limit=100&offset=0&fmt=json
+```
+
+The existing suggestion code can stay on releases — it needs `media` track counts for its
+length preference, which release groups don't carry. The two paths coexist; only the new
+poller uses release groups.
+
+---
+
+## What counts as "new"
+
+Two different events, and the user asked about the second:
+
+| Event | Detect how |
+|---|---|
+| Artist puts out a new record | `first-release-date` is recent |
+| A record is newly *added to MusicBrainz* | Release-group MBID we've never stored |
+
+Snapshot-diffing on MBID catches both — a catalogue addition of a 1978 record is a genuine
+"new to MusicBrainz" event, and for a user tracking obscure artists it's often the more
+interesting one. But firing an alert for every archival edit is noisy, so the age of the
+release is a **filter on presentation**, not on detection:
+
+- Always record the new release group in `artist_releases`.
+- Raise an alert when `first-release-date` is within the freshness window
+  (default 18 months), **or** when the setting `alert_on_catalogue_additions` is on.
+
+That way turning the setting on later surfaces history we already captured, rather than
+needing a re-scan.
+
+### Baseline
+
+The first successful poll for an artist inserts every release group with
+`is_baseline = 1` and raises **no** alerts. Without this, adding a well-documented artist
+would immediately dump 40 alerts. Only rows first seen after the baseline can alert.
+
+### Noise filters (defaults, all overridable in settings)
+
+- Skip secondary types `compilation`, `live`, `remix`, `dj-mix`, `interview`, `audiobook`.
+- Skip primary type `other`.
+- Never track the Various Artists MBID (`89ad4ac3-39f7-470e-963a-56509c546377`).
+- Cap alerts at 3 per artist per sweep; the rest stay recorded and surface next sweep.
+
+---
+
+## Which artists get tracked
+
+Derived, with an explicit override — no separate "follow" action to remember.
+
+An artist is **tracked** when they have at least one item with `listen_status = 'listened'`.
+On top of that, `artists.follow_state`:
+
+| Value | Meaning |
+|---|---|
+| `auto` (default) | Tracked iff the derived rule says so |
+| `always` | Tracked regardless (user asked for it explicitly) |
+| `muted` | Never tracked, never alerted |
+
+`muted` is the important one. Compilation credits, "Various Artists"-alikes, and one-off
+features generate alerts nobody wants, and the only person who can tell is the user.
+
+**Open question for later:** should `to-listen`-only artists be tracked too? Arguably yes —
+the user picked them up somewhere. Starting with `listened` keeps the first sweep small and
+the semantics honest to the request; widening it is a one-line predicate change.
+
+---
+
+## Data model
+
+### `artists` — new columns
+
+| Column | Type | Notes |
+|---|---|---|
+| `musicbrainz_artist_id` | text, nullable | The artist's MBID |
+| `mbid_confidence` | text, nullable | `confirmed` \| `probable` \| `unresolved` |
+| `mbid_resolved_at` | timestamp, nullable | Last resolution attempt (hit or miss) |
+| `follow_state` | text, not null, default `auto` | `auto` \| `always` \| `muted` |
+| `last_polled_at` | timestamp, nullable | Last successful release-group poll |
+| `next_poll_at` | timestamp, nullable | Due time; the sweep's work queue |
+| `poll_failure_count` | integer, not null, default 0 | Drives exponential backoff |
+
+Index on `next_poll_at` — the sweep's only hot query.
+
+### `artist_releases` — the snapshot
+
+```sql
+CREATE TABLE artist_releases (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  artist_id integer NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+  mb_release_group_id text NOT NULL,
+  title text NOT NULL,
+  normalized_title text NOT NULL,
+  primary_type text,
+  secondary_types text,            -- JSON array
+  first_release_date text,         -- MB's partial date, verbatim: "1974", "1974-05"
+  first_release_year integer,      -- parsed for sorting/filtering
+  is_baseline integer NOT NULL DEFAULT 0,
+  first_seen_at integer NOT NULL
+);
+CREATE UNIQUE INDEX artist_releases_artist_group ON artist_releases (artist_id, mb_release_group_id);
+CREATE INDEX idx_artist_releases_artist_id ON artist_releases (artist_id);
+```
+
+Store MB's date string as given — partial dates (`1974`, `1974-05`) are normal and coercing
+them to a full `Date` invents precision. Keep the parsed year alongside for filtering.
+
+### `release_alerts` — the user-facing queue
+
+```sql
+CREATE TABLE release_alerts (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  artist_id integer NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+  artist_release_id integer NOT NULL REFERENCES artist_releases(id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'pending',   -- pending | seen | added | dismissed
+  music_item_id integer REFERENCES music_items(id) ON DELETE SET NULL,
+  created_at integer NOT NULL,
+  resolved_at integer
+);
+CREATE UNIQUE INDEX release_alerts_release ON release_alerts (artist_release_id);
+CREATE INDEX idx_release_alerts_status ON release_alerts (status);
+```
+
+The unique index on `artist_release_id` is the idempotency guarantee: a release can alert
+once, ever, no matter how the sweep is retried or restarted.
+
+**Not reusing `item_suggestions`.** It's keyed to a *source item* and answers "what else by
+this artist have you not heard" — an editorial pick of one release, cleared when accepted.
+Alerts are keyed to an artist, are an unbounded stream, and must never re-fire. Same
+neighbourhood, different lifecycle; sharing the table would mean two meanings of `status`
+in one column.
+
+---
+
+## Resolving artist MBIDs
+
+This is the part most likely to produce wrong results, so it gets the most care. A bare
+name search for "Nirvana", "Bad Company" or "Sun Ra Arkestra" returns several real artists,
+and picking wrong means alerting on a stranger's discography forever.
+
+Resolution ladder, best evidence first:
+
+1. **From existing items.** `music_items.musicbrainz_artist_id` is already populated by the
+   scan/manual-add enrichment path. Take the most frequent non-null value across the
+   artist's items → `confirmed`. This backfills most of the library for free, no network.
+2. **Via a known release.** For artists with no stored MBID, take one of their tracked
+   releases and call the existing `lookupRelease(artist, title, year)` — the release search
+   pins the artist through a record we know they made. Its `musicbrainzArtistId` →
+   `confirmed`. This is far safer than a name search and reuses code that already exists.
+3. **Name search fallback.** `/ws/2/artist?query=…`. Accept only when the top hit's score
+   is ≥ 95 **and** it beats the second hit by ≥ 20 → `probable`. Otherwise `unresolved`.
+
+Only `confirmed` and `probable` artists are polled. `unresolved` artists are listed in
+settings with their candidate matches (name, disambiguation comment, country, life span) so
+the user can pick — a small retro list dialog, in keeping with the existing chrome. Until
+then they're simply not polled; no alerts is the correct failure mode, wrong alerts is not.
+
+Re-resolution is attempted at most once per 30 days per unresolved artist.
+
+---
+
+## The poller
+
+A new `server/artist-watch.ts`, started from `src/hooks.server.ts` alongside the existing
+reminder and suggestion intervals, guarded by the same `globalThis` flag pattern and
+no-opping under `OTB_DISABLE_EXTERNAL_LOOKUPS`.
+
+**Cadence.** Sweep wakes every hour; each run drains artists where
+`next_poll_at <= now`, oldest first, throttled at the existing 2.5 s (env-overridable,
+matching `OTB_SUGGESTION_SWEEP_THROTTLE_MS`). MusicBrainz allows ~1 req/s; at 2.5 s that's
+~1,400 artists/hour, which comfortably exceeds any realistic personal library.
+
+Per artist, one request (100 release groups covers all but the most prolific; paginate only
+when the response is full).
+
+**Adaptive intervals** — most artists are dormant and don't deserve weekly polls:
+
+| Artist's most recent release | Next poll in |
+|---|---|
+| Within 2 years | 7 days |
+| 2–10 years ago | 21 days |
+| Older than 10 years | 60 days |
+
+Jitter each interval by ±20 % so an import batch doesn't resynchronise into a thundering
+herd forever after.
+
+**Failures.** On network error or 5xx: `poll_failure_count++`, `next_poll_at = now +
+2^failures hours`, capped at 7 days; `last_polled_at` untouched so the artist keeps its
+baseline. On 503 (MB's rate-limit response) additionally pause the whole sweep for the rest
+of the run. Reset the counter on success. Errors are logged and never thrown out of the
+sweep — one bad artist must not stop the queue.
+
+**Sweep budget.** Stop after 200 artists per run so a cold start with a big library spreads
+over hours instead of hammering MB for a solid day.
+
+---
+
+## Surfacing alerts
+
+Three surfaces, in build order.
+
+### 1. In-app: a "New Releases" view
+
+Not a real `stacks` row — alerts aren't music items until accepted. A dedicated view
+reached from the taskbar, showing pending alerts as cards: artwork (Cover Art Archive by
+release-group MBID, already wired for suggestions), artist, title, type, first-release date,
+and the reason it fired ("new release" vs "added to MusicBrainz").
+
+Actions per card, matching `SuggestionPickerModal`'s vocabulary:
+
+- **Add** → creates a `to-listen` item via `music-item-creator` with the MB metadata
+  prefilled; alert → `added`, `music_item_id` set.
+- **Dismiss** → alert → `dismissed`. Never re-fires (unique index on the release).
+- **Mute artist** → `follow_state = 'muted'`, dismisses that artist's pending alerts.
+
+A count badge on the taskbar entry when any alert is `pending`. Marking the view as viewed
+flips `pending` → `seen` so the badge clears without forcing a decision on each card.
+
+### 2. RSS: `/feed/new-releases.rss`
+
+Nearly free given `server/routes/rss.ts`, and it's the closest thing to a push notification
+this app can offer without notification infrastructure — the user's existing reader does the
+alerting. The renderer currently assumes `MusicItemFull`; this feed needs a small generic
+item shape, which is a worthwhile tidy-up of that module anyway.
+
+`guid` = `release-alert-{id}`, `pubDate` = alert `created_at` (not the release date — a
+1978 record surfacing today should appear at the top of the reader, which is when the news
+actually happened).
+
+### 3. Later: iOS
+
+`native/` has a share extension and a widget but no push plumbing, and a widget listing
+pending alerts is a much smaller job than APNs. Out of scope here; the `release_alerts`
+table is the API either would read.
+
+---
+
+## Settings
+
+New keys in `app_settings` (existing key/value pattern, single-user app):
+
+| Key | Default | Effect |
+|---|---|---|
+| `artist_watch_enabled` | `true` | Master switch for the sweep |
+| `alert_freshness_months` | `18` | Age window for "new release" alerts |
+| `alert_on_catalogue_additions` | `false` | Also alert on newly-added older records |
+| `alert_excluded_secondary_types` | `compilation,live,remix,dj-mix` | Noise filter |
+
+Exposed through the existing `GET`/`PUT /api/settings` handlers, plus an artist-management
+panel listing tracked artists with their MBID confidence, last poll, and a mute toggle.
+
+---
+
+## API
+
+| Route | Purpose |
+|---|---|
+| `GET /api/release-alerts?status=pending` | List alerts with artist + release joined |
+| `POST /api/release-alerts/:id/add` | Create the item, mark `added`, return the item |
+| `POST /api/release-alerts/:id/dismiss` | Mark `dismissed` |
+| `POST /api/release-alerts/mark-seen` | Bulk `pending` → `seen`, clears the badge |
+| `GET /api/artists/tracked` | Artists with follow state, MBID confidence, last poll |
+| `PUT /api/artists/:id/follow` | Set `auto` \| `always` \| `muted` |
+| `PUT /api/artists/:id/mbid` | Confirm an MBID from the disambiguation dialog |
+| `POST /api/artists/:id/poll` | Force an immediate poll (debug / "check now") |
+| `GET /feed/new-releases.rss` | RSS feed of alerts |
+
+All mutating routes go through the existing CSRF handle in `src/hooks.server.ts`; no change
+needed there.
+
+---
+
+## Implementation phases
+
+Each phase is independently shippable and leaves the app working.
+
+**Phase 1 — artist identity.** Migration for the new `artists` columns. Backfill MBIDs from
+`music_items` (resolution step 1, no network). New `server/artist-identity.ts` with steps 2
+and 3. Unit tests for the confidence rules, especially the ambiguous-name rejection.
+
+**Phase 2 — snapshot + poller.** Migrations for `artist_releases` and `release_alerts`.
+`server/musicbrainz.ts` grows `fetchArtistReleaseGroups(mbid)`. `server/artist-watch.ts`
+holds the queue, the diff, the baseline rule and the filters. Wire the interval into
+`src/hooks.server.ts`. Tests with a stubbed fetch: baseline silence, new group alerts,
+repeat poll doesn't re-alert, secondary-type filtering, backoff on failure.
+
+**Phase 3 — API + RSS.** `server/routes/release-alerts.ts`, mounted in `server/app.ts`;
+generalise the RSS renderer and add the feed. Route tests in the style of
+`tests/unit/release-route.test.ts`.
+
+**Phase 4 — UI.** New Releases view, taskbar badge with count, artist-management panel in
+settings. Retro chrome throughout (Encarta / Win97), and the alert cards need to hold up at
+mobile width — a Playwright spec alongside the existing visual tests, per `AGENTS.md`.
+
+**Phase 5 — polish.** Adaptive intervals and jitter, per-artist "check now", cover art on
+alert cards, and the settings toggles.
+
+Phases 1–2 alone make the system *correct but invisible* — alerts accumulate in the table.
+That's a deliberate ordering: it lets the poller bake against real data for a week before
+any UI depends on its output, and the baseline-vs-alert behaviour is exactly the thing you
+want to observe before it starts pinging you.
+
+---
+
+## Risks
+
+**Wrong artist match.** The big one. Mitigated by the confidence ladder, by preferring
+release-derived MBIDs over name search, and by never polling `unresolved`. Worst realistic
+case is a `probable` mismatch producing a stream of alerts for the wrong band — the mute
+action and the artist panel make that recoverable in one click, and a mismatch is visible
+immediately because the titles will look wrong.
+
+**MusicBrainz rate limiting.** Existing code already got bitten by this (see the User-Agent
+comment in `server/musicbrainz.ts`). Mitigated by the shared throttle, per-run budget,
+adaptive intervals, and 503 handling. Worth considering a single shared MB request queue
+across the suggestion sweep and this one, since they now compete for the same 1 req/s —
+otherwise two concurrent sweeps quietly double the rate.
+
+**Alert fatigue.** A 300-artist library with catalogue additions on could produce dozens of
+alerts a week. Defaults are conservative (freshness window on, catalogue additions off,
+per-artist cap) and the mute path is prominent.
+
+**Baseline correctness.** If a poll partially fails mid-pagination and we still write the
+baseline, the missing groups will alert as "new" on the next successful poll. Only mark the
+baseline when every page fetched cleanly.
+
+---
+
+## Open questions
+
+1. Track `to-listen` artists too, or `listened` only to start?
+2. Should accepting an alert put the item in a specific stack (e.g. "New Releases"), or
+   just the general to-listen list?
+3. Is the RSS feed enough for delivery, or is a real notification path (email via the
+   existing ingest infrastructure, iOS push) wanted sooner than Phase 5?
+4. Should the freshness window default to alerting on *upcoming* releases too —
+   MusicBrainz often lists announced records with future `first-release-date`s, which is
+   arguably the most useful alert of all.

--- a/docs/plans/2026-07-31-artist-release-alerts-design.md
+++ b/docs/plans/2026-07-31-artist-release-alerts-design.md
@@ -4,7 +4,14 @@
 those artists that we haven't seen before, and surface them as alerts the user can accept
 into the library.
 
-**Status:** design only — no code written yet.
+**Status:** implemented. Phases 1–5 all landed together; see `server/artist-identity.ts`,
+`server/artist-watch.ts`, `server/release-alerts.ts`, the `/api/release-alerts` and
+`/api/artists` routes, `/feed/new-releases.rss`, and the `/new-releases` view.
+
+Two details settled during the build, both noted inline below: the excluded secondary types
+default to the full six-type list from [Noise filters](#noise-filters-defaults-all-overridable-in-settings)
+rather than the four quoted in the settings table, and `release_alerts` carries a `reason`
+column so a card can say *why* it fired without re-deriving it from the release date.
 
 ---
 

--- a/drizzle/0013_melodic_malice.sql
+++ b/drizzle/0013_melodic_malice.sql
@@ -1,0 +1,41 @@
+CREATE TABLE `artist_releases` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`artist_id` integer NOT NULL,
+	`mb_release_group_id` text NOT NULL,
+	`title` text NOT NULL,
+	`normalized_title` text NOT NULL,
+	`primary_type` text,
+	`secondary_types` text,
+	`first_release_date` text,
+	`first_release_year` integer,
+	`is_baseline` integer DEFAULT false NOT NULL,
+	`first_seen_at` integer NOT NULL,
+	FOREIGN KEY (`artist_id`) REFERENCES `artists`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_artist_releases_artist_id` ON `artist_releases` (`artist_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `artist_releases_artist_group` ON `artist_releases` (`artist_id`,`mb_release_group_id`);--> statement-breakpoint
+CREATE TABLE `release_alerts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`artist_id` integer NOT NULL,
+	`artist_release_id` integer NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`reason` text DEFAULT 'new-release' NOT NULL,
+	`music_item_id` integer,
+	`created_at` integer NOT NULL,
+	`resolved_at` integer,
+	FOREIGN KEY (`artist_id`) REFERENCES `artists`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`artist_release_id`) REFERENCES `artist_releases`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`music_item_id`) REFERENCES `music_items`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_release_alerts_status` ON `release_alerts` (`status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `release_alerts_release` ON `release_alerts` (`artist_release_id`);--> statement-breakpoint
+ALTER TABLE `artists` ADD `musicbrainz_artist_id` text;--> statement-breakpoint
+ALTER TABLE `artists` ADD `mbid_confidence` text;--> statement-breakpoint
+ALTER TABLE `artists` ADD `mbid_resolved_at` integer;--> statement-breakpoint
+ALTER TABLE `artists` ADD `follow_state` text DEFAULT 'auto' NOT NULL;--> statement-breakpoint
+ALTER TABLE `artists` ADD `last_polled_at` integer;--> statement-breakpoint
+ALTER TABLE `artists` ADD `next_poll_at` integer;--> statement-breakpoint
+ALTER TABLE `artists` ADD `poll_failure_count` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_artists_next_poll_at` ON `artists` (`next_poll_at`);

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1148 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ed97d5f7-8f55-423c-9bc6-28fc00e72e91",
+  "prevId": "f43c19ff-c420-4f98-82a2-388e8790c5f3",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artist_releases": {
+      "name": "artist_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mb_release_group_id": {
+          "name": "mb_release_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_title": {
+          "name": "normalized_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondary_types": {
+          "name": "secondary_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_release_year": {
+          "name": "first_release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_baseline": {
+          "name": "is_baseline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_artist_releases_artist_id": {
+          "name": "idx_artist_releases_artist_id",
+          "columns": [
+            "artist_id"
+          ],
+          "isUnique": false
+        },
+        "artist_releases_artist_group": {
+          "name": "artist_releases_artist_group",
+          "columns": [
+            "artist_id",
+            "mb_release_group_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "artist_releases_artist_id_artists_id_fk": {
+          "name": "artist_releases_artist_id_artists_id_fk",
+          "tableFrom": "artist_releases",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mbid_confidence": {
+          "name": "mbid_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mbid_resolved_at": {
+          "name": "mbid_resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follow_state": {
+          "name": "follow_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poll_failure_count": {
+          "name": "poll_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "artists_normalized_name_unique": {
+          "name": "artists_normalized_name_unique",
+          "columns": [
+            "normalized_name"
+          ],
+          "isUnique": true
+        },
+        "idx_artists_next_poll_at": {
+          "name": "idx_artists_next_poll_at",
+          "columns": [
+            "next_poll_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_suggestions": {
+      "name": "item_suggestions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_item_id": {
+          "name": "source_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'album'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "musicbrainz_release_id": {
+          "name": "musicbrainz_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_item_suggestions_source_item_id": {
+          "name": "idx_item_suggestions_source_item_id",
+          "columns": [
+            "source_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_suggestions_source_item_id_music_items_id_fk": {
+          "name": "item_suggestions_source_item_id_music_items_id_fk",
+          "tableFrom": "item_suggestions",
+          "tableTo": "music_items",
+          "columnsFrom": [
+            "source_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "music_item_order": {
+      "name": "music_item_order",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "music_item_stacks": {
+      "name": "music_item_stacks",
+      "columns": {
+        "music_item_id": {
+          "name": "music_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stack_id": {
+          "name": "stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_music_item_stacks_stack_id": {
+          "name": "idx_music_item_stacks_stack_id",
+          "columns": [
+            "stack_id"
+          ],
+          "isUnique": false
+        },
+        "idx_music_item_stacks_music_item_id": {
+          "name": "idx_music_item_stacks_music_item_id",
+          "columns": [
+            "music_item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "music_item_stacks_music_item_id_music_items_id_fk": {
+          "name": "music_item_stacks_music_item_id_music_items_id_fk",
+          "tableFrom": "music_item_stacks",
+          "tableTo": "music_items",
+          "columnsFrom": [
+            "music_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_item_stacks_stack_id_stacks_id_fk": {
+          "name": "music_item_stacks_stack_id_stacks_id_fk",
+          "tableFrom": "music_item_stacks",
+          "tableTo": "stacks",
+          "columnsFrom": [
+            "stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "music_item_stacks_music_item_id_stack_id_pk": {
+          "columns": [
+            "music_item_id",
+            "stack_id"
+          ],
+          "name": "music_item_stacks_music_item_id_stack_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "music_items": {
+      "name": "music_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_title": {
+          "name": "normalized_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'album'"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listen_status": {
+          "name": "listen_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'to-listen'"
+        },
+        "purchase_intent": {
+          "name": "purchase_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'no'"
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_to_listen_at": {
+          "name": "added_to_listen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listened_at": {
+          "name": "listened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_physical": {
+          "name": "is_physical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "physical_format": {
+          "name": "physical_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalogue_number": {
+          "name": "catalogue_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "musicbrainz_release_id": {
+          "name": "musicbrainz_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apple_music_lookup_at": {
+          "name": "apple_music_lookup_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_pending": {
+          "name": "reminder_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_music_items_listen_status": {
+          "name": "idx_music_items_listen_status",
+          "columns": [
+            "listen_status"
+          ],
+          "isUnique": false
+        },
+        "idx_music_items_purchase_intent": {
+          "name": "idx_music_items_purchase_intent",
+          "columns": [
+            "purchase_intent"
+          ],
+          "isUnique": false
+        },
+        "idx_music_items_artist_id": {
+          "name": "idx_music_items_artist_id",
+          "columns": [
+            "artist_id"
+          ],
+          "isUnique": false
+        },
+        "idx_music_items_created_at": {
+          "name": "idx_music_items_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_music_items_added_to_listen_at": {
+          "name": "idx_music_items_added_to_listen_at",
+          "columns": [
+            "added_to_listen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "music_items_artist_id_artists_id_fk": {
+          "name": "music_items_artist_id_artists_id_fk",
+          "tableFrom": "music_items",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "music_links": {
+      "name": "music_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "music_item_id": {
+          "name": "music_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_music_links_music_item_id": {
+          "name": "idx_music_links_music_item_id",
+          "columns": [
+            "music_item_id"
+          ],
+          "isUnique": false
+        },
+        "idx_music_links_url": {
+          "name": "idx_music_links_url",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        },
+        "music_links_item_url": {
+          "name": "music_links_item_url",
+          "columns": [
+            "music_item_id",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "music_links_music_item_id_music_items_id_fk": {
+          "name": "music_links_music_item_id_music_items_id_fk",
+          "tableFrom": "music_links",
+          "tableTo": "music_items",
+          "columnsFrom": [
+            "music_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "music_links_source_id_sources_id_fk": {
+          "name": "music_links_source_id_sources_id_fk",
+          "tableFrom": "music_links",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_alerts": {
+      "name": "release_alerts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_release_id": {
+          "name": "artist_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'new-release'"
+        },
+        "music_item_id": {
+          "name": "music_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_release_alerts_status": {
+          "name": "idx_release_alerts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "release_alerts_release": {
+          "name": "release_alerts_release",
+          "columns": [
+            "artist_release_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_alerts_artist_id_artists_id_fk": {
+          "name": "release_alerts_artist_id_artists_id_fk",
+          "tableFrom": "release_alerts",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "release_alerts_artist_release_id_artist_releases_id_fk": {
+          "name": "release_alerts_artist_release_id_artist_releases_id_fk",
+          "tableFrom": "release_alerts",
+          "tableTo": "artist_releases",
+          "columnsFrom": [
+            "artist_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "release_alerts_music_item_id_music_items_id_fk": {
+          "name": "release_alerts_music_item_id_music_items_id_fk",
+          "tableFrom": "release_alerts",
+          "tableTo": "music_items",
+          "columnsFrom": [
+            "music_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sources_name_unique": {
+          "name": "sources_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stack_parents": {
+      "name": "stack_parents",
+      "columns": {
+        "parent_stack_id": {
+          "name": "parent_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_stack_id": {
+          "name": "child_stack_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stack_parents_parent_stack_id": {
+          "name": "idx_stack_parents_parent_stack_id",
+          "columns": [
+            "parent_stack_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stack_parents_child_stack_id": {
+          "name": "idx_stack_parents_child_stack_id",
+          "columns": [
+            "child_stack_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stack_parents_parent_stack_id_stacks_id_fk": {
+          "name": "stack_parents_parent_stack_id_stacks_id_fk",
+          "tableFrom": "stack_parents",
+          "tableTo": "stacks",
+          "columnsFrom": [
+            "parent_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stack_parents_child_stack_id_stacks_id_fk": {
+          "name": "stack_parents_child_stack_id_stacks_id_fk",
+          "tableFrom": "stack_parents",
+          "tableTo": "stacks",
+          "columnsFrom": [
+            "child_stack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stack_parents_parent_stack_id_child_stack_id_pk": {
+          "columns": [
+            "parent_stack_id",
+            "child_stack_id"
+          ],
+          "name": "stack_parents_parent_stack_id_child_stack_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stacks": {
+      "name": "stacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stacks_name_unique": {
+          "name": "stacks_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783963047782,
       "tag": "0012_ensure_item_suggestions",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1785485613384,
+      "tag": "0013_melodic_malice",
+      "breakpoints": true
     }
   ]
 }

--- a/playwright/new-releases.spec.ts
+++ b/playwright/new-releases.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "./fixtures/parallel-test";
+
+test.beforeEach(async ({ request }) => {
+  await request.post("/api/__test__/reset");
+});
+
+test("the alert queue triages a release into the library", async ({ page, request }) => {
+  await request.post("/api/__test__/release-alerts", {
+    data: {
+      artistName: "Nera Coast",
+      title: "Glass Harbour",
+      firstReleaseDate: "2099-09-18",
+      reason: "announced",
+    },
+  });
+  await request.post("/api/__test__/release-alerts", {
+    data: {
+      artistName: "Shore Unit",
+      title: "Moon Pool",
+      firstReleaseDate: "2026-05-01",
+      reason: "new-release",
+    },
+  });
+
+  // The taskbar carries the pending count until the queue is opened.
+  await page.goto("/");
+  await expect(page.locator("#taskbar-alerts-count")).toHaveText("2");
+
+  await page.locator("#taskbar-alerts").click();
+  await expect(page).toHaveURL(/\/new-releases$/);
+
+  const cards = page.locator(".alert-card");
+  await expect(cards).toHaveCount(2);
+  await expect(page.getByText("Glass Harbour")).toBeVisible();
+  await expect(page.getByText("Announced")).toBeVisible();
+
+  // Adding files the record in the library and takes the card off the queue.
+  const announced = cards.filter({ hasText: "Glass Harbour" });
+  await announced.locator('[data-alert-action="add"]').click();
+  await expect(cards).toHaveCount(1);
+  await expect(page.locator("#alerts-status")).toContainText("Added");
+
+  // An announced record is scheduled rather than dropped into To Listen now.
+  const scheduled = await request.get("/api/music-items?hasReminder=true");
+  const body = await scheduled.json();
+  expect(body.items.some((item: { title: string }) => item.title === "Glass Harbour")).toBe(true);
+
+  // Dismissing clears the rest, and the badge goes with them.
+  await cards.first().locator('[data-alert-action="dismiss"]').click();
+  await expect(page.locator("#alerts-empty")).toBeVisible();
+
+  await page.goto("/");
+  await expect(page.locator("#taskbar-alerts")).toHaveCount(0);
+});
+
+test("muting an artist from a card clears their whole queue", async ({ page, request }) => {
+  for (const title of ["Wire Garden", "Tape Horizon"]) {
+    await request.post("/api/__test__/release-alerts", {
+      data: { artistName: "Parallel Park", title, firstReleaseDate: "2026-06-01" },
+    });
+  }
+
+  await page.goto("/new-releases");
+  await expect(page.locator(".alert-card")).toHaveCount(2);
+
+  await page.locator('[data-alert-action="mute"]').first().click();
+
+  await expect(page.locator("#alerts-empty")).toBeVisible();
+  await expect(page.locator("#alerts-status")).toContainText("Muted Parallel Park");
+});
+
+test("alert cards stay usable at mobile width", async ({ page, request }) => {
+  await request.post("/api/__test__/release-alerts", {
+    data: {
+      artistName: "Delta Static",
+      title: "Sleep Dealer",
+      firstReleaseDate: "2026-05-01",
+    },
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/new-releases");
+
+  const card = page.locator(".alert-card").first();
+  await expect(card).toBeVisible();
+
+  // Nothing overflows the viewport, and every action is a real touch target.
+  const cardBox = await card.boundingBox();
+  expect(cardBox!.width).toBeLessThanOrEqual(390);
+
+  for (const action of ["add", "dismiss", "mute"]) {
+    const button = card.locator(`[data-alert-action="${action}"]`);
+    await expect(button).toBeVisible();
+    const box = await button.boundingBox();
+    expect(box!.height).toBeGreaterThanOrEqual(28);
+  }
+});

--- a/playwright/start-menu.spec.ts
+++ b/playwright/start-menu.spec.ts
@@ -10,7 +10,8 @@ test("start menu opens, runs an action, and closes", async ({ page }) => {
   await startBtn.click();
   await expect(menu).toBeVisible();
   await expect(startBtn).toHaveAttribute("aria-expanded", "true");
-  await expect(menu.locator(".start-menu__item")).toHaveCount(5);
+  // Add, Pick One, Search, Manage stacks, New releases, RSS feed
+  await expect(menu.locator(".start-menu__item")).toHaveCount(6);
 
   // "Add a release" focuses the add input and closes the menu
   await menu.locator('[data-start-action="add"]').click();

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,6 +6,8 @@ import { releaseRoutes } from "./routes/release";
 import { appleMusicRoutes } from "./routes/apple-music";
 import { settingsRoutes } from "./routes/settings";
 import { rssRoutes } from "./routes/rss";
+import { releaseAlertRoutes } from "./routes/release-alerts";
+import { artistRoutes } from "./routes/artists";
 
 /**
  * The REST API and RSS feeds are served by Hono route modules, mounted into
@@ -25,6 +27,8 @@ apiApp.route("/api/ingest", ingestRoutes);
 apiApp.route("/api/release", releaseRoutes);
 apiApp.route("/api/apple-music", appleMusicRoutes);
 apiApp.route("/api/settings", settingsRoutes);
+apiApp.route("/api/release-alerts", releaseAlertRoutes);
+apiApp.route("/api/artists", artistRoutes);
 apiApp.route("/feed", rssRoutes);
 
 // Test-only routes, enabled when the server runs under NODE_ENV=test

--- a/server/artist-identity.ts
+++ b/server/artist-identity.ts
@@ -1,0 +1,262 @@
+import { and, desc, eq, isNotNull, isNull, or, lt } from "drizzle-orm";
+import { db } from "./db/index";
+import { artists, musicItems } from "./db/schema";
+import { lookupRelease, searchArtistCandidates, type MbArtistCandidate } from "./musicbrainz";
+
+// ---------------------------------------------------------------------------
+// Artist MBID resolution
+//
+// This is the part of the artist watch most likely to produce wrong results,
+// so it gets the most care. A bare name search for "Nirvana", "Bad Company" or
+// "Sun Ra Arkestra" returns several real artists, and picking wrong means
+// alerting on a stranger's discography forever.
+//
+// Resolution ladder, best evidence first:
+//   1. From existing items — music_items.musicbrainz_artist_id is already
+//      populated by the scan/manual-add enrichment path. No network.
+//   2. Via a known release — search for a record we know the artist made and
+//      take the artist credit off it. Far safer than a name search.
+//   3. Name search — accepted only when the top hit is both strong and clearly
+//      ahead of the runner-up.
+//
+// Anything else stays `unresolved` and is never polled: no alerts is the
+// correct failure mode, alerts for the wrong band is not.
+// ---------------------------------------------------------------------------
+
+export type MbidConfidence = "confirmed" | "probable" | "unresolved";
+
+/** MusicBrainz's Various Artists placeholder — never a real artist to track. */
+export const VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
+
+/** A name-search hit is only accepted at or above this score. */
+const MIN_ACCEPTED_SCORE = 95;
+/** …and only when it beats the runner-up by at least this much. */
+const MIN_SCORE_MARGIN = 20;
+
+/** Unresolved artists are retried at most this often. */
+export const RE_RESOLUTION_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface ArtistResolution {
+  mbid: string | null;
+  confidence: MbidConfidence;
+  /** Populated when a name search was ambiguous, for the settings picker. */
+  candidates?: MbArtistCandidate[];
+}
+
+/**
+ * Choose an artist from name-search candidates, or refuse to. A single strong
+ * hit is `probable`; a strong hit shadowed by an almost-as-strong one is
+ * exactly the ambiguity this ladder exists to avoid, so it resolves to nothing
+ * and the user is asked instead.
+ *
+ * Pure — the interesting rules are here rather than behind a fetch.
+ */
+export function pickArtistFromSearch(candidates: MbArtistCandidate[]): ArtistResolution {
+  const ranked = [...candidates]
+    .filter((candidate) => candidate.id !== VARIOUS_ARTISTS_MBID)
+    .sort((a, b) => b.score - a.score);
+
+  const top = ranked[0];
+  if (!top || top.score < MIN_ACCEPTED_SCORE) {
+    return { mbid: null, confidence: "unresolved", candidates: ranked };
+  }
+
+  const runnerUp = ranked[1];
+  if (runnerUp && top.score - runnerUp.score < MIN_SCORE_MARGIN) {
+    return { mbid: null, confidence: "unresolved", candidates: ranked };
+  }
+
+  return { mbid: top.id, confidence: "probable", candidates: ranked };
+}
+
+/**
+ * The MBID most of an artist's items agree on. Ties break towards the value
+ * seen on the most recently added item — a re-scan that corrects a bad match
+ * should win over an old one.
+ */
+export async function mbidFromItems(artistId: number): Promise<string | null> {
+  const rows = await db
+    .select({ mbid: musicItems.musicbrainzArtistId })
+    .from(musicItems)
+    .where(and(eq(musicItems.artistId, artistId), isNotNull(musicItems.musicbrainzArtistId)))
+    .orderBy(desc(musicItems.id));
+
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const mbid = row.mbid;
+    if (!mbid || mbid === VARIOUS_ARTISTS_MBID) continue;
+    counts.set(mbid, (counts.get(mbid) ?? 0) + 1);
+  }
+
+  let best: string | null = null;
+  let bestCount = 0;
+  // `rows` is newest-first and Map preserves insertion order, so a strict `>`
+  // keeps the most recent of two equally frequent values.
+  for (const [mbid, count] of counts) {
+    if (count > bestCount) {
+      best = mbid;
+      bestCount = count;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Backfill artist MBIDs from the items that already carry them. Runs with no
+ * network at all, which covers most of a library for free. Only fills artists
+ * that have no MBID yet — a value the user confirmed is never overwritten.
+ */
+export async function backfillArtistMbidsFromItems(): Promise<{ resolved: number }> {
+  const unresolved = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .where(isNull(artists.musicbrainzArtistId));
+
+  let resolved = 0;
+  const now = new Date();
+
+  for (const artist of unresolved) {
+    const mbid = await mbidFromItems(artist.id);
+    if (!mbid) continue;
+
+    await db
+      .update(artists)
+      .set({
+        musicbrainzArtistId: mbid,
+        mbidConfidence: "confirmed",
+        mbidResolvedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(artists.id, artist.id));
+    resolved += 1;
+  }
+
+  if (resolved > 0) {
+    console.log(`[artist-identity] backfilled ${resolved} artist MBID(s) from existing items`);
+  }
+
+  return { resolved };
+}
+
+/**
+ * Resolve one artist's MBID over the network, rungs 2 and 3 of the ladder.
+ * Rung 1 (existing items) is tried first and costs nothing, so a caller never
+ * has to check it separately.
+ *
+ * Never throws: a lookup failure resolves to `unresolved`, which is retried on
+ * the next sweep after the re-resolution interval.
+ */
+export async function resolveArtistMbid(artistId: number): Promise<ArtistResolution> {
+  const artist = await db
+    .select({ id: artists.id, name: artists.name })
+    .from(artists)
+    .where(eq(artists.id, artistId))
+    .get();
+  if (!artist) return { mbid: null, confidence: "unresolved" };
+
+  // 1. Existing items.
+  const fromItems = await mbidFromItems(artistId);
+  if (fromItems) {
+    await storeResolution(artistId, { mbid: fromItems, confidence: "confirmed" });
+    return { mbid: fromItems, confidence: "confirmed" };
+  }
+
+  // 2. Via a release we know they made — the search pins the artist through a
+  //    record rather than through their name alone.
+  const knownRelease = await db
+    .select({ title: musicItems.title, year: musicItems.year })
+    .from(musicItems)
+    .where(eq(musicItems.artistId, artistId))
+    .orderBy(desc(musicItems.id))
+    .get();
+
+  if (knownRelease?.title) {
+    try {
+      const fields = await lookupRelease(
+        artist.name,
+        knownRelease.title,
+        knownRelease.year ? String(knownRelease.year) : undefined,
+      );
+      const mbid = fields?.musicbrainzArtistId ?? null;
+      if (mbid && mbid !== VARIOUS_ARTISTS_MBID) {
+        await storeResolution(artistId, { mbid, confidence: "confirmed" });
+        return { mbid, confidence: "confirmed" };
+      }
+    } catch (err) {
+      console.warn(`[artist-identity] release-derived lookup failed for "${artist.name}":`, err);
+    }
+  }
+
+  // 3. Name search, accepted only when unambiguous.
+  try {
+    const candidates = await searchArtistCandidates(artist.name);
+    const picked = pickArtistFromSearch(candidates);
+    await storeResolution(artistId, picked);
+    if (picked.confidence === "unresolved") {
+      console.info("[artist-identity] name search was ambiguous", {
+        artist: artist.name,
+        candidates: candidates.slice(0, 3).map((c) => ({ name: c.name, score: c.score })),
+      });
+    }
+    return picked;
+  } catch (err) {
+    console.warn(`[artist-identity] name search failed for "${artist.name}":`, err);
+    // Stamp the attempt so a persistently failing artist doesn't get retried
+    // on every single sweep.
+    await storeResolution(artistId, { mbid: null, confidence: "unresolved" });
+    return { mbid: null, confidence: "unresolved" };
+  }
+}
+
+async function storeResolution(artistId: number, resolution: ArtistResolution): Promise<void> {
+  const now = new Date();
+  await db
+    .update(artists)
+    .set({
+      musicbrainzArtistId: resolution.mbid,
+      mbidConfidence: resolution.confidence,
+      mbidResolvedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(artists.id, artistId));
+}
+
+/** Manually confirm an MBID for an artist (the settings disambiguation list). */
+export async function setArtistMbid(artistId: number, mbid: string): Promise<boolean> {
+  const now = new Date();
+  const updated = await db
+    .update(artists)
+    .set({
+      musicbrainzArtistId: mbid,
+      mbidConfidence: "confirmed",
+      mbidResolvedAt: now,
+      // A newly confirmed identity deserves a poll straight away; the old
+      // failure count belonged to the wrong artist.
+      nextPollAt: now,
+      pollFailureCount: 0,
+      updatedAt: now,
+    })
+    .where(eq(artists.id, artistId))
+    .returning({ id: artists.id });
+
+  return updated.length > 0;
+}
+
+/**
+ * Artists eligible for a re-resolution attempt: never attempted, or attempted
+ * long enough ago that MusicBrainz may have gained the entry since.
+ */
+export async function artistsDueForResolution(now: Date = new Date()): Promise<number[]> {
+  const cutoff = new Date(now.getTime() - RE_RESOLUTION_INTERVAL_MS);
+  const rows = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .where(
+      and(
+        isNull(artists.musicbrainzArtistId),
+        or(isNull(artists.mbidResolvedAt), lt(artists.mbidResolvedAt, cutoff)),
+      ),
+    );
+  return rows.map((row) => row.id);
+}

--- a/server/artist-watch.ts
+++ b/server/artist-watch.ts
@@ -339,7 +339,14 @@ export async function pollArtist(
 
   // The first successful poll records the whole discography silently. Only
   // rows first seen after the baseline can ever alert.
-  const isBaselinePoll = artist.lastPolledAt === null && existing.length === 0;
+  //
+  // Keyed on `last_polled_at` alone, deliberately: it is stamped only after
+  // every insert below has landed, so a process that dies mid-baseline leaves
+  // it null and the next poll resumes as a baseline. Also requiring
+  // `existing.length === 0` would make that interrupted run look like an
+  // established artist, and the rest of the discography would drip out as
+  // alerts three per sweep.
+  const isBaselinePoll = artist.lastPolledAt === null;
 
   let newReleases = 0;
   let rescheduled = 0;
@@ -497,9 +504,16 @@ export function parseSecondaryTypes(raw: string | null): string[] {
 
 /**
  * Announced dates slip; delayed albums are the norm. When MusicBrainz moves a
- * date, move the reminder we derived from it — but only ours. The alert →
- * item link is what tells the two apart: reminders the user set themselves are
- * never touched.
+ * date, move the reminder we derived from it — but only ours. The alert → item
+ * link is what tells the two apart: a reminder on an item that never came from
+ * an alert is never touched.
+ *
+ * The link proves the item's *origin*, not that its date is still untouched —
+ * if the user hand-edited `remind_at` on an accepted item, a later MusicBrainz
+ * date change will overwrite that edit. Distinguishing the two would mean
+ * recording the date we set and comparing, which is more bookkeeping than a
+ * rare case is worth: the release date moving is the more likely reason the
+ * two disagree.
  *
  * When MusicBrainz drops the date entirely, clear `remind_at` rather than
  * leaving a reminder standing against a value nobody stands behind any more.
@@ -647,6 +661,14 @@ export async function pollArtistNow(artistId: number): Promise<PollOutcome | nul
     .where(eq(artists.id, artistId))
     .get();
   if (!artist) return null;
+
+  // Same guard the sweep and the candidate search carry: "check now" is still
+  // an external lookup, and an environment that switched them off means it.
+  // Below the existence check, so a bad id still 404s rather than reporting a
+  // skipped poll for an artist that doesn't exist.
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) {
+    return { status: "skipped", baseline: false, newReleases: 0, alertsRaised: 0, rescheduled: 0 };
+  }
 
   if (!artist.musicbrainzArtistId) {
     const resolution = await resolveArtistMbid(artistId);

--- a/server/artist-watch.ts
+++ b/server/artist-watch.ts
@@ -1,0 +1,667 @@
+import { and, asc, eq, inArray, isNull, isNotNull, or, lte, sql } from "drizzle-orm";
+import { db } from "./db/index";
+import { artistReleases, artists, musicItems, releaseAlerts } from "./db/schema";
+import { fetchArtistReleaseGroups, MusicBrainzHttpError, type MbReleaseGroup } from "./musicbrainz";
+import {
+  artistsDueForResolution,
+  backfillArtistMbidsFromItems,
+  resolveArtistMbid,
+  VARIOUS_ARTISTS_MBID,
+} from "./artist-identity";
+import { getArtistWatchSettings, type ArtistWatchSettings } from "./settings";
+import { normalize } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Artist release watch
+//
+// A daily sweep drains the artists whose `next_poll_at` has come round, asks
+// MusicBrainz for their release groups, and diffs that against the snapshot in
+// `artist_releases`. Groups we've never seen become `release_alerts` rows.
+//
+// The shape deliberately mirrors the suggestion prefetch (./suggestions.ts): a
+// throttled background sweep started from src/hooks.server.ts, writing pending
+// rows surfaced later with accept/dismiss. Different lifecycle, same feel.
+//
+// Two rules carry most of the weight:
+//   * The first successful poll for an artist is a silent **baseline** — every
+//     group is recorded, none alerts. Without it, adding a well-documented
+//     artist would immediately dump forty alerts.
+//   * Due-ness lives in the database, not in the timer, so a restart neither
+//     skips nor double-polls.
+// ---------------------------------------------------------------------------
+
+/** Cap per artist per sweep; the rest stay recorded and surface next sweep. */
+const MAX_ALERTS_PER_ARTIST_PER_SWEEP = 3;
+/** Cold start with a big library spreads over days instead of hammering MB. */
+const MAX_ARTISTS_PER_SWEEP = 200;
+/** Primary types that are never worth an alert. */
+const EXCLUDED_PRIMARY_TYPES = new Set(["other"]);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+const MAX_BACKOFF_MS = 7 * DAY_MS;
+
+export const SWEEP_INTERVAL_MS = DAY_MS;
+
+const sleep = (ms: number): Promise<void> =>
+  ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+
+/** MusicBrainz allows ~1 request/second; one artist is one request. */
+function sweepThrottleMs(): number {
+  for (const key of ["OTB_ARTIST_WATCH_THROTTLE_MS", "OTB_SUGGESTION_SWEEP_THROTTLE_MS"]) {
+    const fromEnv = Number(process.env[key]);
+    if (Number.isFinite(fromEnv) && fromEnv >= 0) return fromEnv;
+  }
+  return 2_500;
+}
+
+// ---------------------------------------------------------------------------
+// Dates
+//
+// MusicBrainz dates are frequently incomplete — "1974" and "1974-05" are as
+// normal as "1974-05-01" — so partial dates are first-class here rather than
+// being coerced into a full timestamp that invents precision.
+// ---------------------------------------------------------------------------
+
+/** The year of an MB partial date, or null when there isn't one. */
+export function parseReleaseYear(date: string | null): number | null {
+  if (!date || date.length < 4) return null;
+  const year = Number.parseInt(date.slice(0, 4), 10);
+  return Number.isFinite(year) ? year : null;
+}
+
+/** The earliest instant an MB partial date could refer to. */
+export function earliestInstant(date: string | null): Date | null {
+  const year = parseReleaseYear(date);
+  if (year === null || !date) return null;
+
+  const month = date.length >= 7 ? Number.parseInt(date.slice(5, 7), 10) : 1;
+  const day = date.length >= 10 ? Number.parseInt(date.slice(8, 10), 10) : 1;
+  if (!Number.isFinite(month) || !Number.isFinite(day)) return null;
+
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * The reminder date for an announced release, per the design's mapping:
+ *
+ * | `first-release-date` | `remind_at`             |
+ * |----------------------|-------------------------|
+ * | `2026-09-18`         | that date               |
+ * | `2026-09`            | 1st of that month       |
+ * | `2027` (future year) | 1st January of that year|
+ * | `2026` (current year)| none                    |
+ *
+ * A year-only date in the current year can't be scheduled meaningfully — it
+ * may already have passed — so the item goes straight into To Listen rather
+ * than being scheduled into the past. Anything already elapsed maps to null
+ * for the same reason.
+ */
+export function remindAtForReleaseDate(date: string | null, now: Date = new Date()): Date | null {
+  const instant = earliestInstant(date);
+  if (!instant) return null;
+
+  // Year-only: only meaningful when the whole year is still ahead.
+  if (date && date.length === 4 && instant.getUTCFullYear() <= now.getUTCFullYear()) {
+    return null;
+  }
+
+  return instant.getTime() > now.getTime() ? instant : null;
+}
+
+/** A release MusicBrainz says hasn't happened yet. */
+export function isAnnouncedRelease(date: string | null, now: Date = new Date()): boolean {
+  return remindAtForReleaseDate(date, now) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Alert eligibility
+// ---------------------------------------------------------------------------
+
+export type AlertReason = "announced" | "new-release" | "catalogue-addition";
+
+export interface ReleaseGroupFacts {
+  primaryType: string | null;
+  secondaryTypes: string[];
+  firstReleaseDate: string | null;
+}
+
+/** Archival editing churn nobody asked about. */
+export function passesNoiseFilters(
+  group: ReleaseGroupFacts,
+  excludedSecondaryTypes: string[],
+): boolean {
+  const primary = group.primaryType?.toLowerCase() ?? null;
+  if (primary && EXCLUDED_PRIMARY_TYPES.has(primary)) return false;
+
+  const excluded = new Set(excludedSecondaryTypes.map((type) => type.toLowerCase()));
+  return !group.secondaryTypes.some((type) => excluded.has(type.toLowerCase()));
+}
+
+/**
+ * Why a newly-seen release group should alert, or null for "record it but stay
+ * quiet". Age is a filter on *presentation*, not on detection: the group is
+ * always stored, so turning `alert_on_catalogue_additions` on later surfaces
+ * history we already captured rather than needing a re-scan.
+ */
+export function alertReasonFor(
+  group: ReleaseGroupFacts,
+  settings: ArtistWatchSettings,
+  now: Date = new Date(),
+): AlertReason | null {
+  if (!passesNoiseFilters(group, settings.excludedSecondaryTypes)) return null;
+
+  if (isAnnouncedRelease(group.firstReleaseDate, now)) return "announced";
+
+  const instant = earliestInstant(group.firstReleaseDate);
+  if (instant) {
+    const cutoff = new Date(now.getTime());
+    cutoff.setUTCMonth(cutoff.getUTCMonth() - settings.freshnessMonths);
+    if (instant.getTime() >= cutoff.getTime()) return "new-release";
+  }
+
+  return settings.alertOnCatalogueAdditions ? "catalogue-addition" : null;
+}
+
+// ---------------------------------------------------------------------------
+// Polling cadence
+// ---------------------------------------------------------------------------
+
+/**
+ * Most artists are dormant and don't deserve weekly polls. Jitter keeps an
+ * import batch from resynchronising into a thundering herd forever after.
+ */
+export function nextPollInterval(
+  mostRecentReleaseYear: number | null,
+  now: Date = new Date(),
+  jitter: number = Math.random(),
+): number {
+  const currentYear = now.getUTCFullYear();
+  const age = mostRecentReleaseYear === null ? Infinity : currentYear - mostRecentReleaseYear;
+
+  const baseDays = age <= 2 ? 7 : age <= 10 ? 21 : 60;
+  // ±20%
+  const factor = 0.8 + jitter * 0.4;
+  return Math.round(baseDays * DAY_MS * factor);
+}
+
+function backoffMs(failureCount: number): number {
+  return Math.min(2 ** failureCount * HOUR_MS, MAX_BACKOFF_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Which artists get tracked
+// ---------------------------------------------------------------------------
+
+export interface TrackedArtistRow {
+  id: number;
+  name: string;
+  musicbrainzArtistId: string | null;
+  mbidConfidence: string | null;
+  followState: string;
+  lastPolledAt: Date | null;
+  nextPollAt: Date | null;
+  pollFailureCount: number;
+}
+
+/**
+ * An artist is tracked when `follow_state` is `always`, or when it is `auto`
+ * and they have at least one listened item. `to-listen` is not evidence of
+ * wanting an artist's whole future output — a record sits in To Listen
+ * precisely because you haven't formed that opinion yet. Listening is the
+ * signal, and this predicate is the one place to widen it.
+ */
+function trackedArtistPredicate() {
+  const hasListenedItem = sql`EXISTS (
+    SELECT 1 FROM ${musicItems}
+    WHERE ${musicItems.artistId} = ${artists.id}
+      AND ${musicItems.listenStatus} = 'listened'
+  )`;
+
+  return and(
+    sql`${artists.followState} != 'muted'`,
+    or(eq(artists.followState, "always"), hasListenedItem),
+  );
+}
+
+export async function listTrackedArtists(): Promise<TrackedArtistRow[]> {
+  return db
+    .select({
+      id: artists.id,
+      name: artists.name,
+      musicbrainzArtistId: artists.musicbrainzArtistId,
+      mbidConfidence: artists.mbidConfidence,
+      followState: artists.followState,
+      lastPolledAt: artists.lastPolledAt,
+      nextPollAt: artists.nextPollAt,
+      pollFailureCount: artists.pollFailureCount,
+    })
+    .from(artists)
+    .where(trackedArtistPredicate())
+    .orderBy(asc(artists.name));
+}
+
+/** Tracked, identified artists whose `next_poll_at` has come round. */
+async function artistsDueForPoll(now: Date, limit: number): Promise<TrackedArtistRow[]> {
+  return (
+    db
+      .select({
+        id: artists.id,
+        name: artists.name,
+        musicbrainzArtistId: artists.musicbrainzArtistId,
+        mbidConfidence: artists.mbidConfidence,
+        followState: artists.followState,
+        lastPolledAt: artists.lastPolledAt,
+        nextPollAt: artists.nextPollAt,
+        pollFailureCount: artists.pollFailureCount,
+      })
+      .from(artists)
+      .where(
+        and(
+          trackedArtistPredicate(),
+          isNotNull(artists.musicbrainzArtistId),
+          sql`${artists.musicbrainzArtistId} != ${VARIOUS_ARTISTS_MBID}`,
+          inArray(artists.mbidConfidence, ["confirmed", "probable"]),
+          or(isNull(artists.nextPollAt), lte(artists.nextPollAt, now)),
+        ),
+      )
+      // Oldest first — never-polled artists (NULL) sort ahead of scheduled ones.
+      .orderBy(asc(artists.nextPollAt))
+      .limit(limit)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Polling one artist
+// ---------------------------------------------------------------------------
+
+export interface PollOutcome {
+  status: "polled" | "skipped" | "failed";
+  baseline: boolean;
+  newReleases: number;
+  alertsRaised: number;
+  rescheduled: number;
+  /** Set when the failure was MusicBrainz asking us to back off. */
+  rateLimited?: boolean;
+}
+
+/**
+ * Fetch, diff and record one artist's release groups. Never throws: a failure
+ * backs the artist off and is reported, because one bad artist must not stop
+ * the queue.
+ */
+export async function pollArtist(
+  artist: TrackedArtistRow,
+  settings: ArtistWatchSettings,
+  now: Date = new Date(),
+): Promise<PollOutcome> {
+  const mbid = artist.musicbrainzArtistId;
+  if (!mbid || mbid === VARIOUS_ARTISTS_MBID) {
+    return { status: "skipped", baseline: false, newReleases: 0, alertsRaised: 0, rescheduled: 0 };
+  }
+
+  let groups: MbReleaseGroup[];
+  try {
+    groups = await fetchArtistReleaseGroups(mbid);
+  } catch (err) {
+    const failureCount = artist.pollFailureCount + 1;
+    await db
+      .update(artists)
+      .set({
+        pollFailureCount: failureCount,
+        // `last_polled_at` is deliberately untouched so the artist keeps its
+        // baseline: a failed poll must not look like a successful empty one.
+        nextPollAt: new Date(now.getTime() + backoffMs(failureCount)),
+        updatedAt: now,
+      })
+      .where(eq(artists.id, artist.id));
+
+    const rateLimited = err instanceof MusicBrainzHttpError && err.status === 503;
+    console.error(
+      `[artist-watch] poll failed for "${artist.name}" (attempt ${failureCount}):`,
+      err,
+    );
+    return {
+      status: "failed",
+      baseline: false,
+      newReleases: 0,
+      alertsRaised: 0,
+      rescheduled: 0,
+      rateLimited,
+    };
+  }
+
+  const existing = await db
+    .select()
+    .from(artistReleases)
+    .where(eq(artistReleases.artistId, artist.id));
+  const existingByGroup = new Map(existing.map((row) => [row.mbReleaseGroupId, row]));
+
+  // The first successful poll records the whole discography silently. Only
+  // rows first seen after the baseline can ever alert.
+  const isBaselinePoll = artist.lastPolledAt === null && existing.length === 0;
+
+  let newReleases = 0;
+  let rescheduled = 0;
+
+  for (const group of groups) {
+    const stored = existingByGroup.get(group.id);
+
+    if (!stored) {
+      await db.insert(artistReleases).values({
+        artistId: artist.id,
+        mbReleaseGroupId: group.id,
+        title: group.title,
+        normalizedTitle: normalize(group.title),
+        primaryType: group.primaryType,
+        secondaryTypes: JSON.stringify(group.secondaryTypes),
+        firstReleaseDate: group.firstReleaseDate,
+        firstReleaseYear: parseReleaseYear(group.firstReleaseDate),
+        isBaseline: isBaselinePoll,
+        firstSeenAt: now,
+      });
+      newReleases += 1;
+      continue;
+    }
+
+    if (stored.firstReleaseDate !== group.firstReleaseDate) {
+      await db
+        .update(artistReleases)
+        .set({
+          title: group.title,
+          normalizedTitle: normalize(group.title),
+          primaryType: group.primaryType,
+          secondaryTypes: JSON.stringify(group.secondaryTypes),
+          firstReleaseDate: group.firstReleaseDate,
+          firstReleaseYear: parseReleaseYear(group.firstReleaseDate),
+        })
+        .where(eq(artistReleases.id, stored.id));
+
+      if (await reconcileReminderForRelease(stored.id, group.firstReleaseDate, now)) {
+        rescheduled += 1;
+      }
+    }
+  }
+
+  const alertsRaised = isBaselinePoll ? 0 : await raiseAlertsForArtist(artist.id, settings, now);
+
+  const mostRecentYear = groups.reduce<number | null>((latest, group) => {
+    const year = parseReleaseYear(group.firstReleaseDate);
+    if (year === null) return latest;
+    return latest === null || year > latest ? year : latest;
+  }, null);
+
+  await db
+    .update(artists)
+    .set({
+      lastPolledAt: now,
+      pollFailureCount: 0,
+      nextPollAt: new Date(now.getTime() + nextPollInterval(mostRecentYear, now)),
+      updatedAt: now,
+    })
+    .where(eq(artists.id, artist.id));
+
+  return {
+    status: "polled",
+    baseline: isBaselinePoll,
+    newReleases,
+    alertsRaised,
+    rescheduled,
+  };
+}
+
+/**
+ * Raise alerts for this artist's recorded-but-unalerted releases, newest
+ * first, up to the per-sweep cap. Working from the table rather than from the
+ * diff is what makes the cap a *deferral*: whatever doesn't fit this sweep is
+ * still a candidate on the next one, and flipping
+ * `alert_on_catalogue_additions` on surfaces history already captured.
+ */
+async function raiseAlertsForArtist(
+  artistId: number,
+  settings: ArtistWatchSettings,
+  now: Date,
+): Promise<number> {
+  const candidates = await db
+    .select({
+      id: artistReleases.id,
+      primaryType: artistReleases.primaryType,
+      secondaryTypes: artistReleases.secondaryTypes,
+      firstReleaseDate: artistReleases.firstReleaseDate,
+      firstSeenAt: artistReleases.firstSeenAt,
+      alertId: releaseAlerts.id,
+    })
+    .from(artistReleases)
+    .leftJoin(releaseAlerts, eq(releaseAlerts.artistReleaseId, artistReleases.id))
+    .where(and(eq(artistReleases.artistId, artistId), eq(artistReleases.isBaseline, false)));
+
+  const eligible = candidates
+    .filter((row) => row.alertId === null)
+    .map((row) => ({
+      row,
+      reason: alertReasonFor(
+        {
+          primaryType: row.primaryType,
+          secondaryTypes: parseSecondaryTypes(row.secondaryTypes),
+          firstReleaseDate: row.firstReleaseDate,
+        },
+        settings,
+        now,
+      ),
+    }))
+    .filter(
+      (entry): entry is { row: (typeof candidates)[number]; reason: AlertReason } =>
+        entry.reason !== null,
+    )
+    // Announced records first, then by release date, newest first.
+    .sort((a, b) => {
+      const rank = (reason: AlertReason): number => (reason === "announced" ? 0 : 1);
+      return (
+        rank(a.reason) - rank(b.reason) ||
+        (earliestInstant(b.row.firstReleaseDate)?.getTime() ?? 0) -
+          (earliestInstant(a.row.firstReleaseDate)?.getTime() ?? 0)
+      );
+    })
+    .slice(0, MAX_ALERTS_PER_ARTIST_PER_SWEEP);
+
+  let raised = 0;
+  for (const { row, reason } of eligible) {
+    // The unique index on artist_release_id is the real idempotency guarantee:
+    // a release alerts once, ever, however the sweep is retried or restarted.
+    const inserted = await db
+      .insert(releaseAlerts)
+      .values({
+        artistId,
+        artistReleaseId: row.id,
+        status: "pending",
+        reason,
+        createdAt: now,
+      })
+      .onConflictDoNothing({ target: releaseAlerts.artistReleaseId })
+      .returning({ id: releaseAlerts.id });
+    if (inserted.length > 0) raised += 1;
+  }
+
+  return raised;
+}
+
+export function parseSecondaryTypes(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((t): t is string => typeof t === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Announced dates slip; delayed albums are the norm. When MusicBrainz moves a
+ * date, move the reminder we derived from it — but only ours. The alert →
+ * item link is what tells the two apart: reminders the user set themselves are
+ * never touched.
+ *
+ * When MusicBrainz drops the date entirely, clear `remind_at` rather than
+ * leaving a reminder standing against a value nobody stands behind any more.
+ * The item falls out of Scheduled and into To Listen, which does mean
+ * surfacing a record that may not be out yet — that's the accepted cost, and
+ * it beats holding the item against a phantom date, which fails silently.
+ */
+async function reconcileReminderForRelease(
+  artistReleaseId: number,
+  newDate: string | null,
+  now: Date,
+): Promise<boolean> {
+  const alert = await db
+    .select({ musicItemId: releaseAlerts.musicItemId })
+    .from(releaseAlerts)
+    .where(eq(releaseAlerts.artistReleaseId, artistReleaseId))
+    .get();
+  if (!alert?.musicItemId) return false;
+
+  const item = await db
+    .select({
+      id: musicItems.id,
+      remindAt: musicItems.remindAt,
+      reminderPending: musicItems.reminderPending,
+    })
+    .from(musicItems)
+    .where(eq(musicItems.id, alert.musicItemId))
+    .get();
+
+  // Only an unfired reminder this system created is ours to move.
+  if (!item || item.remindAt === null || item.reminderPending) return false;
+
+  const remindAt = remindAtForReleaseDate(newDate, now);
+  if (remindAt !== null && item.remindAt.getTime() === remindAt.getTime()) return false;
+
+  await db.update(musicItems).set({ remindAt, updatedAt: now }).where(eq(musicItems.id, item.id));
+
+  console.info("[artist-watch] reconciled reminder after a MusicBrainz date change", {
+    itemId: item.id,
+    from: item.remindAt.toISOString(),
+    to: remindAt?.toISOString() ?? null,
+    newDate,
+  });
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// The sweep
+// ---------------------------------------------------------------------------
+
+export interface SweepSummary {
+  artistsPolled: number;
+  artistsResolved: number;
+  alertsRaised: number;
+  failures: number;
+  stoppedEarly: boolean;
+}
+
+/**
+ * Drain the due queue. Runs on startup and then daily (see hooks.server.ts) —
+ * both paths ask the database the same question, so a deployment that restarts
+ * more than once a day neither skips artists nor polls them twice.
+ */
+export async function sweepArtistReleases(now: Date = new Date()): Promise<SweepSummary> {
+  const summary: SweepSummary = {
+    artistsPolled: 0,
+    artistsResolved: 0,
+    alertsRaised: 0,
+    failures: 0,
+    stoppedEarly: false,
+  };
+
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return summary;
+
+  const settings = await getArtistWatchSettings();
+  if (!settings.enabled) return summary;
+
+  // Rung 1 of the identity ladder is free — no network — so it runs every
+  // sweep and picks up artists whose items gained an MBID since last time.
+  await backfillArtistMbidsFromItems();
+
+  const throttle = sweepThrottleMs();
+  let requests = 0;
+
+  // Tracked artists we still can't identify get a network resolution attempt,
+  // at most once every 30 days each, sharing the sweep's request budget.
+  const trackedIds = new Set((await listTrackedArtists()).map((artist) => artist.id));
+  const resolutionQueue = (await artistsDueForResolution(now)).filter((id) => trackedIds.has(id));
+
+  for (const artistId of resolutionQueue) {
+    if (requests >= MAX_ARTISTS_PER_SWEEP) break;
+    if (requests > 0) await sleep(throttle);
+    requests += 1;
+
+    try {
+      const resolution = await resolveArtistMbid(artistId);
+      if (resolution.mbid) summary.artistsResolved += 1;
+    } catch (err) {
+      console.error("[artist-watch] MBID resolution failed for artist", artistId, err);
+    }
+  }
+
+  const due = await artistsDueForPoll(now, MAX_ARTISTS_PER_SWEEP - requests);
+
+  for (const artist of due) {
+    if (requests >= MAX_ARTISTS_PER_SWEEP) break;
+    if (requests > 0) await sleep(throttle);
+    requests += 1;
+
+    const outcome = await pollArtist(artist, settings, now);
+    if (outcome.status === "polled") summary.artistsPolled += 1;
+    if (outcome.status === "failed") summary.failures += 1;
+    summary.alertsRaised += outcome.alertsRaised;
+
+    if (outcome.rateLimited) {
+      // MusicBrainz is asking us to stop. The remaining artists keep their due
+      // times and are picked up by the next run.
+      console.warn("[artist-watch] rate limited by MusicBrainz — pausing the rest of this sweep");
+      summary.stoppedEarly = true;
+      break;
+    }
+  }
+
+  if (requests > 0) {
+    console.log(`[artist-watch] sweep visited ${requests} artist(s):`, summary);
+  }
+
+  return summary;
+}
+
+/** Force one artist to the front of the queue ("check now" / debug). */
+export async function pollArtistNow(artistId: number): Promise<PollOutcome | null> {
+  const artist = await db
+    .select({
+      id: artists.id,
+      name: artists.name,
+      musicbrainzArtistId: artists.musicbrainzArtistId,
+      mbidConfidence: artists.mbidConfidence,
+      followState: artists.followState,
+      lastPolledAt: artists.lastPolledAt,
+      nextPollAt: artists.nextPollAt,
+      pollFailureCount: artists.pollFailureCount,
+    })
+    .from(artists)
+    .where(eq(artists.id, artistId))
+    .get();
+  if (!artist) return null;
+
+  if (!artist.musicbrainzArtistId) {
+    const resolution = await resolveArtistMbid(artistId);
+    if (!resolution.mbid) {
+      return {
+        status: "skipped",
+        baseline: false,
+        newReleases: 0,
+        alertsRaised: 0,
+        rescheduled: 0,
+      };
+    }
+    artist.musicbrainzArtistId = resolution.mbid;
+    artist.mbidConfidence = resolution.confidence;
+  }
+
+  return pollArtist(artist, await getArtistWatchSettings());
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -10,17 +10,38 @@ export const sources = sqliteTable("sources", {
     .$defaultFn(() => new Date()),
 });
 
-export const artists = sqliteTable("artists", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  name: text("name").notNull(),
-  normalizedName: text("normalized_name").notNull().unique(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: integer("updated_at", { mode: "timestamp" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+export const artists = sqliteTable(
+  "artists",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    name: text("name").notNull(),
+    normalizedName: text("normalized_name").notNull().unique(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    // ---- Artist watch (see server/artist-identity.ts, server/artist-watch.ts) ----
+    // The artist's MusicBrainz id, promoted from music_items so that an artist —
+    // not an item — is the unit of release tracking.
+    musicbrainzArtistId: text("musicbrainz_artist_id"),
+    // 'confirmed' | 'probable' | 'unresolved'. Only the first two are polled:
+    // no alerts is the correct failure mode, alerts for the wrong band is not.
+    mbidConfidence: text("mbid_confidence"),
+    // Last resolution attempt, hit or miss — throttles re-resolution.
+    mbidResolvedAt: integer("mbid_resolved_at", { mode: "timestamp" }),
+    // 'auto' | 'always' | 'muted'. `auto` defers to the derived rule (tracked
+    // iff the artist has a listened item).
+    followState: text("follow_state").notNull().default("auto"),
+    lastPolledAt: integer("last_polled_at", { mode: "timestamp" }),
+    // Due time — the sweep's work queue. Held in the database, not the timer,
+    // so a restart neither skips nor double-polls.
+    nextPollAt: integer("next_poll_at", { mode: "timestamp" }),
+    pollFailureCount: integer("poll_failure_count").notNull().default(0),
+  },
+  (table) => [index("idx_artists_next_poll_at").on(table.nextPollAt)],
+);
 
 export const musicItems = sqliteTable(
   "music_items",
@@ -177,4 +198,69 @@ export const itemSuggestions = sqliteTable(
       .$defaultFn(() => new Date()),
   },
   (table) => [index("idx_item_suggestions_source_item_id").on(table.sourceItemId)],
+);
+
+/**
+ * Every MusicBrainz release group we've seen for a tracked artist. The first
+ * successful poll writes the artist's whole discography with `isBaseline` set
+ * and raises no alerts; only rows first seen after that can alert.
+ */
+export const artistReleases = sqliteTable(
+  "artist_releases",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    artistId: integer("artist_id")
+      .notNull()
+      .references(() => artists.id, { onDelete: "cascade" }),
+    mbReleaseGroupId: text("mb_release_group_id").notNull(),
+    title: text("title").notNull(),
+    normalizedTitle: text("normalized_title").notNull(),
+    primaryType: text("primary_type"),
+    secondaryTypes: text("secondary_types"), // JSON array
+    // MusicBrainz's date verbatim — partial dates ("1974", "1974-05") are
+    // normal and coercing them to a full Date invents precision.
+    firstReleaseDate: text("first_release_date"),
+    firstReleaseYear: integer("first_release_year"),
+    isBaseline: integer("is_baseline", { mode: "boolean" }).notNull().default(false),
+    firstSeenAt: integer("first_seen_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    unique("artist_releases_artist_group").on(table.artistId, table.mbReleaseGroupId),
+    index("idx_artist_releases_artist_id").on(table.artistId),
+  ],
+);
+
+/**
+ * The user-facing alert queue. The unique index on `artistReleaseId` is the
+ * idempotency guarantee: a release can alert once, ever, however the sweep is
+ * retried or restarted.
+ */
+export const releaseAlerts = sqliteTable(
+  "release_alerts",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    artistId: integer("artist_id")
+      .notNull()
+      .references(() => artists.id, { onDelete: "cascade" }),
+    artistReleaseId: integer("artist_release_id")
+      .notNull()
+      .references(() => artistReleases.id, { onDelete: "cascade" }),
+    // pending | seen | added | dismissed
+    status: text("status").notNull().default("pending"),
+    // Why it fired: announced | new-release | catalogue-addition
+    reason: text("reason").notNull().default("new-release"),
+    musicItemId: integer("music_item_id").references(() => musicItems.id, {
+      onDelete: "set null",
+    }),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    resolvedAt: integer("resolved_at", { mode: "timestamp" }),
+  },
+  (table) => [
+    unique("release_alerts_release").on(table.artistReleaseId),
+    index("idx_release_alerts_status").on(table.status),
+  ],
 );

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -12,6 +12,7 @@ import {
   fetchFullItem,
   getOrCreateArtist,
   queueSuggestionPrefetch,
+  type CreateMusicItemDirectOptions,
   type CreateResult,
 } from "./music-item-store";
 import type {
@@ -35,7 +36,7 @@ export { fullItemSelect };
 // Item reads and URL-less writes live in ./music-item-store.ts, out of reach
 // of the process-wide `mock.module` on this file (see that module's header).
 export { getOrCreateArtist, fetchFullItem };
-export type { CreateResult };
+export type { CreateResult, CreateMusicItemDirectOptions };
 
 /**
  * Create a music item without a URL — no scraping, no link inserted.
@@ -47,8 +48,9 @@ export type { CreateResult };
  */
 export async function createMusicItemDirect(
   overrides: Partial<CreateMusicItemInput>,
+  options?: CreateMusicItemDirectOptions,
 ): Promise<CreateResult> {
-  return createMusicItemDirectInStore(overrides);
+  return createMusicItemDirectInStore(overrides, options);
 }
 
 /** Resolve the DB id for a source name (e.g. "bandcamp"). */

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -1,13 +1,19 @@
 import { eq } from "drizzle-orm";
 import { assign, createActor, fromPromise, setup, waitFor } from "xstate";
 import { db } from "./db/index";
-import { musicItems, artists, musicLinks, sources, musicItemStacks, stacks } from "./db/schema";
+import { musicItems, musicLinks, sources } from "./db/schema";
 import { parseUrl, isValidUrl, normalize, capitalize } from "./utils";
 import { scrapeUrl, UnsupportedMusicLinkError } from "./scraper";
 import { enrichSecondaryLinkInBackground } from "./secondary-link-enrichment";
-import { fetchSuggestionInBackground } from "./suggestions";
 import { pickPrimaryReleaseCandidate } from "./link-extractor";
 import { fullItemSelect } from "./queries/full-item-select";
+import {
+  createMusicItemDirect as createMusicItemDirectInStore,
+  fetchFullItem,
+  getOrCreateArtist,
+  queueSuggestionPrefetch,
+  type CreateResult,
+} from "./music-item-store";
 import type {
   AmbiguousLinkPayload,
   CreateMusicItemInput,
@@ -26,26 +32,23 @@ import type {
 // break SSR paths that need the real query builder.
 export { fullItemSelect };
 
-/** Look up an existing artist by normalized name, or create a new one. */
-export async function getOrCreateArtist(name: string): Promise<number> {
-  const normalizedName = normalize(name);
+// Item reads and URL-less writes live in ./music-item-store.ts, out of reach
+// of the process-wide `mock.module` on this file (see that module's header).
+export { getOrCreateArtist, fetchFullItem };
+export type { CreateResult };
 
-  const existing = await db
-    .select({ id: artists.id })
-    .from(artists)
-    .where(eq(artists.normalizedName, normalizedName))
-    .limit(1);
-
-  if (existing[0]) {
-    return existing[0].id;
-  }
-
-  const [created] = await db
-    .insert(artists)
-    .values({ name: capitalize(name), normalizedName })
-    .returning({ id: artists.id });
-
-  return created.id;
+/**
+ * Create a music item without a URL — no scraping, no link inserted.
+ *
+ * A wrapper, deliberately: a bare `export { createMusicItemDirect }` would be
+ * a re-export, and bun's `mock.module` on *this* module follows re-export
+ * chains all the way back to the defining module — which would hand the stub
+ * to callers that import from `./music-item-store` precisely to avoid it.
+ */
+export async function createMusicItemDirect(
+  overrides: Partial<CreateMusicItemInput>,
+): Promise<CreateResult> {
+  return createMusicItemDirectInStore(overrides);
 }
 
 /** Resolve the DB id for a source name (e.g. "bandcamp"). */
@@ -66,60 +69,9 @@ export type { ItemWithStacks } from "./hydrate-item-stacks";
 // that import the helper from `./hydrate-item-stacks` directly. New code
 // should import it from `./hydrate-item-stacks`.
 
-/** Fetch a single full item by its id, including stacks and all links. */
-export async function fetchFullItem(id: number): Promise<MusicItemFull | null> {
-  const rows = await fullItemSelect().where(eq(musicItems.id, id));
-  if (!rows[0]) return null;
-
-  const [stackRows, linkRows] = await Promise.all([
-    db
-      .select({ musicItemId: musicItemStacks.musicItemId, id: stacks.id, name: stacks.name })
-      .from(musicItemStacks)
-      .innerJoin(stacks, eq(stacks.id, musicItemStacks.stackId))
-      .where(eq(musicItemStacks.musicItemId, id)),
-    db
-      .select({
-        id: musicLinks.id,
-        url: musicLinks.url,
-        source_name: sources.name,
-        display_name: sources.displayName,
-        is_primary: musicLinks.isPrimary,
-      })
-      .from(musicLinks)
-      .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
-      .where(eq(musicLinks.musicItemId, id)),
-  ]);
-
-  const item = {
-    ...(rows[0] as unknown as MusicItemFull),
-    stacks: [] as Array<{ id: number; name: string }>,
-    links: [] as Array<{
-      id: number;
-      url: string;
-      source_name: string | null;
-      display_name: string | null;
-      is_primary: boolean;
-    }>,
-  };
-  item.stacks = stackRows.map((r) => ({ id: r.id, name: r.name }));
-  item.links = linkRows.map((r) => ({
-    id: r.id,
-    url: r.url,
-    source_name: r.source_name,
-    display_name: r.display_name,
-    is_primary: r.is_primary,
-  }));
-  return item;
-}
-
 // ---------------------------------------------------------------------------
 // Shared creation logic
 // ---------------------------------------------------------------------------
-
-export interface CreateResult {
-  item: MusicItemFull;
-  created: boolean;
-}
 
 interface ReleaseCandidateInput {
   candidateId?: string;
@@ -244,23 +196,6 @@ async function insertMusicItemWithLink(
   queueSuggestionPrefetch(item);
 
   return item;
-}
-
-/**
- * Prefetch another release by the same artist so the "you might also like"
- * prompt has one ready when this item is later marked listened. Lives here —
- * not in the routes — so every creation path (web form, share extension,
- * email/photo ingest, accepted suggestions) triggers it. Non-blocking.
- */
-function queueSuggestionPrefetch(item: MusicItemFull): void {
-  if (item.listen_status !== "to-listen" || !item.artist_name) return;
-
-  fetchSuggestionInBackground({
-    id: item.id,
-    artist_name: item.artist_name,
-    year: item.year,
-    musicbrainz_artist_id: item.musicbrainz_artist_id,
-  });
 }
 
 function resolveSelectedCandidate(
@@ -597,53 +532,4 @@ export async function createMusicItemsFromUrl(
   }
 
   return snapshot.context.results;
-}
-
-/**
- * Create a music item without a URL — no scraping, no link inserted.
- * Used for physical records or items known only from memory.
- */
-export async function createMusicItemDirect(
-  overrides: Partial<CreateMusicItemInput>,
-): Promise<CreateResult> {
-  const title = overrides.title || "Untitled";
-  const artistName = overrides.artistName;
-
-  let artistId: number | null = null;
-  if (artistName) {
-    artistId = await getOrCreateArtist(artistName);
-  }
-
-  const [inserted] = await db
-    .insert(musicItems)
-    .values({
-      title: capitalize(title),
-      normalizedTitle: normalize(title),
-      itemType: overrides.itemType ?? "album",
-      artistId,
-      listenStatus: overrides.listenStatus ?? "to-listen",
-      purchaseIntent: overrides.purchaseIntent ?? "no",
-      notes: overrides.notes ?? null,
-      artworkUrl: overrides.artworkUrl ?? null,
-      label: overrides.label ?? null,
-      year: overrides.year ?? null,
-      country: overrides.country ?? null,
-      genre: overrides.genre ?? null,
-      catalogueNumber: overrides.catalogueNumber ?? null,
-      musicbrainzReleaseId: overrides.musicbrainzReleaseId ?? null,
-      musicbrainzArtistId: overrides.musicbrainzArtistId ?? null,
-    })
-    .returning({ id: musicItems.id });
-
-  const item = await fetchFullItem(inserted.id);
-  if (!item) {
-    throw new Error("Failed to fetch created item");
-  }
-
-  // Direct items (physical / from-memory) have no primary link, so they're
-  // always eligible for a secondary-link lookup. Non-blocking.
-  enrichSecondaryLinkInBackground(inserted.id);
-  queueSuggestionPrefetch(item);
-
-  return { item, created: true };
 }

--- a/server/music-item-store.ts
+++ b/server/music-item-store.ts
@@ -1,0 +1,160 @@
+import { eq } from "drizzle-orm";
+import { db } from "./db/index";
+import { musicItems, artists, musicLinks, sources, musicItemStacks, stacks } from "./db/schema";
+import { normalize, capitalize } from "./utils";
+import { enrichSecondaryLinkInBackground } from "./secondary-link-enrichment";
+import { fetchSuggestionInBackground } from "./suggestions";
+import { fullItemSelect } from "./queries/full-item-select";
+import type { CreateMusicItemInput, MusicItemFull } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Item reads and URL-less writes.
+//
+// Split out of ./music-item-creator.ts for the same reason
+// ./queries/full-item-select.ts was: `ingest.test.ts` calls
+// `mock.module(".../music-item-creator")`, and bun's module mocks are
+// process-wide, so anything importing the creator after that point gets stubs.
+// Callers that need the real implementations — the release-alert accept path,
+// for one — import them from here instead. The creator re-exports them so
+// existing importers are unaffected.
+// ---------------------------------------------------------------------------
+
+/** Look up an existing artist by normalized name, or create a new one. */
+export async function getOrCreateArtist(name: string): Promise<number> {
+  const normalizedName = normalize(name);
+
+  const existing = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .where(eq(artists.normalizedName, normalizedName))
+    .limit(1);
+
+  if (existing[0]) {
+    return existing[0].id;
+  }
+
+  const [created] = await db
+    .insert(artists)
+    .values({ name: capitalize(name), normalizedName })
+    .returning({ id: artists.id });
+
+  return created.id;
+}
+
+/** Fetch a single full item by its id, including stacks and all links. */
+export async function fetchFullItem(id: number): Promise<MusicItemFull | null> {
+  const rows = await fullItemSelect().where(eq(musicItems.id, id));
+  if (!rows[0]) return null;
+
+  const [stackRows, linkRows] = await Promise.all([
+    db
+      .select({ musicItemId: musicItemStacks.musicItemId, id: stacks.id, name: stacks.name })
+      .from(musicItemStacks)
+      .innerJoin(stacks, eq(stacks.id, musicItemStacks.stackId))
+      .where(eq(musicItemStacks.musicItemId, id)),
+    db
+      .select({
+        id: musicLinks.id,
+        url: musicLinks.url,
+        source_name: sources.name,
+        display_name: sources.displayName,
+        is_primary: musicLinks.isPrimary,
+      })
+      .from(musicLinks)
+      .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
+      .where(eq(musicLinks.musicItemId, id)),
+  ]);
+
+  const item = {
+    ...(rows[0] as unknown as MusicItemFull),
+    stacks: [] as Array<{ id: number; name: string }>,
+    links: [] as Array<{
+      id: number;
+      url: string;
+      source_name: string | null;
+      display_name: string | null;
+      is_primary: boolean;
+    }>,
+  };
+  item.stacks = stackRows.map((r) => ({ id: r.id, name: r.name }));
+  item.links = linkRows.map((r) => ({
+    id: r.id,
+    url: r.url,
+    source_name: r.source_name,
+    display_name: r.display_name,
+    is_primary: r.is_primary,
+  }));
+  return item;
+}
+
+/**
+ * Prefetch another release by the same artist so the "you might also like"
+ * prompt has one ready when this item is later marked listened. Lives at this
+ * level — not in the routes — so every creation path (web form, share
+ * extension, email/photo ingest, accepted suggestions, accepted release
+ * alerts) triggers it. Non-blocking.
+ */
+export function queueSuggestionPrefetch(item: MusicItemFull): void {
+  if (item.listen_status !== "to-listen" || !item.artist_name) return;
+
+  fetchSuggestionInBackground({
+    id: item.id,
+    artist_name: item.artist_name,
+    year: item.year,
+    musicbrainz_artist_id: item.musicbrainz_artist_id,
+  });
+}
+
+export interface CreateResult {
+  item: MusicItemFull;
+  created: boolean;
+}
+
+/**
+ * Create a music item without a URL — no scraping, no link inserted.
+ * Used for physical records or items known only from memory.
+ */
+export async function createMusicItemDirect(
+  overrides: Partial<CreateMusicItemInput>,
+): Promise<CreateResult> {
+  const title = overrides.title || "Untitled";
+  const artistName = overrides.artistName;
+
+  let artistId: number | null = null;
+  if (artistName) {
+    artistId = await getOrCreateArtist(artistName);
+  }
+
+  const [inserted] = await db
+    .insert(musicItems)
+    .values({
+      title: capitalize(title),
+      normalizedTitle: normalize(title),
+      itemType: overrides.itemType ?? "album",
+      artistId,
+      listenStatus: overrides.listenStatus ?? "to-listen",
+      purchaseIntent: overrides.purchaseIntent ?? "no",
+      notes: overrides.notes ?? null,
+      artworkUrl: overrides.artworkUrl ?? null,
+      label: overrides.label ?? null,
+      year: overrides.year ?? null,
+      country: overrides.country ?? null,
+      genre: overrides.genre ?? null,
+      catalogueNumber: overrides.catalogueNumber ?? null,
+      musicbrainzReleaseId: overrides.musicbrainzReleaseId ?? null,
+      musicbrainzArtistId: overrides.musicbrainzArtistId ?? null,
+    })
+    .returning({ id: musicItems.id });
+
+  const item = await fetchFullItem(inserted.id);
+  if (!item) {
+    throw new Error("Failed to fetch created item");
+  }
+
+  // Direct items (physical / from-memory) have no primary link, so they're
+  // always eligible for a secondary-link lookup. Non-blocking.
+  enrichSecondaryLinkInBackground(inserted.id);
+  queueSuggestionPrefetch(item);
+
+  return { item, created: true };
+}

--- a/server/music-item-store.ts
+++ b/server/music-item-store.ts
@@ -114,8 +114,20 @@ export interface CreateResult {
  * Create a music item without a URL — no scraping, no link inserted.
  * Used for physical records or items known only from memory.
  */
+export interface CreateMusicItemDirectOptions {
+  /**
+   * Skip the secondary-link lookup. For a record that isn't released yet there
+   * is nothing on the streaming services to find, and the lookup stamps
+   * `apple_music_lookup_at` on a miss just as it does on a hit — so a single
+   * futile attempt now would keep the item out of the backfill for good, and
+   * it would never pick up a link once the record actually came out.
+   */
+  skipLinkEnrichment?: boolean;
+}
+
 export async function createMusicItemDirect(
   overrides: Partial<CreateMusicItemInput>,
+  options: CreateMusicItemDirectOptions = {},
 ): Promise<CreateResult> {
   const title = overrides.title || "Untitled";
   const artistName = overrides.artistName;
@@ -153,7 +165,11 @@ export async function createMusicItemDirect(
 
   // Direct items (physical / from-memory) have no primary link, so they're
   // always eligible for a secondary-link lookup. Non-blocking.
-  enrichSecondaryLinkInBackground(inserted.id);
+  if (!options.skipLinkEnrichment) {
+    enrichSecondaryLinkInBackground(inserted.id);
+  }
+  // The suggestion prefetch runs either way: it's keyed to the artist, not to
+  // this release, so it's just as useful for a record that isn't out yet.
   queueSuggestionPrefetch(item);
 
   return { item, created: true };

--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -6,6 +6,53 @@ const MB_API_BASE = "https://musicbrainz.org/ws/2";
 // placeholder/generic UAs get throttled or blocked (403/503).
 const USER_AGENT = "on-the-beach/1.0 (https://github.com/richpjames/on-the-beach)";
 
+/** A non-2xx response from MusicBrainz, carrying the status for backoff decisions. */
+export class MusicBrainzHttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "MusicBrainzHttpError";
+    this.status = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared request gate
+//
+// MusicBrainz allows roughly one request per second per client. Two background
+// sweeps now compete for that budget (the suggestion prefetch and the artist
+// release watcher), and each sweep's own throttle only paces itself — run
+// concurrently they quietly double the rate and earn a 503. Every outbound MB
+// request passes through this single serialising gate so the process as a
+// whole stays inside the limit, whichever caller is asking.
+// ---------------------------------------------------------------------------
+
+function minRequestGapMs(): number {
+  const fromEnv = Number(process.env.OTB_MB_MIN_REQUEST_GAP_MS);
+  return Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 1_100;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+
+let gateTail: Promise<void> = Promise.resolve();
+
+function mbFetch(url: string): Promise<Response> {
+  const gap = minRequestGapMs();
+  const turn = gateTail.then(() =>
+    fetch(url, { headers: { "User-Agent": USER_AGENT, Accept: "application/json" } }),
+  );
+  // The next caller waits for this request to finish plus the minimum gap.
+  // Failures must not wedge the queue, so the tail swallows them — the
+  // rejection is still delivered to the caller through `turn`.
+  gateTail = turn.then(
+    () => sleep(gap),
+    () => sleep(gap),
+  );
+  return turn;
+}
+
 export interface MusicBrainzFields {
   year: number | null;
   label: string | null;
@@ -124,11 +171,12 @@ interface MbArtistSearchResponse {
 async function fetchArtistMbid(artistName: string): Promise<string | null> {
   const params = new URLSearchParams({ query: artistName, limit: "1", fmt: "json" });
   const url = `${MB_API_BASE}/artist?${params}`;
-  const response = await fetch(url, {
-    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-  });
+  const response = await mbFetch(url);
   if (!response.ok) {
-    throw new Error(`MusicBrainz artist search returned ${response.status} for "${artistName}"`);
+    throw new MusicBrainzHttpError(
+      response.status,
+      `MusicBrainz artist search returned ${response.status} for "${artistName}"`,
+    );
   }
   const data = (await response.json()) as MbArtistSearchResponse;
   const first = data.artists?.[0];
@@ -140,11 +188,12 @@ async function fetchArtistReleases(mbid: string): Promise<MbArtistRelease[]> {
   // release-length preference needs them to rank candidates.
   const params = new URLSearchParams({ inc: "releases+media", fmt: "json" });
   const url = `${MB_API_BASE}/artist/${mbid}?${params}`;
-  const response = await fetch(url, {
-    headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-  });
+  const response = await mbFetch(url);
   if (!response.ok) {
-    throw new Error(`MusicBrainz artist lookup returned ${response.status} for ${mbid}`);
+    throw new MusicBrainzHttpError(
+      response.status,
+      `MusicBrainz artist lookup returned ${response.status} for ${mbid}`,
+    );
   }
   const data = (await response.json()) as MbArtistReleasesResponse;
   return Array.isArray(data.releases) ? (data.releases as MbArtistRelease[]) : [];
@@ -235,6 +284,160 @@ export async function findSuggestedRelease(opts: {
   return picked;
 }
 
+// ---------------------------------------------------------------------------
+// Release groups (artist watch)
+//
+// The suggestion path above browses *releases* because it needs `media` track
+// counts to size a record. The watcher needs the opposite grain: release
+// **groups** are the album-level entity, one per work, so a 2026 Japanese
+// repress of a 1974 album doesn't read as a new record. The two paths coexist.
+// ---------------------------------------------------------------------------
+
+export interface MbReleaseGroup {
+  id: string;
+  title: string;
+  primaryType: string | null;
+  secondaryTypes: string[];
+  /** MB's date verbatim: "1974", "1974-05" and "1974-05-01" are all possible. */
+  firstReleaseDate: string | null;
+}
+
+interface MbReleaseGroupResponse {
+  "release-groups"?: unknown[];
+  "release-group-count"?: unknown;
+}
+
+const RELEASE_GROUP_PAGE_SIZE = 100;
+// Even Sun Ra tops out well short of 1,000 release groups; the cap stops a
+// malformed count from looping the sweep forever.
+const RELEASE_GROUP_MAX_PAGES = 10;
+
+function parseReleaseGroup(raw: unknown): MbReleaseGroup | null {
+  if (!raw || typeof raw !== "object") return null;
+  const group = raw as Record<string, unknown>;
+  if (typeof group.id !== "string" || typeof group.title !== "string") return null;
+
+  const secondary = Array.isArray(group["secondary-types"])
+    ? group["secondary-types"].filter((t): t is string => typeof t === "string")
+    : [];
+
+  return {
+    id: group.id,
+    title: group.title,
+    primaryType: typeof group["primary-type"] === "string" ? group["primary-type"] : null,
+    secondaryTypes: secondary,
+    firstReleaseDate:
+      typeof group["first-release-date"] === "string" && group["first-release-date"].length > 0
+        ? group["first-release-date"]
+        : null,
+  };
+}
+
+/**
+ * Every release group credited to an artist. Paginates only when a page comes
+ * back full — one request covers all but the most prolific artists.
+ *
+ * Throws `MusicBrainzHttpError` on a non-2xx response and the underlying error
+ * on a network failure: the caller has to tell "no releases" apart from "the
+ * lookup failed", because writing a baseline from a partial fetch would make
+ * every missing group alert as new on the next successful poll.
+ */
+export async function fetchArtistReleaseGroups(mbid: string): Promise<MbReleaseGroup[]> {
+  const groups: MbReleaseGroup[] = [];
+
+  for (let page = 0; page < RELEASE_GROUP_MAX_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      artist: mbid,
+      limit: String(RELEASE_GROUP_PAGE_SIZE),
+      offset: String(page * RELEASE_GROUP_PAGE_SIZE),
+      fmt: "json",
+    });
+    const response = await mbFetch(`${MB_API_BASE}/release-group?${params}`);
+    if (!response.ok) {
+      throw new MusicBrainzHttpError(
+        response.status,
+        `MusicBrainz release-group browse returned ${response.status} for ${mbid}`,
+      );
+    }
+
+    const data = (await response.json()) as MbReleaseGroupResponse;
+    const raw = Array.isArray(data["release-groups"]) ? data["release-groups"] : [];
+    for (const entry of raw) {
+      const parsed = parseReleaseGroup(entry);
+      if (parsed) groups.push(parsed);
+    }
+
+    if (raw.length < RELEASE_GROUP_PAGE_SIZE) break;
+  }
+
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Artist search (MBID resolution, last resort)
+// ---------------------------------------------------------------------------
+
+export interface MbArtistCandidate {
+  id: string;
+  name: string;
+  score: number;
+  /** MB's disambiguation comment — the thing that tells two Nirvanas apart. */
+  disambiguation: string | null;
+  country: string | null;
+  type: string | null;
+  lifeSpanBegin: string | null;
+  lifeSpanEnd: string | null;
+}
+
+interface MbArtistCandidateResponse {
+  artists?: unknown[];
+}
+
+/**
+ * Name-search an artist, returning the ranked candidates with the fields a
+ * human needs to disambiguate them. Scoring is left to the caller — see
+ * `pickArtistFromSearch` in server/artist-identity.ts.
+ */
+export async function searchArtistCandidates(
+  artistName: string,
+  limit = 5,
+): Promise<MbArtistCandidate[]> {
+  const params = new URLSearchParams({ query: artistName, limit: String(limit), fmt: "json" });
+  const response = await mbFetch(`${MB_API_BASE}/artist?${params}`);
+  if (!response.ok) {
+    throw new MusicBrainzHttpError(
+      response.status,
+      `MusicBrainz artist search returned ${response.status} for "${artistName}"`,
+    );
+  }
+
+  const data = (await response.json()) as MbArtistCandidateResponse;
+  const raw = Array.isArray(data.artists) ? data.artists : [];
+
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const artist = entry as Record<string, unknown>;
+    if (typeof artist.id !== "string" || typeof artist.name !== "string") return [];
+    const lifeSpan = (artist["life-span"] ?? {}) as Record<string, unknown>;
+
+    return [
+      {
+        id: artist.id,
+        name: artist.name,
+        score: typeof artist.score === "number" ? artist.score : 0,
+        disambiguation:
+          typeof artist.disambiguation === "string" && artist.disambiguation.length > 0
+            ? artist.disambiguation
+            : null,
+        country: typeof artist.country === "string" ? artist.country : null,
+        type: typeof artist.type === "string" ? artist.type : null,
+        lifeSpanBegin: typeof lifeSpan.begin === "string" ? lifeSpan.begin : null,
+        lifeSpanEnd: typeof lifeSpan.end === "string" ? lifeSpan.end : null,
+      },
+    ];
+  });
+}
+
 export async function lookupRelease(
   artist: string,
   title: string,
@@ -257,12 +460,7 @@ export async function lookupRelease(
   try {
     console.info("[musicbrainz] Searching releases", searchLog);
 
-    const response = await fetch(url, {
-      headers: {
-        "User-Agent": USER_AGENT,
-        Accept: "application/json",
-      },
-    });
+    const response = await mbFetch(url);
 
     if (!response.ok) {
       console.warn(`[musicbrainz] Search returned ${response.status}`, searchLog);

--- a/server/release-alerts.ts
+++ b/server/release-alerts.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, count, desc, eq, inArray, ne } from "drizzle-orm";
 import { db } from "./db/index";
 import {
   artistReleases,
@@ -101,11 +101,14 @@ export async function listReleaseAlerts(
 }
 
 export async function countPendingAlerts(): Promise<number> {
-  const rows = await db
-    .select({ id: releaseAlerts.id })
+  // Aggregate rather than counting rows in JS: this runs on every taskbar
+  // navigation and every alert-list request.
+  const row = await db
+    .select({ value: count() })
     .from(releaseAlerts)
-    .where(eq(releaseAlerts.status, "pending"));
-  return rows.length;
+    .where(eq(releaseAlerts.status, "pending"))
+    .get();
+  return row?.value ?? 0;
 }
 
 /** Bulk `pending` → `seen`, so the taskbar badge clears without forcing a decision. */
@@ -231,35 +234,67 @@ export async function acceptAlert(
 
   if (!alert || alert.status === "added") return null;
 
-  const settings = await getArtistWatchSettings();
-  const remindAt = settings.scheduleAnnouncedReleases
-    ? remindAtForReleaseDate(alert.firstReleaseDate, now)
-    : null;
-
-  const { item } = await createMusicItemDirect({
-    title: alert.title,
-    artistName: alert.artistName,
-    itemType: itemTypeForReleaseGroup(alert.primaryType),
-    listenStatus: "to-listen",
-    year: alert.firstReleaseYear ?? undefined,
-  });
-
-  if (remindAt) {
-    await db
-      .update(musicItems)
-      .set({ remindAt, reminderPending: false, updatedAt: now })
-      .where(eq(musicItems.id, item.id));
-  }
-
-  // Items land in the stack *in addition* to normal status handling, so it
-  // accumulates as a running record of what the watcher has fed the library.
-  const stackId = await ensureNewReleasesStack();
-  await db.insert(musicItemStacks).values({ musicItemId: item.id, stackId }).onConflictDoNothing();
-
-  await db
+  // Claim the alert before creating anything. Reading the status and acting on
+  // it are two steps, so without a claim two concurrent accepts of the same
+  // alert both pass the check above and both create an item. Flipping the
+  // status under a `status != 'added'` predicate makes exactly one of them win;
+  // the loser sees zero rows and bails.
+  const claimed = await db
     .update(releaseAlerts)
-    .set({ status: "added", musicItemId: item.id, resolvedAt: now })
-    .where(eq(releaseAlerts.id, alertId));
+    .set({ status: "added", resolvedAt: now })
+    .where(and(eq(releaseAlerts.id, alertId), ne(releaseAlerts.status, "added")))
+    .returning({ id: releaseAlerts.id });
+  if (claimed.length === 0) return null;
 
-  return { itemId: item.id, remindAt };
+  try {
+    const settings = await getArtistWatchSettings();
+    const remindAt = settings.scheduleAnnouncedReleases
+      ? remindAtForReleaseDate(alert.firstReleaseDate, now)
+      : null;
+
+    const { item } = await createMusicItemDirect(
+      {
+        title: alert.title,
+        artistName: alert.artistName,
+        itemType: itemTypeForReleaseGroup(alert.primaryType),
+        listenStatus: "to-listen",
+        year: alert.firstReleaseYear ?? undefined,
+      },
+      // A record that isn't out yet has nothing to find on the streaming
+      // services, and the lookup stamps an attempt marker that would stop the
+      // item being re-queried once it actually is released.
+      { skipLinkEnrichment: remindAt !== null },
+    );
+
+    if (remindAt) {
+      await db
+        .update(musicItems)
+        .set({ remindAt, reminderPending: false, updatedAt: now })
+        .where(eq(musicItems.id, item.id));
+    }
+
+    // Items land in the stack *in addition* to normal status handling, so it
+    // accumulates as a running record of what the watcher has fed the library.
+    const stackId = await ensureNewReleasesStack();
+    await db
+      .insert(musicItemStacks)
+      .values({ musicItemId: item.id, stackId })
+      .onConflictDoNothing();
+
+    await db
+      .update(releaseAlerts)
+      .set({ musicItemId: item.id })
+      .where(eq(releaseAlerts.id, alertId));
+
+    return { itemId: item.id, remindAt };
+  } catch (err) {
+    // The claim is only good if the work behind it succeeded — otherwise the
+    // alert would sit as `added` with no item to show for it, unreachable from
+    // the queue and impossible to retry.
+    await db
+      .update(releaseAlerts)
+      .set({ status: alert.status, resolvedAt: null })
+      .where(eq(releaseAlerts.id, alertId));
+    throw err;
+  }
 }

--- a/server/release-alerts.ts
+++ b/server/release-alerts.ts
@@ -1,0 +1,265 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { db } from "./db/index";
+import {
+  artistReleases,
+  artists,
+  musicItemStacks,
+  musicItems,
+  releaseAlerts,
+  stacks,
+} from "./db/schema";
+// Deliberately not via ./music-item-creator: `ingest.test.ts` mocks that
+// module process-wide (see ./music-item-store.ts).
+import { createMusicItemDirect } from "./music-item-store";
+import { remindAtForReleaseDate, parseSecondaryTypes, type AlertReason } from "./artist-watch";
+import { getArtistWatchSettings, getNewReleasesStackId, setNewReleasesStackId } from "./settings";
+import type { ItemType } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// The alert queue: reading it, and the three things you can do with a card.
+//
+// Alerts aren't music items until accepted, which is why the queue is its own
+// table rather than a stack. Accepting one files a real item into the New
+// Releases stack; if the record isn't out yet it's scheduled to arrive in To
+// Listen on release day, by handing `remind_at` to the reminder cron that
+// already runs.
+// ---------------------------------------------------------------------------
+
+export const NEW_RELEASES_STACK_NAME = "New Releases";
+
+export type AlertStatus = "pending" | "seen" | "added" | "dismissed";
+
+export interface ReleaseAlertView {
+  id: number;
+  status: AlertStatus;
+  reason: AlertReason;
+  created_at: string;
+  resolved_at: string | null;
+  music_item_id: number | null;
+  artist_id: number;
+  artist_name: string;
+  musicbrainz_artist_id: string | null;
+  release_id: number;
+  mb_release_group_id: string;
+  title: string;
+  primary_type: string | null;
+  secondary_types: string[];
+  first_release_date: string | null;
+  first_release_year: number | null;
+}
+
+function toIso(value: Date | null): string | null {
+  return value instanceof Date ? value.toISOString() : null;
+}
+
+export async function listReleaseAlerts(
+  statuses: AlertStatus[] = ["pending"],
+): Promise<ReleaseAlertView[]> {
+  const rows = await db
+    .select({
+      id: releaseAlerts.id,
+      status: releaseAlerts.status,
+      reason: releaseAlerts.reason,
+      createdAt: releaseAlerts.createdAt,
+      resolvedAt: releaseAlerts.resolvedAt,
+      musicItemId: releaseAlerts.musicItemId,
+      artistId: artists.id,
+      artistName: artists.name,
+      musicbrainzArtistId: artists.musicbrainzArtistId,
+      releaseId: artistReleases.id,
+      mbReleaseGroupId: artistReleases.mbReleaseGroupId,
+      title: artistReleases.title,
+      primaryType: artistReleases.primaryType,
+      secondaryTypes: artistReleases.secondaryTypes,
+      firstReleaseDate: artistReleases.firstReleaseDate,
+      firstReleaseYear: artistReleases.firstReleaseYear,
+    })
+    .from(releaseAlerts)
+    .innerJoin(artistReleases, eq(artistReleases.id, releaseAlerts.artistReleaseId))
+    .innerJoin(artists, eq(artists.id, releaseAlerts.artistId))
+    .where(inArray(releaseAlerts.status, statuses))
+    .orderBy(desc(releaseAlerts.createdAt), desc(releaseAlerts.id));
+
+  return rows.map((row) => ({
+    id: row.id,
+    status: row.status as AlertStatus,
+    reason: row.reason as AlertReason,
+    created_at: toIso(row.createdAt) ?? new Date(0).toISOString(),
+    resolved_at: toIso(row.resolvedAt),
+    music_item_id: row.musicItemId,
+    artist_id: row.artistId,
+    artist_name: row.artistName,
+    musicbrainz_artist_id: row.musicbrainzArtistId,
+    release_id: row.releaseId,
+    mb_release_group_id: row.mbReleaseGroupId,
+    title: row.title,
+    primary_type: row.primaryType,
+    secondary_types: parseSecondaryTypes(row.secondaryTypes),
+    first_release_date: row.firstReleaseDate,
+    first_release_year: row.firstReleaseYear,
+  }));
+}
+
+export async function countPendingAlerts(): Promise<number> {
+  const rows = await db
+    .select({ id: releaseAlerts.id })
+    .from(releaseAlerts)
+    .where(eq(releaseAlerts.status, "pending"));
+  return rows.length;
+}
+
+/** Bulk `pending` → `seen`, so the taskbar badge clears without forcing a decision. */
+export async function markAlertsSeen(): Promise<number> {
+  const updated = await db
+    .update(releaseAlerts)
+    .set({ status: "seen" })
+    .where(eq(releaseAlerts.status, "pending"))
+    .returning({ id: releaseAlerts.id });
+  return updated.length;
+}
+
+export async function dismissAlert(alertId: number): Promise<boolean> {
+  const updated = await db
+    .update(releaseAlerts)
+    .set({ status: "dismissed", resolvedAt: new Date() })
+    .where(eq(releaseAlerts.id, alertId))
+    .returning({ id: releaseAlerts.id });
+  return updated.length > 0;
+}
+
+/**
+ * Mute an artist and clear the alerts already queued for them. Compilation
+ * credits and one-off features generate alerts nobody wants, and the only
+ * person who can tell is the user.
+ */
+export async function muteArtist(artistId: number): Promise<boolean> {
+  const now = new Date();
+  const updated = await db
+    .update(artists)
+    .set({ followState: "muted", nextPollAt: null, updatedAt: now })
+    .where(eq(artists.id, artistId))
+    .returning({ id: artists.id });
+  if (updated.length === 0) return false;
+
+  await db
+    .update(releaseAlerts)
+    .set({ status: "dismissed", resolvedAt: now })
+    .where(
+      and(eq(releaseAlerts.artistId, artistId), inArray(releaseAlerts.status, ["pending", "seen"])),
+    );
+
+  return true;
+}
+
+/**
+ * The stack accepted alerts are filed into, created on first accept and
+ * referenced by id in settings. `stacks.name` is unique and user-editable, so
+ * name-matching would silently create a duplicate the moment the user renames
+ * it — the id is recreated only when it no longer resolves.
+ */
+export async function ensureNewReleasesStack(): Promise<number> {
+  const storedId = await getNewReleasesStackId();
+  if (storedId !== null) {
+    const existing = await db
+      .select({ id: stacks.id })
+      .from(stacks)
+      .where(eq(stacks.id, storedId))
+      .get();
+    if (existing) return existing.id;
+  }
+
+  // A stack of that name may already exist from a previous install whose
+  // setting was lost — adopt it rather than colliding with the unique index.
+  const byName = await db
+    .select({ id: stacks.id })
+    .from(stacks)
+    .where(eq(stacks.name, NEW_RELEASES_STACK_NAME))
+    .get();
+  if (byName) {
+    await setNewReleasesStackId(byName.id);
+    return byName.id;
+  }
+
+  const [created] = await db
+    .insert(stacks)
+    .values({ name: NEW_RELEASES_STACK_NAME })
+    .returning({ id: stacks.id });
+  await setNewReleasesStackId(created.id);
+  return created.id;
+}
+
+const ITEM_TYPES = new Set<ItemType>(["album", "ep", "single", "track", "mix", "compilation"]);
+
+/** MusicBrainz primary types map onto our item types where they overlap. */
+export function itemTypeForReleaseGroup(primaryType: string | null): ItemType {
+  const candidate = primaryType?.toLowerCase();
+  return candidate && ITEM_TYPES.has(candidate as ItemType) ? (candidate as ItemType) : "album";
+}
+
+export interface AcceptResult {
+  itemId: number;
+  remindAt: Date | null;
+}
+
+/**
+ * Accept an alert: create the item with the MusicBrainz metadata prefilled,
+ * file it in the New Releases stack, and — when the record is still
+ * announced-only — hand its release date to the reminder cron via `remind_at`.
+ * `processReminders()` flips the item to To Listen on release day; until then
+ * it sits in Scheduled, already excluded from the To Listen feeds. No new
+ * scheduling code.
+ */
+export async function acceptAlert(
+  alertId: number,
+  now: Date = new Date(),
+): Promise<AcceptResult | null> {
+  const alert = await db
+    .select({
+      id: releaseAlerts.id,
+      status: releaseAlerts.status,
+      artistName: artists.name,
+      title: artistReleases.title,
+      primaryType: artistReleases.primaryType,
+      firstReleaseDate: artistReleases.firstReleaseDate,
+      firstReleaseYear: artistReleases.firstReleaseYear,
+    })
+    .from(releaseAlerts)
+    .innerJoin(artistReleases, eq(artistReleases.id, releaseAlerts.artistReleaseId))
+    .innerJoin(artists, eq(artists.id, releaseAlerts.artistId))
+    .where(eq(releaseAlerts.id, alertId))
+    .get();
+
+  if (!alert || alert.status === "added") return null;
+
+  const settings = await getArtistWatchSettings();
+  const remindAt = settings.scheduleAnnouncedReleases
+    ? remindAtForReleaseDate(alert.firstReleaseDate, now)
+    : null;
+
+  const { item } = await createMusicItemDirect({
+    title: alert.title,
+    artistName: alert.artistName,
+    itemType: itemTypeForReleaseGroup(alert.primaryType),
+    listenStatus: "to-listen",
+    year: alert.firstReleaseYear ?? undefined,
+  });
+
+  if (remindAt) {
+    await db
+      .update(musicItems)
+      .set({ remindAt, reminderPending: false, updatedAt: now })
+      .where(eq(musicItems.id, item.id));
+  }
+
+  // Items land in the stack *in addition* to normal status handling, so it
+  // accumulates as a running record of what the watcher has fed the library.
+  const stackId = await ensureNewReleasesStack();
+  await db.insert(musicItemStacks).values({ musicItemId: item.id, stackId }).onConflictDoNothing();
+
+  await db
+    .update(releaseAlerts)
+    .set({ status: "added", musicItemId: item.id, resolvedAt: now })
+    .where(eq(releaseAlerts.id, alertId));
+
+  return { itemId: item.id, remindAt };
+}

--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -1,0 +1,131 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "../db/index";
+import { artists } from "../db/schema";
+import { listTrackedArtists, pollArtistNow } from "../artist-watch";
+import { muteArtist } from "../release-alerts";
+import { searchArtistCandidates } from "../musicbrainz";
+import { setArtistMbid } from "../artist-identity";
+
+const FOLLOW_STATES = ["auto", "always", "muted"] as const;
+type FollowState = (typeof FOLLOW_STATES)[number];
+
+function parseId(value: string): number | null {
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export function createArtistRoutes(): Hono {
+  const routes = new Hono();
+
+  // GET /tracked — the artist-management panel: follow state, MBID confidence,
+  // last poll.
+  routes.get("/tracked", async (c) => {
+    const tracked = await listTrackedArtists();
+    return c.json({
+      artists: tracked.map((artist) => ({
+        id: artist.id,
+        name: artist.name,
+        musicbrainz_artist_id: artist.musicbrainzArtistId,
+        mbid_confidence: artist.mbidConfidence ?? "unresolved",
+        follow_state: artist.followState,
+        last_polled_at: artist.lastPolledAt?.toISOString() ?? null,
+        next_poll_at: artist.nextPollAt?.toISOString() ?? null,
+        poll_failure_count: artist.pollFailureCount,
+      })),
+    });
+  });
+
+  // GET /:id/mbid-candidates — the disambiguation list for an unresolved
+  // artist: name, disambiguation comment, country and life span, so the user
+  // can pick the one we refused to guess at.
+  routes.get("/:id/mbid-candidates", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    const artist = await db
+      .select({ name: artists.name })
+      .from(artists)
+      .where(eq(artists.id, id))
+      .get();
+    if (!artist) return c.json({ error: "Artist not found" }, 404);
+
+    if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return c.json({ candidates: [] });
+
+    try {
+      return c.json({ candidates: await searchArtistCandidates(artist.name) });
+    } catch (err) {
+      console.error("[api] artist MBID candidate search failed:", err);
+      return c.json({ error: "MusicBrainz lookup failed" }, 502);
+    }
+  });
+
+  // PUT /:id/follow — auto | always | muted.
+  routes.put("/:id/follow", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON payload" }, 400);
+    }
+
+    const followState = (body as { followState?: unknown } | null)?.followState;
+    if (!FOLLOW_STATES.includes(followState as FollowState)) {
+      return c.json({ error: `followState must be one of: ${FOLLOW_STATES.join(", ")}` }, 400);
+    }
+
+    if (followState === "muted") {
+      // Muting also clears the alerts already queued for that artist.
+      const muted = await muteArtist(id);
+      return muted ? c.json({ followState }) : c.json({ error: "Artist not found" }, 404);
+    }
+
+    const updated = await db
+      .update(artists)
+      .set({ followState: followState as FollowState, updatedAt: new Date() })
+      .where(eq(artists.id, id))
+      .returning({ id: artists.id });
+    if (updated.length === 0) return c.json({ error: "Artist not found" }, 404);
+
+    return c.json({ followState });
+  });
+
+  // PUT /:id/mbid — confirm an MBID from the disambiguation dialog.
+  routes.put("/:id/mbid", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON payload" }, 400);
+    }
+
+    const mbid = (body as { musicbrainzArtistId?: unknown } | null)?.musicbrainzArtistId;
+    if (typeof mbid !== "string" || mbid.trim().length === 0) {
+      return c.json({ error: "musicbrainzArtistId is required" }, 400);
+    }
+
+    const updated = await setArtistMbid(id, mbid.trim());
+    if (!updated) return c.json({ error: "Artist not found" }, 404);
+    return c.json({ musicbrainzArtistId: mbid.trim(), mbidConfidence: "confirmed" });
+  });
+
+  // POST /:id/poll — "check now".
+  routes.post("/:id/poll", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    const outcome = await pollArtistNow(id);
+    if (!outcome) return c.json({ error: "Artist not found" }, 404);
+    return c.json(outcome);
+  });
+
+  return routes;
+}
+
+export const artistRoutes = createArtistRoutes();

--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -10,6 +10,8 @@ import { setArtistMbid } from "../artist-identity";
 const FOLLOW_STATES = ["auto", "always", "muted"] as const;
 type FollowState = (typeof FOLLOW_STATES)[number];
 
+const MBID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function parseId(value: string): number | null {
   const id = Number(value);
   return Number.isInteger(id) && id > 0 ? id : null;
@@ -108,6 +110,12 @@ export function createArtistRoutes(): Hono {
     const mbid = (body as { musicbrainzArtistId?: unknown } | null)?.musicbrainzArtistId;
     if (typeof mbid !== "string" || mbid.trim().length === 0) {
       return c.json({ error: "musicbrainzArtistId is required" }, 400);
+    }
+    // A confirmed MBID drives every future poll for this artist, so catch a
+    // mistyped or half-pasted one here rather than discovering it as a run of
+    // 404s from MusicBrainz weeks later.
+    if (!MBID_PATTERN.test(mbid.trim())) {
+      return c.json({ error: "musicbrainzArtistId must be a UUID" }, 400);
     }
 
     const updated = await setArtistMbid(id, mbid.trim());

--- a/server/routes/release-alerts.ts
+++ b/server/routes/release-alerts.ts
@@ -1,0 +1,81 @@
+import { Hono } from "hono";
+import {
+  acceptAlert,
+  countPendingAlerts,
+  dismissAlert,
+  listReleaseAlerts,
+  markAlertsSeen,
+  type AlertStatus,
+} from "../release-alerts";
+import { fetchFullItem } from "../music-item-store";
+
+const ALERT_STATUSES: readonly AlertStatus[] = ["pending", "seen", "added", "dismissed"];
+
+function parseStatuses(raw: string | undefined): AlertStatus[] | null {
+  if (!raw) return ["pending"];
+  const parsed = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (parsed.length === 0) return ["pending"];
+  if (
+    !parsed.every((value): value is AlertStatus => ALERT_STATUSES.includes(value as AlertStatus))
+  ) {
+    return null;
+  }
+  return parsed as AlertStatus[];
+}
+
+function parseId(value: string): number | null {
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export function createReleaseAlertRoutes(): Hono {
+  const routes = new Hono();
+
+  // GET / — the alert queue, artist and release joined in.
+  routes.get("/", async (c) => {
+    const statuses = parseStatuses(c.req.query("status"));
+    if (!statuses) {
+      return c.json({ error: `status must be one of: ${ALERT_STATUSES.join(", ")}` }, 400);
+    }
+
+    const alerts = await listReleaseAlerts(statuses);
+    return c.json({ alerts, pendingCount: await countPendingAlerts() });
+  });
+
+  // POST /mark-seen — bulk pending → seen, clearing the taskbar badge without
+  // forcing a decision on each card.
+  routes.post("/mark-seen", async (c) => {
+    const seen = await markAlertsSeen();
+    return c.json({ seen });
+  });
+
+  // POST /:id/add — create the item, file it in New Releases, schedule it if
+  // the record is still announced-only.
+  routes.post("/:id/add", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    const result = await acceptAlert(id);
+    if (!result) return c.json({ error: "Alert not found or already added" }, 404);
+
+    const item = await fetchFullItem(result.itemId);
+    return c.json({ item, remindAt: result.remindAt?.toISOString() ?? null }, 201);
+  });
+
+  // POST /:id/dismiss — never re-fires (unique index on the release).
+  routes.post("/:id/dismiss", async (c) => {
+    const id = parseId(c.req.param("id"));
+    if (id === null) return c.json({ error: "Invalid ID" }, 400);
+
+    const dismissed = await dismissAlert(id);
+    if (!dismissed) return c.json({ error: "Alert not found" }, 404);
+    return c.json({ success: true });
+  });
+
+  return routes;
+}
+
+export const releaseAlertRoutes = createReleaseAlertRoutes();

--- a/server/routes/rss.ts
+++ b/server/routes/rss.ts
@@ -4,6 +4,8 @@ import { musicItems, artists, musicLinks, sources, stacks, musicItemStacks } fro
 import { eq, and, inArray, isNull } from "drizzle-orm";
 import type { MusicItemFull } from "../../src/types";
 import type { PrimaryFeedKey } from "../../shared/rss";
+import type { ReleaseAlertView } from "../release-alerts";
+import { listReleaseAlerts } from "../release-alerts";
 
 type StackInfo = { id: number; name: string };
 type FeedInfo = { title: string; description: string };
@@ -11,6 +13,21 @@ type FeedInfo = { title: string; description: string };
 export type FetchStackFn = (stackId: number) => Promise<StackInfo | null>;
 export type FetchStackItemsFn = (stackId: number) => Promise<MusicItemFull[]>;
 export type FetchPrimaryFeedItemsFn = (feed: PrimaryFeedKey) => Promise<MusicItemFull[]>;
+export type FetchReleaseAlertsFn = () => Promise<ReleaseAlertView[]>;
+
+/**
+ * The renderer's unit of work. Feeds that aren't lists of music items — the
+ * new-release alerts, for one — map onto this rather than pretending to be
+ * `MusicItemFull`.
+ */
+export interface FeedEntry {
+  guid: string;
+  title: string;
+  link: string;
+  /** ISO 8601; rendered as RFC 2822. */
+  pubDate: string;
+  description: string;
+}
 
 // ---------------------------------------------------------------------------
 // XML helpers
@@ -87,21 +104,65 @@ function renderItemDescription(item: MusicItemFull): string {
   return lines.join("\n");
 }
 
-function renderRss(feed: FeedInfo, items: MusicItemFull[], baseUrl: string): string {
-  const itemsXml = items
-    .map((item) => {
-      const title = escapeXml(itemTitle(item));
-      const link = escapeXml(`${baseUrl}/r/${item.id}`);
-      const pubDate = toRfc2822(item.created_at);
-      const guid = `music-item-${item.id}`;
-      const description = renderItemDescription(item);
+/** A music item as a feed entry. */
+function itemToEntry(item: MusicItemFull, baseUrl: string): FeedEntry {
+  return {
+    guid: `music-item-${item.id}`,
+    title: itemTitle(item),
+    link: `${baseUrl}/r/${item.id}`,
+    pubDate: item.created_at,
+    description: renderItemDescription(item),
+  };
+}
+
+const ALERT_REASON_LABELS: Record<string, string> = {
+  announced: "Announced release",
+  "new-release": "New release",
+  "catalogue-addition": "Added to MusicBrainz",
+};
+
+function renderAlertDescription(alert: ReleaseAlertView): string {
+  const lines: string[] = [ALERT_REASON_LABELS[alert.reason] ?? "New release"];
+
+  const metaParts: string[] = [];
+  if (alert.primary_type) metaParts.push(capitalize(alert.primary_type));
+  for (const type of alert.secondary_types) metaParts.push(capitalize(type));
+  if (alert.first_release_date) metaParts.push(alert.first_release_date);
+  if (metaParts.length > 0) lines.push(metaParts.join(" · "));
+
+  lines.push(`MusicBrainz: https://musicbrainz.org/release-group/${alert.mb_release_group_id}`);
+
+  return lines.join("\n");
+}
+
+/**
+ * An alert as a feed entry. `pubDate` is when the alert fired, not the release
+ * date — a 1978 record surfacing today is news today, and should appear at the
+ * top of the reader rather than buried in 1978.
+ */
+function alertToEntry(alert: ReleaseAlertView, baseUrl: string): FeedEntry {
+  return {
+    guid: `release-alert-${alert.id}`,
+    title: `${alert.artist_name} — ${alert.title}`,
+    link: `${baseUrl}/new-releases`,
+    pubDate: alert.created_at,
+    description: renderAlertDescription(alert),
+  };
+}
+
+function renderRss(feed: FeedInfo, entries: FeedEntry[]): string {
+  const itemsXml = entries
+    .map((entry) => {
+      const title = escapeXml(entry.title);
+      const link = escapeXml(entry.link);
+      const pubDate = toRfc2822(entry.pubDate);
 
       return `    <item>
       <title>${title}</title>
       <link>${link}</link>
       <pubDate>${pubDate}</pubDate>
-      <guid isPermaLink="false">${guid}</guid>
-      <description><![CDATA[${description}]]></description>
+      <guid isPermaLink="false">${entry.guid}</guid>
+      <description><![CDATA[${entry.description}]]></description>
     </item>`;
     })
     .join("\n");
@@ -302,6 +363,7 @@ export function createRssRoutes(
   fetchStack: FetchStackFn = defaultFetchStack,
   fetchStackItems: FetchStackItemsFn = defaultFetchStackItems,
   fetchPrimaryFeedItems: FetchPrimaryFeedItemsFn = defaultFetchPrimaryFeedItems,
+  fetchReleaseAlerts: FetchReleaseAlertsFn = () => listReleaseAlerts(["pending", "seen"]),
 ): Hono {
   const routes = new Hono();
 
@@ -313,8 +375,7 @@ export function createRssRoutes(
         title: "On the Beach — All",
         description: "All items in On the Beach",
       },
-      items,
-      baseUrl,
+      items.map((item) => itemToEntry(item, baseUrl)),
     );
 
     return c.body(xml, 200, {
@@ -330,8 +391,7 @@ export function createRssRoutes(
         title: "On the Beach — To Listen",
         description: 'Items with status "To Listen" in On the Beach',
       },
-      items,
-      baseUrl,
+      items.map((item) => itemToEntry(item, baseUrl)),
     );
 
     return c.body(xml, 200, {
@@ -347,8 +407,25 @@ export function createRssRoutes(
         title: "On the Beach — Listened",
         description: 'Items with status "Listened" in On the Beach',
       },
-      items,
-      baseUrl,
+      items.map((item) => itemToEntry(item, baseUrl)),
+    );
+
+    return c.body(xml, 200, {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    });
+  });
+
+  // The closest thing to a push notification this app can offer without
+  // notification infrastructure: the user's existing reader does the alerting.
+  routes.get("/new-releases.rss", async (c) => {
+    const alerts = await fetchReleaseAlerts();
+    const baseUrl = new URL(c.req.url).origin;
+    const xml = renderRss(
+      {
+        title: "On the Beach — New Releases",
+        description: "New releases by artists you've listened to",
+      },
+      alerts.map((alert) => alertToEntry(alert, baseUrl)),
     );
 
     return c.body(xml, 200, {
@@ -376,8 +453,7 @@ export function createRssRoutes(
         title: `On the Beach — ${stack.name}`,
         description: `Items in the ${stack.name} stack on On the Beach`,
       },
-      items,
-      baseUrl,
+      items.map((item) => itemToEntry(item, baseUrl)),
     );
 
     return c.body(xml, 200, {

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -8,8 +8,52 @@ import {
   setReleaseLengthPreference,
   isReleaseLengthPreference,
   RELEASE_LENGTH_PREFERENCES,
+  getArtistWatchSettings,
+  setArtistWatchSettings,
+  type ArtistWatchSettings,
 } from "../settings";
 import { ensureSuggestionsForToListenArtists } from "../suggestions";
+
+/**
+ * Pick the artist-watch fields out of a settings payload, rejecting values of
+ * the wrong shape rather than coercing them — a `freshnessMonths` of "soon"
+ * should be a 400, not an 18.
+ */
+function readArtistWatchUpdate(
+  body: Record<string, unknown>,
+): { update: Partial<ArtistWatchSettings> } | { error: string } {
+  const update: Partial<ArtistWatchSettings> = {};
+
+  const booleans: Array<[string, keyof ArtistWatchSettings]> = [
+    ["artistWatchEnabled", "enabled"],
+    ["alertOnCatalogueAdditions", "alertOnCatalogueAdditions"],
+    ["scheduleAnnouncedReleases", "scheduleAnnouncedReleases"],
+  ];
+  for (const [field, key] of booleans) {
+    const value = body[field];
+    if (value === undefined) continue;
+    if (typeof value !== "boolean") return { error: `${field} must be a boolean` };
+    (update[key] as boolean) = value;
+  }
+
+  if (body.alertFreshnessMonths !== undefined) {
+    const months = body.alertFreshnessMonths;
+    if (typeof months !== "number" || !Number.isFinite(months) || months < 0) {
+      return { error: "alertFreshnessMonths must be a non-negative number" };
+    }
+    update.freshnessMonths = months;
+  }
+
+  if (body.alertExcludedSecondaryTypes !== undefined) {
+    const types = body.alertExcludedSecondaryTypes;
+    if (!Array.isArray(types) || types.some((type) => typeof type !== "string")) {
+      return { error: "alertExcludedSecondaryTypes must be an array of strings" };
+    }
+    update.excludedSecondaryTypes = (types as string[]).map((type) => type.trim().toLowerCase());
+  }
+
+  return { update };
+}
 
 export function createSettingsRoutes(): Hono {
   const routes = new Hono();
@@ -22,6 +66,7 @@ export function createSettingsRoutes(): Hono {
       lookupServices: LOOKUP_SERVICES,
       releaseLengthPreference,
       releaseLengthPreferences: RELEASE_LENGTH_PREFERENCES,
+      artistWatch: await getArtistWatchSettings(),
     });
   });
 
@@ -37,8 +82,18 @@ export function createSettingsRoutes(): Hono {
       return c.json({ error: "Invalid JSON payload" }, 400);
     }
 
-    const { lookupService, releaseLengthPreference } = body as Record<string, unknown>;
-    if (lookupService === undefined && releaseLengthPreference === undefined) {
+    const payload = body as Record<string, unknown>;
+    const { lookupService, releaseLengthPreference } = payload;
+
+    const artistWatch = readArtistWatchUpdate(payload);
+    if ("error" in artistWatch) return c.json({ error: artistWatch.error }, 400);
+    const hasArtistWatchUpdate = Object.keys(artistWatch.update).length > 0;
+
+    if (
+      lookupService === undefined &&
+      releaseLengthPreference === undefined &&
+      !hasArtistWatchUpdate
+    ) {
       return c.json({ error: "Provide lookupService and/or releaseLengthPreference" }, 400);
     }
     if (lookupService !== undefined && !isLookupService(lookupService)) {
@@ -73,10 +128,16 @@ export function createSettingsRoutes(): Hono {
       }
     }
 
+    if (hasArtistWatchUpdate) {
+      await setArtistWatchSettings(artistWatch.update);
+      changed = true;
+    }
+
     return c.json(
       {
         lookupService: await getLookupService(),
         releaseLengthPreference: await getReleaseLengthPreference(),
+        artistWatch: await getArtistWatchSettings(),
         changed,
       },
       200,

--- a/server/routes/test.ts
+++ b/server/routes/test.ts
@@ -1,15 +1,19 @@
 import { Hono } from "hono";
+import { eq } from "drizzle-orm";
 import { db } from "../db/index";
 import {
   musicItemStacks,
   musicLinks,
   musicItems,
   artists,
+  artistReleases,
+  releaseAlerts,
   stacks,
   stackParents,
   musicItemOrder,
   itemSuggestions,
 } from "../db/schema";
+import { normalize } from "../utils";
 
 export const testRoutes = new Hono();
 
@@ -19,6 +23,8 @@ testRoutes.post("/reset", async (c) => {
   await db.delete(stackParents);
   await db.delete(musicLinks);
   await db.delete(itemSuggestions);
+  await db.delete(releaseAlerts);
+  await db.delete(artistReleases);
   await db.delete(musicItems);
   await db.delete(musicItemOrder);
   await db.delete(artists);
@@ -44,4 +50,58 @@ testRoutes.post("/suggestions", async (c) => {
     })
     .returning();
   return c.json(inserted, 201);
+});
+
+// Seed a pending new-release alert directly, standing in for the artist watch
+// sweep (external lookups are disabled under test).
+testRoutes.post("/release-alerts", async (c) => {
+  const body = await c.req.json();
+  const artistName: string = body.artistName;
+
+  const existingArtist = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .where(eq(artists.normalizedName, normalize(artistName)))
+    .get();
+
+  const artistId =
+    existingArtist?.id ??
+    (
+      await db
+        .insert(artists)
+        .values({
+          name: artistName,
+          normalizedName: normalize(artistName),
+          musicbrainzArtistId: body.musicbrainzArtistId ?? `mbid-${normalize(artistName)}`,
+          mbidConfidence: "confirmed",
+        })
+        .returning({ id: artists.id })
+    )[0].id;
+
+  const [release] = await db
+    .insert(artistReleases)
+    .values({
+      artistId,
+      mbReleaseGroupId: body.mbReleaseGroupId ?? `rg-${Date.now()}-${Math.random()}`,
+      title: body.title,
+      normalizedTitle: normalize(body.title),
+      primaryType: body.primaryType ?? "Album",
+      secondaryTypes: "[]",
+      firstReleaseDate: body.firstReleaseDate ?? null,
+      firstReleaseYear: body.firstReleaseDate
+        ? Number.parseInt(String(body.firstReleaseDate).slice(0, 4), 10)
+        : null,
+    })
+    .returning({ id: artistReleases.id });
+
+  const [alert] = await db
+    .insert(releaseAlerts)
+    .values({
+      artistId,
+      artistReleaseId: release.id,
+      reason: body.reason ?? "new-release",
+    })
+    .returning();
+
+  return c.json(alert, 201);
 });

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -18,7 +18,7 @@ export function isLookupService(value: unknown): value is LookupService {
 const LOOKUP_SERVICE_KEY = "lookup_service";
 const DEFAULT_LOOKUP_SERVICE: LookupService = "apple_music";
 
-async function getSetting(key: string): Promise<string | null> {
+export async function getSetting(key: string): Promise<string | null> {
   const rows = await db
     .select({ value: appSettings.value })
     .from(appSettings)
@@ -27,7 +27,7 @@ async function getSetting(key: string): Promise<string | null> {
   return rows[0]?.value ?? null;
 }
 
-async function putSetting(key: string, value: string): Promise<void> {
+export async function putSetting(key: string, value: string): Promise<void> {
   await db
     .insert(appSettings)
     .values({ key, value, updatedAt: new Date() })
@@ -102,4 +102,133 @@ export async function setReleaseLengthPreference(
   await putSetting(RELEASE_LENGTH_PREFERENCE_KEY, preference);
   await db.delete(itemSuggestions).where(eq(itemSuggestions.status, "pending"));
   return { changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Artist watch / new-release alerts
+// ---------------------------------------------------------------------------
+
+export const ARTIST_WATCH_KEYS = {
+  enabled: "artist_watch_enabled",
+  freshnessMonths: "alert_freshness_months",
+  catalogueAdditions: "alert_on_catalogue_additions",
+  excludedSecondaryTypes: "alert_excluded_secondary_types",
+  newReleasesStackId: "new_releases_stack_id",
+  scheduleAnnounced: "schedule_announced_releases",
+} as const;
+
+export interface ArtistWatchSettings {
+  /** Master switch for the sweep. */
+  enabled: boolean;
+  /** Age window, in months, for "new release" alerts. Future dates always qualify. */
+  freshnessMonths: number;
+  /** Also alert on records newly *added to MusicBrainz* however old they are. */
+  alertOnCatalogueAdditions: boolean;
+  /** Secondary types that never raise an alert, lower-cased. */
+  excludedSecondaryTypes: string[];
+  /** Set `remind_at` from a future release date when an alert is accepted. */
+  scheduleAnnouncedReleases: boolean;
+}
+
+// The noise filter defaults: archival editing churn the user did not ask about.
+const DEFAULT_EXCLUDED_SECONDARY_TYPES = [
+  "compilation",
+  "live",
+  "remix",
+  "dj-mix",
+  "interview",
+  "audiobook",
+];
+
+export const DEFAULT_ARTIST_WATCH_SETTINGS: ArtistWatchSettings = {
+  enabled: true,
+  freshnessMonths: 18,
+  alertOnCatalogueAdditions: false,
+  excludedSecondaryTypes: DEFAULT_EXCLUDED_SECONDARY_TYPES,
+  scheduleAnnouncedReleases: true,
+};
+
+function parseBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === null) return fallback;
+  return value === "true" || value === "1";
+}
+
+export async function getArtistWatchSettings(): Promise<ArtistWatchSettings> {
+  const [enabled, freshness, catalogue, excluded, schedule] = await Promise.all([
+    getSetting(ARTIST_WATCH_KEYS.enabled),
+    getSetting(ARTIST_WATCH_KEYS.freshnessMonths),
+    getSetting(ARTIST_WATCH_KEYS.catalogueAdditions),
+    getSetting(ARTIST_WATCH_KEYS.excludedSecondaryTypes),
+    getSetting(ARTIST_WATCH_KEYS.scheduleAnnounced),
+  ]);
+
+  // `Number(null)` is 0, which is a perfectly valid freshness window — so the
+  // unset case has to be ruled out before parsing, or the default never applies.
+  const months = freshness === null ? Number.NaN : Number(freshness);
+
+  return {
+    enabled: parseBoolean(enabled, DEFAULT_ARTIST_WATCH_SETTINGS.enabled),
+    freshnessMonths:
+      Number.isFinite(months) && months >= 0
+        ? months
+        : DEFAULT_ARTIST_WATCH_SETTINGS.freshnessMonths,
+    alertOnCatalogueAdditions: parseBoolean(
+      catalogue,
+      DEFAULT_ARTIST_WATCH_SETTINGS.alertOnCatalogueAdditions,
+    ),
+    excludedSecondaryTypes:
+      excluded === null
+        ? DEFAULT_ARTIST_WATCH_SETTINGS.excludedSecondaryTypes
+        : excluded
+            .split(",")
+            .map((type) => type.trim().toLowerCase())
+            .filter(Boolean),
+    scheduleAnnouncedReleases: parseBoolean(
+      schedule,
+      DEFAULT_ARTIST_WATCH_SETTINGS.scheduleAnnouncedReleases,
+    ),
+  };
+}
+
+export async function setArtistWatchSettings(
+  update: Partial<ArtistWatchSettings>,
+): Promise<ArtistWatchSettings> {
+  if (update.enabled !== undefined) {
+    await putSetting(ARTIST_WATCH_KEYS.enabled, String(update.enabled));
+  }
+  if (update.freshnessMonths !== undefined) {
+    await putSetting(ARTIST_WATCH_KEYS.freshnessMonths, String(update.freshnessMonths));
+  }
+  if (update.alertOnCatalogueAdditions !== undefined) {
+    await putSetting(
+      ARTIST_WATCH_KEYS.catalogueAdditions,
+      String(update.alertOnCatalogueAdditions),
+    );
+  }
+  if (update.excludedSecondaryTypes !== undefined) {
+    await putSetting(
+      ARTIST_WATCH_KEYS.excludedSecondaryTypes,
+      update.excludedSecondaryTypes.join(","),
+    );
+  }
+  if (update.scheduleAnnouncedReleases !== undefined) {
+    await putSetting(ARTIST_WATCH_KEYS.scheduleAnnounced, String(update.scheduleAnnouncedReleases));
+  }
+
+  return getArtistWatchSettings();
+}
+
+/**
+ * The stack accepted alerts are filed into, referenced **by id**. `stacks.name`
+ * is unique and user-editable, so name-matching would silently create a
+ * duplicate the moment the user renames it.
+ */
+export async function getNewReleasesStackId(): Promise<number | null> {
+  const value = await getSetting(ARTIST_WATCH_KEYS.newReleasesStackId);
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export async function setNewReleasesStackId(stackId: number): Promise<void> {
+  await putSetting(ARTIST_WATCH_KEYS.newReleasesStackId, String(stackId));
 }

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -206,6 +206,10 @@ export async function setArtistWatchSettings(
     );
   }
   if (update.excludedSecondaryTypes !== undefined) {
+    // Stored comma-joined, which is safe only because MusicBrainz secondary
+    // types are a closed vocabulary with no commas in it ("compilation",
+    // "live", "dj-mix"…). A free-text value here would not survive the round
+    // trip through `getArtistWatchSettings`.
     await putSetting(
       ARTIST_WATCH_KEYS.excludedSecondaryTypes,
       update.excludedSecondaryTypes.join(","),

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { json, type Handle } from "@sveltejs/kit";
 import { building } from "$app/environment";
 import { processReminders } from "../server/reminders";
 import { ensureSuggestionsForToListenArtists } from "../server/suggestions";
+import { sweepArtistReleases, SWEEP_INTERVAL_MS } from "../server/artist-watch";
 import {
   CSRF_COOKIE_NAME,
   CSRF_HEADER_NAME,
@@ -16,6 +17,7 @@ import {
 const globalState = globalThis as typeof globalThis & {
   __otbRemindersStarted?: boolean;
   __otbSuggestionSweepStarted?: boolean;
+  __otbArtistWatchStarted?: boolean;
 };
 if (!building && !globalState.__otbRemindersStarted) {
   globalState.__otbRemindersStarted = true;
@@ -44,6 +46,24 @@ if (!building && !globalState.__otbSuggestionSweepStarted) {
         console.error("[suggestions] interval sweep failed:", err),
       ),
     60 * 60 * 1000,
+  );
+}
+
+// ---------- Artist release watch ----------
+// Ask MusicBrainz what the artists you've listened to have put out, and raise
+// an alert for anything we haven't seen before. Runs on startup and then
+// daily; which artists are actually *due* is held in the database
+// (artists.next_poll_at), not in this timer, so a restart neither skips an
+// artist nor polls one twice. No-ops under OTB_DISABLE_EXTERNAL_LOOKUPS.
+if (!building && !globalState.__otbArtistWatchStarted) {
+  globalState.__otbArtistWatchStarted = true;
+  sweepArtistReleases().catch((err) => console.error("[artist-watch] startup sweep failed:", err));
+  setInterval(
+    () =>
+      sweepArtistReleases().catch((err) =>
+        console.error("[artist-watch] interval sweep failed:", err),
+      ),
+    SWEEP_INTERVAL_MS,
   );
 }
 

--- a/src/lib/components/Taskbar.svelte
+++ b/src/lib/components/Taskbar.svelte
@@ -18,6 +18,23 @@
     return () => clearInterval(interval);
   });
 
+  // ── New-release alerts ──────────────────────────────────────────────────────
+  // A count of pending alerts on the taskbar, the way a tray icon would carry
+  // one. Visiting the queue marks them seen, which clears the badge without
+  // forcing a decision on each card.
+  let pendingAlerts = $state(0);
+
+  onMount(() => {
+    void api
+      .listReleaseAlerts(["pending"])
+      .then((result) => {
+        pendingAlerts = result.pendingCount;
+      })
+      .catch(() => {
+        pendingAlerts = 0;
+      });
+  });
+
   // ── Start menu ──────────────────────────────────────────────────────────────
   // One canonical, discoverable home for every primary action. The actions
   // drive main-page controls by id — the same contract the e2e specs use.
@@ -213,6 +230,12 @@
         >
           <span class="start-menu__icon" aria-hidden="true">🗂️</span>Manage stacks
         </button>
+        <a class="start-menu__item" role="menuitem" href="/new-releases" onclick={closeStartMenu}>
+          <span class="start-menu__icon" aria-hidden="true">📻</span>New releases
+          {#if pendingAlerts > 0}
+            <span class="start-menu__count">{pendingAlerts}</span>
+          {/if}
+        </a>
         <div class="start-menu__divider" role="separator"></div>
         <a class="start-menu__item" role="menuitem" href="/feed/to-listen.rss" onclick={closeStartMenu}>
           <span class="start-menu__icon" aria-hidden="true">📡</span>RSS feed
@@ -237,6 +260,17 @@
     <span aria-hidden="true">♫</span>
     <span id="taskbar-np-label">{player.active ? player.label : ""}</span>
   </button>
+  {#if pendingAlerts > 0}
+    <a
+      id="taskbar-alerts"
+      class="taskbar__task taskbar__task--alerts"
+      href="/new-releases"
+      title="{pendingAlerts} new release{pendingAlerts === 1 ? '' : 's'} waiting"
+    >
+      <span aria-hidden="true">📻</span>
+      <span class="taskbar__badge" id="taskbar-alerts-count">{pendingAlerts}</span>
+    </a>
+  {/if}
   {#if showClock}
     <div id="clock-popup" class="clock-popup" hidden={!popupOpen}>
       <div class="clock-popup__title">📅 Scheduled reminders</div>

--- a/src/lib/components/Taskbar.svelte
+++ b/src/lib/components/Taskbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { afterNavigate } from "$app/navigation";
   import type { MusicItemFull } from "../../types";
   import { api } from "../api";
   import { player } from "../player.svelte";
@@ -24,7 +25,12 @@
   // forcing a decision on each card.
   let pendingAlerts = $state(0);
 
-  onMount(() => {
+  // Refetched after every navigation rather than once on mount. The taskbar
+  // lives in the root layout, so it never remounts on client-side navigation —
+  // a count fetched at mount would stay lit after /new-releases marked the
+  // queue seen, until a full page reload. `afterNavigate` also fires on the
+  // initial mount, so this covers first paint too.
+  afterNavigate(() => {
     void api
       .listReleaseAlerts(["pending"])
       .then((result) => {

--- a/src/routes/new-releases/+page.server.ts
+++ b/src/routes/new-releases/+page.server.ts
@@ -1,0 +1,13 @@
+import type { PageServerLoad } from "./$types";
+import { listReleaseAlerts } from "../../../server/release-alerts";
+
+export const load: PageServerLoad = async () => {
+  // `seen` alerts stay on the page: marking the view as viewed clears the
+  // badge, it doesn't clear the queue — the cards still want a decision.
+  const alerts = await listReleaseAlerts(["pending", "seen"]);
+
+  return {
+    alerts,
+    pendingCount: alerts.filter((alert) => alert.status === "pending").length,
+  };
+};

--- a/src/routes/new-releases/+page.svelte
+++ b/src/routes/new-releases/+page.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { api } from "$lib/api";
+  import type { ReleaseAlert, ReleaseAlertReason } from "../../types";
+
+  let { data } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let alerts = $state<ReleaseAlert[]>(data.alerts);
+  let statusMessage = $state("");
+  let busyId = $state<number | null>(null);
+
+  const REASON_LABELS: Record<ReleaseAlertReason, string> = {
+    announced: "Announced",
+    "new-release": "New release",
+    "catalogue-addition": "Added to MusicBrainz",
+  };
+
+  // Cover Art Archive keys artwork by release-group MBID, the same wiring the
+  // suggestion prompt already uses.
+  function artworkUrl(alert: ReleaseAlert): string {
+    return `https://coverartarchive.org/release-group/${encodeURIComponent(alert.mb_release_group_id)}/front-250`;
+  }
+
+  let artworkFailed = $state<Record<number, boolean>>({});
+
+  /** MusicBrainz dates are often partial; show exactly what's known. */
+  function releaseDateLabel(alert: ReleaseAlert): string {
+    const date = alert.first_release_date;
+    if (!date) return "Date unknown";
+    if (date.length === 4) return date;
+    if (date.length === 7) {
+      const [year, month] = date.split("-");
+      return `${monthName(Number(month))} ${year}`;
+    }
+    return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  }
+
+  function monthName(month: number): string {
+    return [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ][month - 1] ?? "";
+  }
+
+  function typeLabel(alert: ReleaseAlert): string {
+    return [alert.primary_type, ...alert.secondary_types].filter(Boolean).join(" · ") || "Release";
+  }
+
+  onMount(() => {
+    // Visiting the queue is enough to clear the badge — triaging each card is
+    // a separate decision.
+    if (data.pendingCount > 0) {
+      void api.markReleaseAlertsSeen().catch(() => {});
+    }
+  });
+
+  function removeAlert(id: number): void {
+    alerts = alerts.filter((alert) => alert.id !== id);
+  }
+
+  async function add(alert: ReleaseAlert): Promise<void> {
+    busyId = alert.id;
+    try {
+      const result = await api.addReleaseAlert(alert.id);
+      removeAlert(alert.id);
+      statusMessage = result.remindAt
+        ? `Added “${alert.title}” — scheduled for ${releaseDateLabel(alert)}.`
+        : `Added “${alert.title}” to To Listen.`;
+    } catch {
+      statusMessage = "Couldn't add that release.";
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function dismiss(alert: ReleaseAlert): Promise<void> {
+    busyId = alert.id;
+    try {
+      await api.dismissReleaseAlert(alert.id);
+      removeAlert(alert.id);
+      statusMessage = `Dismissed “${alert.title}”.`;
+    } catch {
+      statusMessage = "Couldn't dismiss that release.";
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function mute(alert: ReleaseAlert): Promise<void> {
+    busyId = alert.id;
+    try {
+      await api.setArtistFollowState(alert.artist_id, "muted");
+      // Muting clears every queued alert for that artist, not just this card.
+      alerts = alerts.filter((row) => row.artist_id !== alert.artist_id);
+      statusMessage = `Muted ${alert.artist_name}. No more alerts for them.`;
+    } catch {
+      statusMessage = "Couldn't mute that artist.";
+    } finally {
+      busyId = null;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>New Releases — On The Beach</title>
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<main class="main">
+  <div class="alerts">
+    <a href="/" class="btn btn--ghost alerts__back">◄ Back</a>
+
+    <section class="alerts__header">
+      <h2 class="alerts__heading">📻 New Releases</h2>
+      <p class="alerts__hint">
+        Records by artists you've listened to that we haven't seen before. Adding one files it in
+        the New Releases stack; anything not out yet is scheduled to arrive in To Listen on release
+        day.
+      </p>
+      <a class="alerts__feed-link" href="/feed/new-releases.rss">📡 Subscribe by RSS</a>
+    </section>
+
+    <p id="alerts-status" class="settings__status" role="status" aria-live="polite">
+      {statusMessage}
+    </p>
+
+    {#if alerts.length === 0}
+      <div class="alerts__empty" id="alerts-empty">
+        <p>Nothing new right now.</p>
+        <p class="alerts__hint">
+          The watcher checks MusicBrainz daily. Artists are tracked once you've marked something of
+          theirs as listened.
+        </p>
+      </div>
+    {:else}
+      <ul class="alerts__list" id="alerts-list">
+        {#each alerts as alert (alert.id)}
+          <li class="alert-card" class:alert-card--busy={busyId === alert.id}>
+            <div class="alert-card__artwork">
+              {#if !artworkFailed[alert.id]}
+                <img
+                  src={artworkUrl(alert)}
+                  alt=""
+                  loading="lazy"
+                  onerror={() => (artworkFailed = { ...artworkFailed, [alert.id]: true })}
+                />
+              {:else}
+                <span class="alert-card__artwork-placeholder" aria-hidden="true">♫</span>
+              {/if}
+            </div>
+
+            <div class="alert-card__main">
+              <span class="alert-card__artist">{alert.artist_name}</span>
+              <span class="alert-card__title">{alert.title}</span>
+              <span class="alert-card__meta">
+                <span class="badge badge--reason badge--{alert.reason}">
+                  {REASON_LABELS[alert.reason]}
+                </span>
+                <span class="alert-card__type">{typeLabel(alert)}</span>
+                <span class="alert-card__date">{releaseDateLabel(alert)}</span>
+              </span>
+            </div>
+
+            <div class="alert-card__actions">
+              <button
+                type="button"
+                class="btn btn--primary"
+                data-alert-action="add"
+                disabled={busyId === alert.id}
+                onclick={() => add(alert)}>Add</button
+              >
+              <button
+                type="button"
+                class="btn"
+                data-alert-action="dismiss"
+                disabled={busyId === alert.id}
+                onclick={() => dismiss(alert)}>Dismiss</button
+              >
+              <button
+                type="button"
+                class="btn btn--ghost"
+                data-alert-action="mute"
+                disabled={busyId === alert.id}
+                onclick={() => mute(alert)}>Mute artist</button
+              >
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</main>

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -4,7 +4,9 @@ import {
   LOOKUP_SERVICES,
   getReleaseLengthPreference,
   RELEASE_LENGTH_PREFERENCES,
+  getArtistWatchSettings,
 } from "../../../server/settings";
+import { listTrackedArtists } from "../../../server/artist-watch";
 import { LOOKUP_SERVICE_CONFIG } from "../../../server/secondary-link-enrichment";
 import { isAppleMusicConfigured, getStorefront } from "../../../server/apple-music-token";
 
@@ -19,5 +21,16 @@ export const load: PageServerLoad = async () => {
     releaseLengthPreferences: RELEASE_LENGTH_PREFERENCES,
     appleMusicConfigured: isAppleMusicConfigured(),
     appleMusicStorefront: getStorefront(),
+    artistWatch: await getArtistWatchSettings(),
+    trackedArtists: (await listTrackedArtists()).map((artist) => ({
+      id: artist.id,
+      name: artist.name,
+      musicbrainz_artist_id: artist.musicbrainzArtistId,
+      mbid_confidence: artist.mbidConfidence ?? "unresolved",
+      follow_state: artist.followState,
+      last_polled_at: artist.lastPolledAt?.toISOString() ?? null,
+      next_poll_at: artist.nextPollAt?.toISOString() ?? null,
+      poll_failure_count: artist.pollFailureCount,
+    })),
   };
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -2,7 +2,9 @@
   import { onMount } from "svelte";
   import { apiFetch } from "$lib/api";
   import { musickit, authorize, unauthorize, ensureConfigured } from "$lib/musickit.svelte";
+  import { api } from "$lib/api";
   import type { LookupService, ReleaseLengthPreference } from "../../../server/settings";
+  import type { ArtistFollowState, MbArtistCandidateView, TrackedArtist } from "../../types";
 
   let { data } = $props();
 
@@ -114,6 +116,134 @@
       lengthStatusMessage = "Failed to save.";
     }
   }
+
+  // ── Artist watch ────────────────────────────────────────────────────────────
+  // svelte-ignore state_referenced_locally
+  let watch = $state({ ...data.artistWatch });
+  let watchStatusMessage = $state("");
+
+  async function saveWatch(update: Record<string, unknown>): Promise<void> {
+    watchStatusMessage = "Saving…";
+    try {
+      const res = await apiFetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        watchStatusMessage = err.error || "Failed to save.";
+        return;
+      }
+      const result = await res.json();
+      watch = { ...result.artistWatch };
+      watchStatusMessage = "Saved.";
+    } catch {
+      watchStatusMessage = "Failed to save.";
+    }
+  }
+
+  // ── Tracked artists ─────────────────────────────────────────────────────────
+  // svelte-ignore state_referenced_locally
+  let trackedArtists = $state<TrackedArtist[]>(data.trackedArtists as TrackedArtist[]);
+  let artistStatusMessage = $state("");
+  let candidatesFor = $state<number | null>(null);
+  let candidates = $state<MbArtistCandidateView[]>([]);
+  let candidatesLoading = $state(false);
+
+  const CONFIDENCE_LABELS: Record<string, string> = {
+    confirmed: "Confirmed",
+    probable: "Probable",
+    unresolved: "Unidentified",
+  };
+
+  function lastPolledLabel(artist: TrackedArtist): string {
+    if (!artist.last_polled_at) return "never polled";
+    return `polled ${new Date(artist.last_polled_at).toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+    })}`;
+  }
+
+  async function setFollowState(
+    artist: TrackedArtist,
+    followState: ArtistFollowState,
+  ): Promise<void> {
+    artistStatusMessage = "Saving…";
+    try {
+      await api.setArtistFollowState(artist.id, followState);
+      if (followState === "muted") {
+        // Muted artists drop out of the tracked list entirely.
+        trackedArtists = trackedArtists.filter((row) => row.id !== artist.id);
+        artistStatusMessage = `Muted ${artist.name}.`;
+        return;
+      }
+      trackedArtists = trackedArtists.map((row) =>
+        row.id === artist.id ? { ...row, follow_state: followState } : row,
+      );
+      artistStatusMessage = "Saved.";
+    } catch {
+      artistStatusMessage = "Failed to save.";
+    }
+  }
+
+  /**
+   * An unidentified artist is one the resolver refused to guess at, so the
+   * candidates go to the only person who can tell them apart.
+   */
+  async function showCandidates(artist: TrackedArtist): Promise<void> {
+    if (candidatesFor === artist.id) {
+      candidatesFor = null;
+      return;
+    }
+    candidatesFor = artist.id;
+    candidates = [];
+    candidatesLoading = true;
+    try {
+      candidates = await api.getArtistMbidCandidates(artist.id);
+    } catch {
+      artistStatusMessage = "Couldn't reach MusicBrainz.";
+      candidatesFor = null;
+    } finally {
+      candidatesLoading = false;
+    }
+  }
+
+  async function confirmMbid(artist: TrackedArtist, mbid: string): Promise<void> {
+    try {
+      await api.setArtistMbid(artist.id, mbid);
+      trackedArtists = trackedArtists.map((row) =>
+        row.id === artist.id
+          ? { ...row, musicbrainz_artist_id: mbid, mbid_confidence: "confirmed" }
+          : row,
+      );
+      candidatesFor = null;
+      artistStatusMessage = `${artist.name} identified. They'll be polled on the next sweep.`;
+    } catch {
+      artistStatusMessage = "Failed to save.";
+    }
+  }
+
+  async function checkNow(artist: TrackedArtist): Promise<void> {
+    artistStatusMessage = `Checking ${artist.name}…`;
+    try {
+      const outcome = await api.pollArtistNow(artist.id);
+      artistStatusMessage =
+        outcome.status === "polled"
+          ? `Checked ${artist.name}: ${outcome.alertsRaised} new alert(s).`
+          : `Couldn't check ${artist.name} (${outcome.status}).`;
+      trackedArtists = await api.listTrackedArtists();
+    } catch {
+      artistStatusMessage = "Check failed.";
+    }
+  }
+
+  function candidateSummary(candidate: MbArtistCandidateView): string {
+    const parts = [candidate.disambiguation, candidate.country, candidate.type].filter(Boolean);
+    const span = [candidate.lifeSpanBegin, candidate.lifeSpanEnd].filter(Boolean).join("–");
+    if (span) parts.push(span);
+    return parts.join(" · ");
+  }
 </script>
 
 <svelte:head>
@@ -179,6 +309,150 @@
         aria-live="polite"
       >
         {lengthStatusMessage}
+      </p>
+    </section>
+
+    <section class="settings__section" id="artist-watch-settings">
+      <h2 class="settings__heading">New release alerts</h2>
+      <p class="settings__hint">
+        Watch MusicBrainz for records by artists you've listened to. <a href="/new-releases"
+          >Open the queue</a
+        >
+        or subscribe to <a href="/feed/new-releases.rss">the RSS feed</a>.
+      </p>
+      <form id="artist-watch-form" class="settings__options">
+        <label class="settings__option">
+          <input
+            type="checkbox"
+            name="artist-watch-enabled"
+            checked={watch.enabled}
+            onchange={(event) =>
+              saveWatch({ artistWatchEnabled: event.currentTarget.checked })}
+          />
+          <span>Check MusicBrainz daily for new releases</span>
+        </label>
+        <label class="settings__option">
+          <input
+            type="checkbox"
+            name="schedule-announced"
+            checked={watch.scheduleAnnouncedReleases}
+            onchange={(event) =>
+              saveWatch({ scheduleAnnouncedReleases: event.currentTarget.checked })}
+          />
+          <span>Schedule unreleased records to arrive in To Listen on release day</span>
+        </label>
+        <label class="settings__option">
+          <input
+            type="checkbox"
+            name="catalogue-additions"
+            checked={watch.alertOnCatalogueAdditions}
+            onchange={(event) =>
+              saveWatch({ alertOnCatalogueAdditions: event.currentTarget.checked })}
+          />
+          <span>Also alert on older records newly added to MusicBrainz</span>
+        </label>
+        <label class="settings__option settings__option--field">
+          <span>Alert on releases from the last</span>
+          <input
+            type="number"
+            class="settings__number"
+            name="freshness-months"
+            min="0"
+            max="120"
+            value={watch.freshnessMonths}
+            onchange={(event) =>
+              saveWatch({ alertFreshnessMonths: Number(event.currentTarget.value) })}
+          />
+          <span>months</span>
+        </label>
+      </form>
+      <p id="artist-watch-status" class="settings__status" role="status" aria-live="polite">
+        {watchStatusMessage}
+      </p>
+    </section>
+
+    <section class="settings__section" id="tracked-artists-settings">
+      <h2 class="settings__heading">Tracked artists</h2>
+      <p class="settings__hint">
+        Artists you've listened to, and whose releases are watched. Muting one stops its alerts for
+        good. An artist marked <em>Unidentified</em> is one MusicBrainz couldn't pin down without
+        guessing — pick the right one and it starts being polled.
+      </p>
+
+      {#if trackedArtists.length === 0}
+        <p class="settings__hint">
+          Nothing tracked yet. Mark a record as listened and its artist joins the list.
+        </p>
+      {:else}
+        <ul class="artist-list" id="tracked-artists-list">
+          {#each trackedArtists as artist (artist.id)}
+            <li class="artist-list__row">
+              <div class="artist-list__main">
+                <span class="artist-list__name">{artist.name}</span>
+                <span class="artist-list__meta">
+                  <span
+                    class="settings__badge"
+                    class:settings__badge--ok={artist.mbid_confidence === "confirmed"}
+                    class:settings__badge--warn={artist.mbid_confidence === "probable"}
+                    class:settings__badge--off={artist.mbid_confidence === "unresolved"}
+                  >
+                    {CONFIDENCE_LABELS[artist.mbid_confidence]}
+                  </span>
+                  <span class="artist-list__polled">{lastPolledLabel(artist)}</span>
+                </span>
+              </div>
+              <div class="artist-list__actions">
+                {#if artist.mbid_confidence === "unresolved"}
+                  <button
+                    type="button"
+                    class="btn"
+                    data-artist-action="identify"
+                    onclick={() => showCandidates(artist)}>Identify…</button
+                  >
+                {:else}
+                  <button
+                    type="button"
+                    class="btn"
+                    data-artist-action="check"
+                    onclick={() => checkNow(artist)}>Check now</button
+                  >
+                {/if}
+                <button
+                  type="button"
+                  class="btn btn--ghost"
+                  data-artist-action="mute"
+                  onclick={() => setFollowState(artist, "muted")}>Mute</button
+                >
+              </div>
+
+              {#if candidatesFor === artist.id}
+                <div class="artist-list__candidates">
+                  {#if candidatesLoading}
+                    <p class="settings__hint">Asking MusicBrainz…</p>
+                  {:else if candidates.length === 0}
+                    <p class="settings__hint">No candidates found.</p>
+                  {:else}
+                    {#each candidates as candidate (candidate.id)}
+                      <button
+                        type="button"
+                        class="artist-list__candidate"
+                        onclick={() => confirmMbid(artist, candidate.id)}
+                      >
+                        <span class="artist-list__candidate-name">{candidate.name}</span>
+                        <span class="artist-list__candidate-detail">
+                          {candidateSummary(candidate) || "no further detail"}
+                        </span>
+                      </button>
+                    {/each}
+                  {/if}
+                </div>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      <p id="tracked-artists-status" class="settings__status" role="status" aria-live="polite">
+        {artistStatusMessage}
       </p>
     </section>
 

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -13,6 +13,11 @@ import type {
   LookupReleaseResult,
   RecognizeResult,
   ItemSuggestion,
+  ReleaseAlert,
+  ReleaseAlertStatus,
+  TrackedArtist,
+  ArtistFollowState,
+  MbArtistCandidateView,
 } from "../types";
 
 import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from "../../server/csrf";
@@ -365,6 +370,84 @@ export class ApiClient {
     await this.request(`/api/music-items/${itemId}/reminder`, "Clear reminder", {
       method: "DELETE",
     });
+  }
+
+  // ── New-release alerts ───────────────────────────────────────
+
+  async listReleaseAlerts(
+    statuses: ReleaseAlertStatus[] = ["pending", "seen"],
+  ): Promise<{ alerts: ReleaseAlert[]; pendingCount: number }> {
+    return this.requestJson<{ alerts: ReleaseAlert[]; pendingCount: number }>(
+      `/api/release-alerts?status=${statuses.join(",")}`,
+      "listReleaseAlerts",
+    );
+  }
+
+  async addReleaseAlert(
+    alertId: number,
+  ): Promise<{ item: MusicItemFull; remindAt: string | null }> {
+    return this.requestJson<{ item: MusicItemFull; remindAt: string | null }>(
+      `/api/release-alerts/${alertId}/add`,
+      "addReleaseAlert",
+      { method: "POST" },
+    );
+  }
+
+  async dismissReleaseAlert(alertId: number): Promise<void> {
+    await this.request(`/api/release-alerts/${alertId}/dismiss`, "dismissReleaseAlert", {
+      method: "POST",
+    });
+  }
+
+  async markReleaseAlertsSeen(): Promise<number> {
+    const body = await this.requestJson<{ seen: number }>(
+      "/api/release-alerts/mark-seen",
+      "markReleaseAlertsSeen",
+      { method: "POST" },
+    );
+    return body.seen;
+  }
+
+  // ── Tracked artists ──────────────────────────────────────────
+
+  async listTrackedArtists(): Promise<TrackedArtist[]> {
+    const body = await this.requestJson<{ artists: TrackedArtist[] }>(
+      "/api/artists/tracked",
+      "listTrackedArtists",
+    );
+    return body.artists;
+  }
+
+  async setArtistFollowState(artistId: number, followState: ArtistFollowState): Promise<void> {
+    await this.request(
+      `/api/artists/${artistId}/follow`,
+      "setArtistFollowState",
+      this.jsonRequest("PUT", { followState }),
+    );
+  }
+
+  async setArtistMbid(artistId: number, musicbrainzArtistId: string): Promise<void> {
+    await this.request(
+      `/api/artists/${artistId}/mbid`,
+      "setArtistMbid",
+      this.jsonRequest("PUT", { musicbrainzArtistId }),
+    );
+  }
+
+  async getArtistMbidCandidates(artistId: number): Promise<MbArtistCandidateView[]> {
+    const body = await this.requestJson<{ candidates: MbArtistCandidateView[] }>(
+      `/api/artists/${artistId}/mbid-candidates`,
+      "getArtistMbidCandidates",
+    );
+    return body.candidates;
+  }
+
+  async pollArtistNow(artistId: number): Promise<{ alertsRaised: number; status: string }> {
+    return this.requestJson<{ alertsRaised: number; status: string }>(
+      `/api/artists/${artistId}/poll`,
+      "pollArtistNow",
+      { method: "POST" },
+    );
   }
 
   async getPendingReminders(): Promise<Array<{ id: number; title: string }>> {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3854,3 +3854,340 @@ a:hover {
   font-size: var(--text-sm);
   color: var(--chrome-darker);
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   New-release alerts
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Taskbar tray: a count of pending alerts, the way a tray icon carries one. */
+.taskbar__task--alerts {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  max-width: none;
+  padding: 2px 8px;
+}
+
+.taskbar__badge {
+  min-width: 16px;
+  padding: 0 4px;
+  background: var(--danger);
+  color: #ffffff;
+  font-size: var(--text-2xs);
+  font-weight: bold;
+  line-height: 14px;
+  text-align: center;
+  border: 1px solid var(--chrome-darker);
+}
+
+.start-menu__count {
+  margin-left: auto;
+  min-width: 16px;
+  padding: 0 4px;
+  background: var(--danger);
+  color: #ffffff;
+  font-size: var(--text-2xs);
+  font-weight: bold;
+  line-height: 14px;
+  text-align: center;
+  border: 1px solid var(--chrome-darker);
+}
+
+.alerts {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.alerts__back {
+  align-self: flex-start;
+}
+
+.alerts__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.alerts__heading {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+}
+
+.alerts__hint {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--chrome-dark);
+}
+
+.alerts__feed-link {
+  align-self: flex-start;
+  font-size: var(--text-xs);
+  color: var(--chrome-darker);
+}
+
+.alerts__empty {
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-field);
+  background: var(--chrome-panel);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  text-align: center;
+  font-size: var(--text-md);
+}
+
+.alerts__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.alert-card {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3);
+  background: var(--chrome-panel);
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-raised);
+}
+
+.alert-card--busy {
+  opacity: 0.6;
+}
+
+.alert-card__artwork {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--chrome-mid);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--bevel-field);
+  overflow: hidden;
+}
+
+.alert-card__artwork img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.alert-card__artwork-placeholder {
+  font-size: var(--text-xl);
+  color: var(--chrome-darker);
+}
+
+.alert-card__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.alert-card__artist {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--chrome-darker);
+}
+
+.alert-card__title {
+  font-size: var(--text-md);
+  font-weight: bold;
+}
+
+.alert-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--chrome-dark);
+}
+
+.badge--reason {
+  font-size: var(--text-2xs);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border: 1px solid var(--chrome-darker);
+  background: var(--chrome);
+  color: var(--chrome-darker);
+}
+
+/* Announced records are the ones worth spotting from across the room. */
+.badge--announced {
+  background: var(--win-blue);
+  border-color: var(--win-blue);
+  color: #ffffff;
+}
+
+.badge--new-release {
+  background: #0a7d2c;
+  border-color: #0a7d2c;
+  color: #ffffff;
+}
+
+.alert-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* On a phone the three-column card stops working: stack it, and let the
+   actions run across the full width as a row of thumb-sized targets. */
+@media (max-width: 560px) {
+  .alert-card {
+    grid-template-columns: 48px 1fr;
+    grid-template-areas:
+      "art main"
+      "actions actions";
+  }
+
+  .alert-card__artwork {
+    grid-area: art;
+    width: 48px;
+    height: 48px;
+  }
+
+  .alert-card__main {
+    grid-area: main;
+  }
+
+  .alert-card__actions {
+    grid-area: actions;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .alert-card__actions .btn {
+    flex: 1 1 auto;
+    min-height: var(--touch-icon);
+  }
+}
+
+/* ── Tracked artists panel ── */
+
+.artist-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-field);
+  background: var(--chrome-light);
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.artist-list__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--chrome-mid);
+}
+
+.artist-list__row:last-child {
+  border-bottom: none;
+}
+
+.artist-list__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1 1 160px;
+  min-width: 0;
+}
+
+.artist-list__name {
+  font-size: var(--text-md);
+}
+
+.artist-list__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.artist-list__polled {
+  font-size: var(--text-xs);
+  color: var(--chrome-dark);
+}
+
+.artist-list__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.artist-list__candidates {
+  flex: 1 1 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  background: var(--chrome-panel);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--bevel-field);
+}
+
+.artist-list__candidate {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: var(--space-2);
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-ui);
+}
+
+.artist-list__candidate:hover,
+.artist-list__candidate:focus-visible {
+  background: var(--win-blue);
+  color: #ffffff;
+  outline: none;
+}
+
+.artist-list__candidate-name {
+  font-size: var(--text-base);
+  font-weight: bold;
+}
+
+.artist-list__candidate-detail {
+  font-size: var(--text-xs);
+}
+
+.settings__option--field {
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.settings__number {
+  width: 60px;
+  padding: 2px 4px;
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--bevel-field);
+  background: var(--chrome-white);
+  font-size: var(--text-base);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,3 +230,53 @@ export interface ItemSuggestion {
   status: string;
   createdAt: string;
 }
+
+// ── Artist tracking & new-release alerts ────────────────────────────────────
+
+export type ReleaseAlertStatus = "pending" | "seen" | "added" | "dismissed";
+/** Why an alert fired: it's announced, it's recent, or MusicBrainz just got it. */
+export type ReleaseAlertReason = "announced" | "new-release" | "catalogue-addition";
+export type ArtistFollowState = "auto" | "always" | "muted";
+export type MbidConfidence = "confirmed" | "probable" | "unresolved";
+
+export interface ReleaseAlert {
+  id: number;
+  status: ReleaseAlertStatus;
+  reason: ReleaseAlertReason;
+  created_at: string;
+  resolved_at: string | null;
+  music_item_id: number | null;
+  artist_id: number;
+  artist_name: string;
+  musicbrainz_artist_id: string | null;
+  release_id: number;
+  mb_release_group_id: string;
+  title: string;
+  primary_type: string | null;
+  secondary_types: string[];
+  /** MusicBrainz's date verbatim — may be partial ("2026", "2026-09"). */
+  first_release_date: string | null;
+  first_release_year: number | null;
+}
+
+export interface TrackedArtist {
+  id: number;
+  name: string;
+  musicbrainz_artist_id: string | null;
+  mbid_confidence: MbidConfidence;
+  follow_state: ArtistFollowState;
+  last_polled_at: string | null;
+  next_poll_at: string | null;
+  poll_failure_count: number;
+}
+
+export interface MbArtistCandidateView {
+  id: string;
+  name: string;
+  score: number;
+  disambiguation: string | null;
+  country: string | null;
+  type: string | null;
+  lifeSpanBegin: string | null;
+  lifeSpanEnd: string | null;
+}

--- a/tests/unit/artist-identity.test.ts
+++ b/tests/unit/artist-identity.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import * as musicbrainz from "../../server/musicbrainz";
+import { db } from "../../server/db/index";
+import { artists, musicItems } from "../../server/db/schema";
+import { normalize } from "../../server/utils";
+import {
+  backfillArtistMbidsFromItems,
+  mbidFromItems,
+  pickArtistFromSearch,
+  resolveArtistMbid,
+  setArtistMbid,
+  VARIOUS_ARTISTS_MBID,
+} from "../../server/artist-identity";
+
+function candidate(
+  overrides: Partial<musicbrainz.MbArtistCandidate>,
+): musicbrainz.MbArtistCandidate {
+  return {
+    id: "mbid-1",
+    name: "Some Artist",
+    score: 100,
+    disambiguation: null,
+    country: null,
+    type: null,
+    lifeSpanBegin: null,
+    lifeSpanEnd: null,
+    ...overrides,
+  };
+}
+
+async function makeArtist(name: string): Promise<number> {
+  const [row] = await db
+    .insert(artists)
+    .values({ name, normalizedName: normalize(name) })
+    .returning({ id: artists.id });
+  return row.id;
+}
+
+async function addItem(
+  artistId: number,
+  title: string,
+  mbArtistId: string | null = null,
+): Promise<number> {
+  const [row] = await db
+    .insert(musicItems)
+    .values({
+      title,
+      normalizedTitle: normalize(title),
+      artistId,
+      musicbrainzArtistId: mbArtistId,
+    })
+    .returning({ id: musicItems.id });
+  return row.id;
+}
+
+describe("pickArtistFromSearch", () => {
+  test("accepts a strong, clearly-ahead hit as probable", () => {
+    const result = pickArtistFromSearch([
+      candidate({ id: "strong", score: 100 }),
+      candidate({ id: "runner-up", score: 70 }),
+    ]);
+
+    expect(result.mbid).toBe("strong");
+    expect(result.confidence).toBe("probable");
+  });
+
+  test("refuses a strong hit shadowed by an almost-as-strong one", () => {
+    // The "Nirvana" case: two real artists, both plausible. Wrong alerts are
+    // worse than no alerts, so this must resolve to nothing.
+    const result = pickArtistFromSearch([
+      candidate({ id: "us-band", score: 100 }),
+      candidate({ id: "uk-band", score: 90 }),
+    ]);
+
+    expect(result.mbid).toBeNull();
+    expect(result.confidence).toBe("unresolved");
+  });
+
+  test("refuses a top hit below the score floor even when unopposed", () => {
+    const result = pickArtistFromSearch([candidate({ id: "weak", score: 80 })]);
+
+    expect(result.mbid).toBeNull();
+    expect(result.confidence).toBe("unresolved");
+  });
+
+  test("accepts the boundary case: exactly 95, exactly 20 clear", () => {
+    const result = pickArtistFromSearch([
+      candidate({ id: "boundary", score: 95 }),
+      candidate({ id: "second", score: 75 }),
+    ]);
+
+    expect(result.mbid).toBe("boundary");
+  });
+
+  test("never picks Various Artists", () => {
+    const result = pickArtistFromSearch([
+      candidate({ id: VARIOUS_ARTISTS_MBID, score: 100 }),
+      candidate({ id: "real-artist", score: 40 }),
+    ]);
+
+    expect(result.mbid).toBeNull();
+  });
+
+  test("returns nothing for an empty search", () => {
+    expect(pickArtistFromSearch([]).confidence).toBe("unresolved");
+  });
+
+  test("ranks by score rather than trusting the response order", () => {
+    const result = pickArtistFromSearch([
+      candidate({ id: "second", score: 60 }),
+      candidate({ id: "first", score: 100 }),
+    ]);
+
+    expect(result.mbid).toBe("first");
+  });
+});
+
+describe("mbidFromItems", () => {
+  test("takes the most frequent non-null MBID across the artist's items", async () => {
+    const artistId = await makeArtist(`Frequency Band ${Date.now()}`);
+    await addItem(artistId, "One", "mbid-a");
+    await addItem(artistId, "Two", "mbid-a");
+    await addItem(artistId, "Three", "mbid-b");
+    await addItem(artistId, "Four", null);
+
+    expect(await mbidFromItems(artistId)).toBe("mbid-a");
+  });
+
+  test("ignores the Various Artists placeholder", async () => {
+    const artistId = await makeArtist(`VA Band ${Date.now()}`);
+    await addItem(artistId, "Comp One", VARIOUS_ARTISTS_MBID);
+    await addItem(artistId, "Comp Two", VARIOUS_ARTISTS_MBID);
+    await addItem(artistId, "Real One", "mbid-real");
+
+    expect(await mbidFromItems(artistId)).toBe("mbid-real");
+  });
+
+  test("returns null when no item carries an MBID", async () => {
+    const artistId = await makeArtist(`Blank Band ${Date.now()}`);
+    await addItem(artistId, "Nothing");
+
+    expect(await mbidFromItems(artistId)).toBeNull();
+  });
+});
+
+describe("backfillArtistMbidsFromItems", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("promotes an item MBID onto the artist as confirmed, with no network", async () => {
+    const searchSpy = spyOn(musicbrainz, "searchArtistCandidates");
+    const artistId = await makeArtist(`Backfill Band ${Date.now()}`);
+    await addItem(artistId, "Backfilled", "mbid-backfill");
+
+    await backfillArtistMbidsFromItems();
+
+    const row = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(row?.musicbrainzArtistId).toBe("mbid-backfill");
+    expect(row?.mbidConfidence).toBe("confirmed");
+    expect(row?.mbidResolvedAt).toBeInstanceOf(Date);
+    expect(searchSpy).not.toHaveBeenCalled();
+  });
+
+  test("leaves an already-resolved artist alone", async () => {
+    const artistId = await makeArtist(`Already Resolved ${Date.now()}`);
+    await setArtistMbid(artistId, "user-confirmed");
+    await addItem(artistId, "Different", "mbid-from-scan");
+
+    await backfillArtistMbidsFromItems();
+
+    const row = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(row?.musicbrainzArtistId).toBe("user-confirmed");
+  });
+});
+
+describe("resolveArtistMbid", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("prefers an MBID already on the artist's items over any lookup", async () => {
+    const releaseSpy = spyOn(musicbrainz, "lookupRelease");
+    const searchSpy = spyOn(musicbrainz, "searchArtistCandidates");
+    const artistId = await makeArtist(`Ladder One ${Date.now()}`);
+    await addItem(artistId, "Known", "mbid-from-item");
+
+    const result = await resolveArtistMbid(artistId);
+
+    expect(result).toEqual({ mbid: "mbid-from-item", confidence: "confirmed" });
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(searchSpy).not.toHaveBeenCalled();
+  });
+
+  test("falls back to a known release, which pins the artist through a record", async () => {
+    const releaseSpy = spyOn(musicbrainz, "lookupRelease").mockResolvedValue({
+      year: 1974,
+      label: null,
+      country: null,
+      catalogueNumber: null,
+      musicbrainzReleaseId: "release-id",
+      musicbrainzArtistId: "mbid-from-release",
+    });
+    const searchSpy = spyOn(musicbrainz, "searchArtistCandidates");
+    const artistId = await makeArtist(`Ladder Two ${Date.now()}`);
+    await addItem(artistId, "On the Beach");
+
+    const result = await resolveArtistMbid(artistId);
+
+    expect(result.mbid).toBe("mbid-from-release");
+    expect(result.confidence).toBe("confirmed");
+    expect(releaseSpy).toHaveBeenCalled();
+    // The name search is a last resort, not a parallel path.
+    expect(searchSpy).not.toHaveBeenCalled();
+  });
+
+  test("falls through to the name search when the release lookup yields nothing", async () => {
+    spyOn(musicbrainz, "lookupRelease").mockResolvedValue(null);
+    spyOn(musicbrainz, "searchArtistCandidates").mockResolvedValue([
+      candidate({ id: "mbid-from-search", score: 100 }),
+    ]);
+    const artistId = await makeArtist(`Ladder Three ${Date.now()}`);
+    await addItem(artistId, "Obscure");
+
+    const result = await resolveArtistMbid(artistId);
+
+    expect(result.mbid).toBe("mbid-from-search");
+    expect(result.confidence).toBe("probable");
+  });
+
+  test("stores unresolved — and the attempt time — when the search is ambiguous", async () => {
+    spyOn(musicbrainz, "lookupRelease").mockResolvedValue(null);
+    spyOn(musicbrainz, "searchArtistCandidates").mockResolvedValue([
+      candidate({ id: "one", score: 100 }),
+      candidate({ id: "two", score: 99 }),
+    ]);
+    const artistId = await makeArtist(`Ambiguous Band ${Date.now()}`);
+    await addItem(artistId, "Which One");
+
+    const result = await resolveArtistMbid(artistId);
+
+    expect(result.mbid).toBeNull();
+    const row = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(row?.musicbrainzArtistId).toBeNull();
+    expect(row?.mbidConfidence).toBe("unresolved");
+    // Stamped so the artist isn't re-searched on every sweep.
+    expect(row?.mbidResolvedAt).toBeInstanceOf(Date);
+  });
+
+  test("a failing search resolves to unresolved rather than throwing", async () => {
+    spyOn(musicbrainz, "lookupRelease").mockResolvedValue(null);
+    spyOn(musicbrainz, "searchArtistCandidates").mockRejectedValue(
+      new musicbrainz.MusicBrainzHttpError(503, "rate limited"),
+    );
+    const artistId = await makeArtist(`Failing Search ${Date.now()}`);
+    await addItem(artistId, "Unreachable");
+
+    const result = await resolveArtistMbid(artistId);
+
+    expect(result.confidence).toBe("unresolved");
+  });
+});
+
+describe("setArtistMbid", () => {
+  test("confirming an MBID queues an immediate poll and clears the failure count", async () => {
+    const artistId = await makeArtist(`Confirmed Band ${Date.now()}`);
+    await db
+      .update(artists)
+      .set({ pollFailureCount: 4, nextPollAt: new Date(Date.now() + 7 * 24 * 3600_000) })
+      .where(eq(artists.id, artistId));
+
+    expect(await setArtistMbid(artistId, "mbid-picked")).toBe(true);
+
+    const row = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(row?.musicbrainzArtistId).toBe("mbid-picked");
+    expect(row?.mbidConfidence).toBe("confirmed");
+    expect(row?.pollFailureCount).toBe(0);
+    expect(row!.nextPollAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+});

--- a/tests/unit/artist-watch.test.ts
+++ b/tests/unit/artist-watch.test.ts
@@ -1,0 +1,690 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import * as musicbrainz from "../../server/musicbrainz";
+import { db } from "../../server/db/index";
+import { artistReleases, artists, musicItems, releaseAlerts } from "../../server/db/schema";
+import { normalize } from "../../server/utils";
+import {
+  alertReasonFor,
+  earliestInstant,
+  isAnnouncedRelease,
+  listTrackedArtists,
+  nextPollInterval,
+  parseReleaseYear,
+  passesNoiseFilters,
+  pollArtist,
+  remindAtForReleaseDate,
+  sweepArtistReleases,
+  type TrackedArtistRow,
+} from "../../server/artist-watch";
+import {
+  DEFAULT_ARTIST_WATCH_SETTINGS,
+  setArtistWatchSettings,
+  type ArtistWatchSettings,
+} from "../../server/settings";
+
+const NOW = new Date("2026-07-31T00:00:00.000Z");
+
+function settings(overrides: Partial<ArtistWatchSettings> = {}): ArtistWatchSettings {
+  return { ...DEFAULT_ARTIST_WATCH_SETTINGS, ...overrides };
+}
+
+function group(overrides: Partial<musicbrainz.MbReleaseGroup> = {}): musicbrainz.MbReleaseGroup {
+  return {
+    id: `rg-${Math.random().toString(36).slice(2)}`,
+    title: "A Record",
+    primaryType: "Album",
+    secondaryTypes: [],
+    firstReleaseDate: "2026-06-01",
+    ...overrides,
+  };
+}
+
+/** An artist with one listened item — the derived tracking rule's happy path. */
+async function makeTrackedArtist(
+  name: string,
+  options: { listenStatus?: "to-listen" | "listened"; followState?: string; mbid?: string } = {},
+): Promise<TrackedArtistRow> {
+  const [artist] = await db
+    .insert(artists)
+    .values({
+      name,
+      normalizedName: normalize(name),
+      musicbrainzArtistId: options.mbid ?? `mbid-${normalize(name).replace(/\W+/g, "-")}`,
+      mbidConfidence: "confirmed",
+      followState: options.followState ?? "auto",
+    })
+    .returning({ id: artists.id });
+
+  await db.insert(musicItems).values({
+    title: `${name} Debut`,
+    normalizedTitle: normalize(`${name} Debut`),
+    artistId: artist.id,
+    listenStatus: options.listenStatus ?? "listened",
+  });
+
+  return (await db
+    .select({
+      id: artists.id,
+      name: artists.name,
+      musicbrainzArtistId: artists.musicbrainzArtistId,
+      mbidConfidence: artists.mbidConfidence,
+      followState: artists.followState,
+      lastPolledAt: artists.lastPolledAt,
+      nextPollAt: artists.nextPollAt,
+      pollFailureCount: artists.pollFailureCount,
+    })
+    .from(artists)
+    .where(eq(artists.id, artist.id))
+    .get())!;
+}
+
+async function reload(artistId: number): Promise<TrackedArtistRow> {
+  return (await db
+    .select({
+      id: artists.id,
+      name: artists.name,
+      musicbrainzArtistId: artists.musicbrainzArtistId,
+      mbidConfidence: artists.mbidConfidence,
+      followState: artists.followState,
+      lastPolledAt: artists.lastPolledAt,
+      nextPollAt: artists.nextPollAt,
+      pollFailureCount: artists.pollFailureCount,
+    })
+    .from(artists)
+    .where(eq(artists.id, artistId))
+    .get())!;
+}
+
+async function alertsFor(artistId: number) {
+  return db.select().from(releaseAlerts).where(eq(releaseAlerts.artistId, artistId));
+}
+
+// ---------------------------------------------------------------------------
+// Dates
+// ---------------------------------------------------------------------------
+
+describe("release date parsing", () => {
+  test("reads the year out of every MusicBrainz date shape", () => {
+    expect(parseReleaseYear("1974")).toBe(1974);
+    expect(parseReleaseYear("1974-05")).toBe(1974);
+    expect(parseReleaseYear("1974-05-01")).toBe(1974);
+    expect(parseReleaseYear(null)).toBeNull();
+    expect(parseReleaseYear("")).toBeNull();
+  });
+
+  test("the earliest instant of a partial date is the start of its period", () => {
+    expect(earliestInstant("1974")?.toISOString()).toBe("1974-01-01T00:00:00.000Z");
+    expect(earliestInstant("1974-05")?.toISOString()).toBe("1974-05-01T00:00:00.000Z");
+    expect(earliestInstant("1974-05-09")?.toISOString()).toBe("1974-05-09T00:00:00.000Z");
+  });
+});
+
+describe("remindAtForReleaseDate", () => {
+  test("a full future date schedules that day", () => {
+    expect(remindAtForReleaseDate("2026-09-18", NOW)?.toISOString()).toBe(
+      "2026-09-18T00:00:00.000Z",
+    );
+  });
+
+  test("a future year-month schedules the 1st of that month", () => {
+    expect(remindAtForReleaseDate("2026-09", NOW)?.toISOString()).toBe("2026-09-01T00:00:00.000Z");
+  });
+
+  test("a future year schedules the 1st of January", () => {
+    expect(remindAtForReleaseDate("2027", NOW)?.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  test("a year-only date in the current year is not scheduled", () => {
+    // It may already have passed — scheduling it would be scheduling into the
+    // past, so the item goes straight to To Listen instead.
+    expect(remindAtForReleaseDate("2026", NOW)).toBeNull();
+  });
+
+  test("a date already gone by is not scheduled", () => {
+    expect(remindAtForReleaseDate("2026-01-15", NOW)).toBeNull();
+    expect(remindAtForReleaseDate("1974", NOW)).toBeNull();
+  });
+
+  test("no date at all is not scheduled", () => {
+    expect(remindAtForReleaseDate(null, NOW)).toBeNull();
+  });
+
+  test("announced-ness and schedulability are the same question", () => {
+    expect(isAnnouncedRelease("2026-09-18", NOW)).toBe(true);
+    expect(isAnnouncedRelease("2026", NOW)).toBe(false);
+    expect(isAnnouncedRelease("1974", NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alert eligibility
+// ---------------------------------------------------------------------------
+
+describe("noise filters", () => {
+  test("skips excluded secondary types", () => {
+    const excluded = DEFAULT_ARTIST_WATCH_SETTINGS.excludedSecondaryTypes;
+    expect(
+      passesNoiseFilters(
+        { primaryType: "Album", secondaryTypes: ["Live"], firstReleaseDate: "2026-06" },
+        excluded,
+      ),
+    ).toBe(false);
+    expect(
+      passesNoiseFilters(
+        { primaryType: "Album", secondaryTypes: [], firstReleaseDate: "2026-06" },
+        excluded,
+      ),
+    ).toBe(true);
+  });
+
+  test("skips the 'other' primary type", () => {
+    expect(
+      passesNoiseFilters(
+        { primaryType: "Other", secondaryTypes: [], firstReleaseDate: "2026-06" },
+        [],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("alertReasonFor", () => {
+  test("a future-dated release is announced", () => {
+    expect(
+      alertReasonFor(
+        { primaryType: "Album", secondaryTypes: [], firstReleaseDate: "2026-09-18" },
+        settings(),
+        NOW,
+      ),
+    ).toBe("announced");
+  });
+
+  test("a future-dated release alerts even outside the freshness window", () => {
+    // The window is an age filter; "the future" is never too old.
+    expect(
+      alertReasonFor(
+        { primaryType: "Album", secondaryTypes: [], firstReleaseDate: "2027-03-01" },
+        settings({ freshnessMonths: 1 }),
+        NOW,
+      ),
+    ).toBe("announced");
+  });
+
+  test("a recent release is a new release", () => {
+    expect(
+      alertReasonFor(
+        { primaryType: "Album", secondaryTypes: [], firstReleaseDate: "2026-03-01" },
+        settings(),
+        NOW,
+      ),
+    ).toBe("new-release");
+  });
+
+  test("an old release stays quiet unless catalogue additions are on", () => {
+    const old = { primaryType: "Album", secondaryTypes: [], firstReleaseDate: "1978-04-01" };
+
+    expect(alertReasonFor(old, settings(), NOW)).toBeNull();
+    expect(alertReasonFor(old, settings({ alertOnCatalogueAdditions: true }), NOW)).toBe(
+      "catalogue-addition",
+    );
+  });
+
+  test("a dateless release only surfaces as a catalogue addition", () => {
+    const undated = { primaryType: "Album", secondaryTypes: [], firstReleaseDate: null };
+
+    expect(alertReasonFor(undated, settings(), NOW)).toBeNull();
+    expect(alertReasonFor(undated, settings({ alertOnCatalogueAdditions: true }), NOW)).toBe(
+      "catalogue-addition",
+    );
+  });
+
+  test("a filtered type never alerts, however fresh", () => {
+    expect(
+      alertReasonFor(
+        { primaryType: "Album", secondaryTypes: ["Compilation"], firstReleaseDate: "2026-09-18" },
+        settings({ alertOnCatalogueAdditions: true }),
+        NOW,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("nextPollInterval", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  test("an active artist is polled weekly", () => {
+    expect(nextPollInterval(2026, NOW, 0.5)).toBe(7 * DAY);
+  });
+
+  test("a semi-dormant artist waits three weeks", () => {
+    expect(nextPollInterval(2020, NOW, 0.5)).toBe(21 * DAY);
+  });
+
+  test("a long-dormant artist waits two months", () => {
+    expect(nextPollInterval(1978, NOW, 0.5)).toBe(60 * DAY);
+  });
+
+  test("an artist with no dated releases is treated as dormant", () => {
+    expect(nextPollInterval(null, NOW, 0.5)).toBe(60 * DAY);
+  });
+
+  test("jitter spreads an import batch by ±20%", () => {
+    expect(nextPollInterval(2026, NOW, 0)).toBe(Math.round(7 * DAY * 0.8));
+    expect(nextPollInterval(2026, NOW, 1)).toBe(Math.round(7 * DAY * 1.2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Polling
+// ---------------------------------------------------------------------------
+
+describe("pollArtist", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("the first poll is a silent baseline", async () => {
+    const groups = [group({ id: "rg-base-1" }), group({ id: "rg-base-2" })];
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue(groups);
+    const artist = await makeTrackedArtist(`Baseline Band ${Date.now()}`);
+
+    const outcome = await pollArtist(artist, settings(), NOW);
+
+    expect(outcome.baseline).toBe(true);
+    expect(outcome.newReleases).toBe(2);
+    expect(outcome.alertsRaised).toBe(0);
+    expect(await alertsFor(artist.id)).toHaveLength(0);
+
+    const stored = await db
+      .select()
+      .from(artistReleases)
+      .where(eq(artistReleases.artistId, artist.id));
+    expect(stored).toHaveLength(2);
+    expect(stored.every((row) => row.isBaseline)).toBe(true);
+  });
+
+  test("a group first seen after the baseline raises one alert", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-known" }),
+    ]);
+    const artist = await makeTrackedArtist(`Diffing Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-known" }),
+      group({ id: "rg-new", title: "Brand New", firstReleaseDate: "2026-07-01" }),
+    ]);
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.baseline).toBe(false);
+    expect(outcome.alertsRaised).toBe(1);
+    const alerts = await alertsFor(artist.id);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].status).toBe("pending");
+    expect(alerts[0].reason).toBe("new-release");
+  });
+
+  test("re-polling the same discography raises nothing further", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-idem" }),
+    ]);
+    const artist = await makeTrackedArtist(`Idempotent Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([group({ id: "rg-idem" }), group({ id: "rg-idem-new" })]);
+    await pollArtist(await reload(artist.id), settings(), NOW);
+    const after = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(after.alertsRaised).toBe(0);
+    expect(await alertsFor(artist.id)).toHaveLength(1);
+  });
+
+  test("filtered secondary types are recorded but never alert", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-filter-base" }),
+    ]);
+    const artist = await makeTrackedArtist(`Filtered Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-filter-base" }),
+      group({ id: "rg-live", secondaryTypes: ["Live"], firstReleaseDate: "2026-07-01" }),
+    ]);
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.newReleases).toBe(1);
+    expect(outcome.alertsRaised).toBe(0);
+  });
+
+  test("a future-dated release alerts as announced, freshness window notwithstanding", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-announced-base" }),
+    ]);
+    const artist = await makeTrackedArtist(`Announced Band ${Date.now()}`);
+    await pollArtist(artist, settings({ freshnessMonths: 0 }), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-announced-base" }),
+      group({ id: "rg-announced", firstReleaseDate: "2026-09-18" }),
+    ]);
+    await pollArtist(await reload(artist.id), settings({ freshnessMonths: 0 }), NOW);
+
+    const alerts = await alertsFor(artist.id);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].reason).toBe("announced");
+  });
+
+  test("caps alerts at three per sweep and carries the rest to the next one", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-cap-base" }),
+    ]);
+    const artist = await makeTrackedArtist(`Prolific Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-cap-base" }),
+      ...Array.from({ length: 5 }, (_unused, index) =>
+        group({ id: `rg-cap-${index}`, firstReleaseDate: `2026-0${index + 1}-01` }),
+      ),
+    ]);
+
+    const first = await pollArtist(await reload(artist.id), settings(), NOW);
+    expect(first.alertsRaised).toBe(3);
+
+    const second = await pollArtist(await reload(artist.id), settings(), NOW);
+    expect(second.alertsRaised).toBe(2);
+    expect(await alertsFor(artist.id)).toHaveLength(5);
+  });
+
+  test("turning catalogue additions on surfaces history already captured", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-archive-base" }),
+    ]);
+    const artist = await makeTrackedArtist(`Archive Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-archive-base" }),
+      group({ id: "rg-archive-old", firstReleaseDate: "1978-04-01" }),
+    ]);
+    const quiet = await pollArtist(await reload(artist.id), settings(), NOW);
+    expect(quiet.alertsRaised).toBe(0);
+
+    // No re-scan needed: the group was recorded all along.
+    const loud = await pollArtist(
+      await reload(artist.id),
+      settings({ alertOnCatalogueAdditions: true }),
+      NOW,
+    );
+    expect(loud.alertsRaised).toBe(1);
+    expect((await alertsFor(artist.id))[0].reason).toBe("catalogue-addition");
+  });
+
+  test("a failed poll backs off and keeps the artist's baseline", async () => {
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([group({ id: "rg-fail" })]);
+    const artist = await makeTrackedArtist(`Flaky Band ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+    const polledAt = (await reload(artist.id)).lastPolledAt;
+
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockRejectedValue(new Error("network down"));
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.status).toBe("failed");
+    const row = await reload(artist.id);
+    expect(row.pollFailureCount).toBe(1);
+    // 2^1 hours out.
+    expect(row.nextPollAt!.getTime()).toBe(NOW.getTime() + 2 * 60 * 60 * 1000);
+    // Untouched, so the next successful poll isn't mistaken for a baseline.
+    expect(row.lastPolledAt?.getTime()).toBe(polledAt?.getTime());
+  });
+
+  test("backoff is exponential and capped at seven days", async () => {
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockRejectedValue(new Error("still down"));
+    const artist = await makeTrackedArtist(`Backoff Band ${Date.now()}`);
+    await db.update(artists).set({ pollFailureCount: 20 }).where(eq(artists.id, artist.id));
+
+    await pollArtist(await reload(artist.id), settings(), NOW);
+
+    const row = await reload(artist.id);
+    expect(row.nextPollAt!.getTime()).toBe(NOW.getTime() + 7 * 24 * 60 * 60 * 1000);
+  });
+
+  test("a successful poll clears the failure count and schedules the next one", async () => {
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-recover", firstReleaseDate: "2026-01-01" }),
+    ]);
+    const artist = await makeTrackedArtist(`Recovering Band ${Date.now()}`);
+    await db.update(artists).set({ pollFailureCount: 3 }).where(eq(artists.id, artist.id));
+
+    await pollArtist(await reload(artist.id), settings(), NOW);
+
+    const row = await reload(artist.id);
+    expect(row.pollFailureCount).toBe(0);
+    expect(row.lastPolledAt?.getTime()).toBe(NOW.getTime());
+    expect(row.nextPollAt!.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  test("a 503 is reported as rate limiting so the sweep can pause", async () => {
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockRejectedValue(
+      new musicbrainz.MusicBrainzHttpError(503, "slow down"),
+    );
+    const artist = await makeTrackedArtist(`Throttled Band ${Date.now()}`);
+
+    const outcome = await pollArtist(artist, settings(), NOW);
+
+    expect(outcome.rateLimited).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date drift
+// ---------------------------------------------------------------------------
+
+describe("date drift reconciliation", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  /** An accepted alert whose item carries a reminder this system created. */
+  async function acceptedAnnouncedRelease(name: string) {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-drift-base" }),
+    ]);
+    const artist = await makeTrackedArtist(name);
+    await pollArtist(artist, settings(), NOW);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-drift-base" }),
+      group({ id: "rg-drift", title: "Delayed", firstReleaseDate: "2026-09-18" }),
+    ]);
+    await pollArtist(await reload(artist.id), settings(), NOW);
+
+    const [item] = await db
+      .insert(musicItems)
+      .values({
+        title: "Delayed",
+        normalizedTitle: "delayed",
+        artistId: artist.id,
+        remindAt: new Date("2026-09-18T00:00:00.000Z"),
+      })
+      .returning({ id: musicItems.id });
+
+    const release = (await db
+      .select()
+      .from(artistReleases)
+      .where(
+        and(
+          eq(artistReleases.artistId, artist.id),
+          eq(artistReleases.mbReleaseGroupId, "rg-drift"),
+        ),
+      )
+      .get())!;
+    await db
+      .update(releaseAlerts)
+      .set({ status: "added", musicItemId: item.id })
+      .where(eq(releaseAlerts.artistReleaseId, release.id));
+
+    return { artist, itemId: item.id, mbSpy };
+  }
+
+  test("a slipped date moves the reminder we created", async () => {
+    const { artist, itemId, mbSpy } = await acceptedAnnouncedRelease(`Drift Band ${Date.now()}`);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-drift-base" }),
+      group({ id: "rg-drift", title: "Delayed", firstReleaseDate: "2026-11-20" }),
+    ]);
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.rescheduled).toBe(1);
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, itemId)).get();
+    expect(item?.remindAt?.toISOString()).toBe("2026-11-20T00:00:00.000Z");
+  });
+
+  test("a date removed from MusicBrainz un-schedules the item", async () => {
+    // A reminder derived from a value MusicBrainz has retracted asserts
+    // something nobody stands behind any more; the item falls into To Listen.
+    const { artist, itemId, mbSpy } = await acceptedAnnouncedRelease(`Retracted ${Date.now()}`);
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-drift-base" }),
+      group({ id: "rg-drift", title: "Delayed", firstReleaseDate: null }),
+    ]);
+    await pollArtist(await reload(artist.id), settings(), NOW);
+
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, itemId)).get();
+    expect(item?.remindAt).toBeNull();
+  });
+
+  test("a reminder the user set themselves is never touched", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-manual", firstReleaseDate: "2026-09-18" }),
+    ]);
+    const artist = await makeTrackedArtist(`Manual Reminder ${Date.now()}`);
+    await pollArtist(artist, settings(), NOW);
+
+    // An item with a reminder but no alert linking it to the release.
+    const userDate = new Date("2026-12-25T00:00:00.000Z");
+    const [item] = await db
+      .insert(musicItems)
+      .values({
+        title: "Hand Scheduled",
+        normalizedTitle: "hand scheduled",
+        artistId: artist.id,
+        remindAt: userDate,
+      })
+      .returning({ id: musicItems.id });
+
+    mbSpy.mockResolvedValue([group({ id: "rg-manual", firstReleaseDate: "2027-02-01" })]);
+    await pollArtist(await reload(artist.id), settings(), NOW);
+
+    const row = await db.select().from(musicItems).where(eq(musicItems.id, item.id)).get();
+    expect(row?.remindAt?.getTime()).toBe(userDate.getTime());
+  });
+
+  test("a reminder that has already fired is left alone", async () => {
+    const { artist, itemId, mbSpy } = await acceptedAnnouncedRelease(
+      `Fired Reminder ${Date.now()}`,
+    );
+    await db.update(musicItems).set({ reminderPending: true }).where(eq(musicItems.id, itemId));
+
+    mbSpy.mockResolvedValue([
+      group({ id: "rg-drift-base" }),
+      group({ id: "rg-drift", title: "Delayed", firstReleaseDate: "2027-01-05" }),
+    ]);
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.rescheduled).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Which artists get tracked, and the sweep around them
+// ---------------------------------------------------------------------------
+
+describe("tracked artists", () => {
+  test("a listened artist is tracked; a to-listen-only artist is not", async () => {
+    const listened = await makeTrackedArtist(`Listened Only ${Date.now()}`);
+    const queued = await makeTrackedArtist(`Queued Only ${Date.now()}`, {
+      listenStatus: "to-listen",
+    });
+
+    const tracked = (await listTrackedArtists()).map((artist) => artist.id);
+
+    expect(tracked).toContain(listened.id);
+    expect(tracked).not.toContain(queued.id);
+  });
+
+  test("follow_state 'always' tracks an artist with nothing listened", async () => {
+    const forced = await makeTrackedArtist(`Always Followed ${Date.now()}`, {
+      listenStatus: "to-listen",
+      followState: "always",
+    });
+
+    expect((await listTrackedArtists()).map((a) => a.id)).toContain(forced.id);
+  });
+
+  test("muted beats everything", async () => {
+    const muted = await makeTrackedArtist(`Muted Band ${Date.now()}`, { followState: "muted" });
+
+    expect((await listTrackedArtists()).map((a) => a.id)).not.toContain(muted.id);
+  });
+});
+
+describe("sweepArtistReleases", () => {
+  beforeEach(async () => {
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+    process.env.OTB_ARTIST_WATCH_THROTTLE_MS = "0";
+    await setArtistWatchSettings(DEFAULT_ARTIST_WATCH_SETTINGS);
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    delete process.env.OTB_ARTIST_WATCH_THROTTLE_MS;
+    await setArtistWatchSettings(DEFAULT_ARTIST_WATCH_SETTINGS);
+  });
+
+  test("no-ops under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups");
+    await makeTrackedArtist(`Disabled Sweep ${Date.now()}`);
+
+    await sweepArtistReleases(NOW);
+
+    expect(mbSpy).not.toHaveBeenCalled();
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+  });
+
+  test("no-ops when the master switch is off", async () => {
+    await setArtistWatchSettings({ enabled: false });
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups");
+    await makeTrackedArtist(`Switched Off ${Date.now()}`);
+
+    await sweepArtistReleases(NOW);
+
+    expect(mbSpy).not.toHaveBeenCalled();
+  });
+
+  test("polls a due artist and leaves one that isn't due alone", async () => {
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-sweep" }),
+    ]);
+    spyOn(musicbrainz, "searchArtistCandidates").mockResolvedValue([]);
+    spyOn(musicbrainz, "lookupRelease").mockResolvedValue(null);
+
+    const due = await makeTrackedArtist(`Sweep Due ${Date.now()}`, { mbid: "mbid-sweep-due" });
+    const notDue = await makeTrackedArtist(`Sweep Later ${Date.now()}`, {
+      mbid: "mbid-sweep-later",
+    });
+    await db
+      .update(artists)
+      .set({ nextPollAt: new Date(NOW.getTime() + 7 * 24 * 3600_000), lastPolledAt: NOW })
+      .where(eq(artists.id, notDue.id));
+
+    await sweepArtistReleases(NOW);
+
+    expect(mbSpy).toHaveBeenCalledWith("mbid-sweep-due");
+    expect(mbSpy).not.toHaveBeenCalledWith("mbid-sweep-later");
+    expect((await reload(due.id)).lastPolledAt).not.toBeNull();
+  });
+});

--- a/tests/unit/artist-watch.test.ts
+++ b/tests/unit/artist-watch.test.ts
@@ -303,6 +303,38 @@ describe("pollArtist", () => {
     expect(stored.every((row) => row.isBaseline)).toBe(true);
   });
 
+  test("an interrupted baseline resumes as a baseline rather than alerting", async () => {
+    // A process that dies mid-baseline leaves rows behind but never stamps
+    // `last_polled_at`. The rest of the discography must not then drip out as
+    // alerts on the next poll.
+    const artist = await makeTrackedArtist(`Interrupted Band ${Date.now()}`);
+    await db.insert(artistReleases).values({
+      artistId: artist.id,
+      mbReleaseGroupId: "rg-partial",
+      title: "Got There First",
+      normalizedTitle: normalize("Got There First"),
+      primaryType: "Album",
+      secondaryTypes: "[]",
+      firstReleaseDate: "2026-06-01",
+      firstReleaseYear: 2026,
+      isBaseline: true,
+      firstSeenAt: NOW,
+    });
+
+    spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-partial" }),
+      group({ id: "rg-rest-1" }),
+      group({ id: "rg-rest-2" }),
+    ]);
+
+    const outcome = await pollArtist(await reload(artist.id), settings(), NOW);
+
+    expect(outcome.baseline).toBe(true);
+    expect(outcome.newReleases).toBe(2);
+    expect(outcome.alertsRaised).toBe(0);
+    expect(await alertsFor(artist.id)).toHaveLength(0);
+  });
+
   test("a group first seen after the baseline raises one alert", async () => {
     const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
       group({ id: "rg-known" }),

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { lookupRelease, findSuggestedRelease } from "../../server/musicbrainz";
+import {
+  lookupRelease,
+  findSuggestedRelease,
+  fetchArtistReleaseGroups,
+  searchArtistCandidates,
+  MusicBrainzHttpError,
+} from "../../server/musicbrainz";
 
 function makeMbArtistSearchResponse(artists: unknown[]): Response {
   return new Response(JSON.stringify({ artists }), {
@@ -463,5 +469,144 @@ describe("lookupRelease", () => {
     const result = await lookupRelease("Artist", "Title");
     expect(result?.musicbrainzReleaseId).toBeNull();
     expect(result?.musicbrainzArtistId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release groups & artist search (artist watch)
+// ---------------------------------------------------------------------------
+
+function makeReleaseGroupResponse(groups: unknown[]): Response {
+  return new Response(JSON.stringify({ "release-groups": groups }), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function releaseGroup(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: `rg-${Math.random().toString(36).slice(2)}`,
+    title: "A Record",
+    "primary-type": "Album",
+    "secondary-types": [],
+    "first-release-date": "2026-06-01",
+    ...overrides,
+  };
+}
+
+describe("fetchArtistReleaseGroups", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("parses a page of release groups", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeReleaseGroupResponse([
+        releaseGroup({
+          id: "rg-1",
+          title: "On the Beach",
+          "secondary-types": ["Live"],
+          "first-release-date": "1974-07-19",
+        }),
+      ]),
+    );
+
+    const groups = await fetchArtistReleaseGroups("artist-uuid");
+
+    expect(groups).toEqual([
+      {
+        id: "rg-1",
+        title: "On the Beach",
+        primaryType: "Album",
+        secondaryTypes: ["Live"],
+        firstReleaseDate: "1974-07-19",
+      },
+    ]);
+  });
+
+  test("keeps a missing first-release-date as null rather than inventing one", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeReleaseGroupResponse([releaseGroup({ "first-release-date": "" })]),
+    );
+
+    const groups = await fetchArtistReleaseGroups("artist-uuid");
+
+    expect(groups[0].firstReleaseDate).toBeNull();
+  });
+
+  test("paginates only when a page comes back full", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        makeReleaseGroupResponse(Array.from({ length: 100 }, () => releaseGroup())),
+      )
+      .mockResolvedValueOnce(makeReleaseGroupResponse([releaseGroup()]));
+
+    const groups = await fetchArtistReleaseGroups("artist-uuid");
+
+    expect(groups).toHaveLength(101);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[1][0])).toContain("offset=100");
+  });
+
+  test("throws with the status so the caller can tell a 503 from a miss", async () => {
+    // A partial fetch must never be written as a baseline: every group it
+    // missed would alert as new on the next successful poll.
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("", { status: 503 }));
+
+    let caught: unknown;
+    try {
+      await fetchArtistReleaseGroups("artist-uuid");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(MusicBrainzHttpError);
+    expect((caught as MusicBrainzHttpError).status).toBe(503);
+  });
+});
+
+describe("searchArtistCandidates", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns the fields a human needs to tell two artists apart", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistSearchResponse([
+        {
+          id: "us-band",
+          name: "Nirvana",
+          score: 100,
+          disambiguation: "90s US grunge band",
+          country: "US",
+          type: "Group",
+          "life-span": { begin: "1987", end: "1994" },
+        },
+      ]),
+    );
+
+    const candidates = await searchArtistCandidates("Nirvana");
+
+    expect(candidates).toEqual([
+      {
+        id: "us-band",
+        name: "Nirvana",
+        score: 100,
+        disambiguation: "90s US grunge band",
+        country: "US",
+        type: "Group",
+        lifeSpanBegin: "1987",
+        lifeSpanEnd: "1994",
+      },
+    ]);
+  });
+
+  test("skips malformed entries rather than failing the whole search", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistSearchResponse([{ name: "No Id" }, { id: "ok", name: "Real", score: 90 }]),
+    );
+
+    const candidates = await searchArtistCandidates("Whoever");
+
+    expect(candidates.map((candidate) => candidate.id)).toEqual(["ok"]);
   });
 });

--- a/tests/unit/preload.ts
+++ b/tests/unit/preload.ts
@@ -13,3 +13,10 @@ if (!process.env.DATABASE_PATH) {
     `on-the-beach-unit-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
   );
 }
+
+// server/musicbrainz.ts paces every outbound request through a shared gate so
+// the two background sweeps together stay inside MusicBrainz's ~1 req/s. Unit
+// tests mock `fetch`, so the pacing buys nothing and costs a second per call.
+if (process.env.OTB_MB_MIN_REQUEST_GAP_MS === undefined) {
+  process.env.OTB_MB_MIN_REQUEST_GAP_MS = "0";
+}

--- a/tests/unit/release-alerts-route.test.ts
+++ b/tests/unit/release-alerts-route.test.ts
@@ -220,6 +220,32 @@ describe("POST /api/release-alerts/:id/add", () => {
     expect(second.status).toBe(404);
   });
 
+  test("concurrent accepts create exactly one item", async () => {
+    // The sequential case above is covered by the status check; this is the
+    // interleaved one it can't catch. Both requests read the alert as
+    // acceptable before either writes, so only an atomic claim keeps them from
+    // both creating an item for the same release.
+    const { alertId } = await makeAlert({ title: "Raced Record" });
+    const app = makeApp();
+
+    const responses = await Promise.all([
+      app.request(`http://localhost/api/release-alerts/${alertId}/add`, { method: "POST" }),
+      app.request(`http://localhost/api/release-alerts/${alertId}/add`, { method: "POST" }),
+    ]);
+
+    expect(responses.filter((res) => res.ok)).toHaveLength(1);
+
+    const created = await db
+      .select({ id: musicItems.id })
+      .from(musicItems)
+      .where(eq(musicItems.normalizedTitle, normalize("Raced Record")));
+    expect(created).toHaveLength(1);
+
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("added");
+    expect(alert?.musicItemId).toBe(created[0].id);
+  });
+
   test("404s for an alert that doesn't exist", async () => {
     const app = makeApp();
     const res = await app.request("http://localhost/api/release-alerts/999999/add", {
@@ -296,13 +322,30 @@ describe("PUT /api/artists/:id/mbid", () => {
     const res = await app.request(`http://localhost/api/artists/${artistId}/mbid`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ musicbrainzArtistId: "picked-by-hand" }),
+      body: JSON.stringify({ musicbrainzArtistId: "a74b1b7f-71a5-4011-9441-d0b5e4122711" }),
     });
     expect(res.status).toBe(200);
 
     const artist = await db.select().from(artists).where(eq(artists.id, artistId)).get();
-    expect(artist?.musicbrainzArtistId).toBe("picked-by-hand");
+    expect(artist?.musicbrainzArtistId).toBe("a74b1b7f-71a5-4011-9441-d0b5e4122711");
     expect(artist?.mbidConfidence).toBe("confirmed");
+  });
+
+  test("rejects an MBID that isn't a UUID", async () => {
+    // A confirmed MBID drives every future poll, so a paste error should fail
+    // here rather than as a run of MusicBrainz 404s weeks later.
+    const { artistId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/artists/${artistId}/mbid`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ musicbrainzArtistId: "picked-by-hand" }),
+    });
+    expect(res.status).toBe(400);
+
+    const artist = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(artist?.musicbrainzArtistId).not.toBe("picked-by-hand");
   });
 
   test("rejects a missing MBID", async () => {

--- a/tests/unit/release-alerts-route.test.ts
+++ b/tests/unit/release-alerts-route.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { db } from "../../server/db/index";
+import {
+  artistReleases,
+  artists,
+  musicItemStacks,
+  musicItems,
+  releaseAlerts,
+  stacks,
+} from "../../server/db/schema";
+import { normalize } from "../../server/utils";
+import { createReleaseAlertRoutes } from "../../server/routes/release-alerts";
+import { createArtistRoutes } from "../../server/routes/artists";
+import {
+  ensureNewReleasesStack,
+  itemTypeForReleaseGroup,
+  NEW_RELEASES_STACK_NAME,
+} from "../../server/release-alerts";
+import { DEFAULT_ARTIST_WATCH_SETTINGS, setArtistWatchSettings } from "../../server/settings";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/release-alerts", createReleaseAlertRoutes());
+  app.route("/api/artists", createArtistRoutes());
+  return app;
+}
+
+interface AlertFixture {
+  alertId: number;
+  artistId: number;
+  releaseId: number;
+}
+
+let sequence = 0;
+
+async function makeAlert(
+  overrides: {
+    firstReleaseDate?: string | null;
+    primaryType?: string;
+    reason?: string;
+    title?: string;
+  } = {},
+): Promise<AlertFixture> {
+  sequence += 1;
+  const name = `Alert Artist ${Date.now()}-${sequence}`;
+
+  const [artist] = await db
+    .insert(artists)
+    .values({
+      name,
+      normalizedName: normalize(name),
+      musicbrainzArtistId: `mbid-${sequence}`,
+      mbidConfidence: "confirmed",
+    })
+    .returning({ id: artists.id });
+
+  const title = overrides.title ?? `Alerted Record ${sequence}`;
+  const [release] = await db
+    .insert(artistReleases)
+    .values({
+      artistId: artist.id,
+      mbReleaseGroupId: `rg-alert-${sequence}`,
+      title,
+      normalizedTitle: normalize(title),
+      primaryType: overrides.primaryType ?? "Album",
+      secondaryTypes: "[]",
+      firstReleaseDate:
+        overrides.firstReleaseDate === undefined ? "2026-06-01" : overrides.firstReleaseDate,
+      firstReleaseYear: 2026,
+    })
+    .returning({ id: artistReleases.id });
+
+  const [alert] = await db
+    .insert(releaseAlerts)
+    .values({
+      artistId: artist.id,
+      artistReleaseId: release.id,
+      reason: overrides.reason ?? "new-release",
+    })
+    .returning({ id: releaseAlerts.id });
+
+  return { alertId: alert.id, artistId: artist.id, releaseId: release.id };
+}
+
+beforeEach(async () => {
+  // Creating an item fires the background suggestion prefetch.
+  process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+  await setArtistWatchSettings(DEFAULT_ARTIST_WATCH_SETTINGS);
+});
+
+afterEach(() => {
+  delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+});
+
+describe("itemTypeForReleaseGroup", () => {
+  test("maps MusicBrainz primary types onto our item types where they overlap", () => {
+    expect(itemTypeForReleaseGroup("Album")).toBe("album");
+    expect(itemTypeForReleaseGroup("EP")).toBe("ep");
+    expect(itemTypeForReleaseGroup("Single")).toBe("single");
+  });
+
+  test("falls back to album for types we don't model", () => {
+    expect(itemTypeForReleaseGroup("Broadcast")).toBe("album");
+    expect(itemTypeForReleaseGroup(null)).toBe("album");
+  });
+});
+
+describe("GET /api/release-alerts", () => {
+  test("returns pending alerts with the artist and release joined in", async () => {
+    const { alertId } = await makeAlert({ title: "Joined Record" });
+    const app = makeApp();
+
+    const res = await app.request("http://localhost/api/release-alerts?status=pending");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const alert = body.alerts.find((row: { id: number }) => row.id === alertId);
+    expect(alert.title).toBe("Joined Record");
+    expect(alert.artist_name).toBeTruthy();
+    expect(alert.reason).toBe("new-release");
+    expect(body.pendingCount).toBeGreaterThan(0);
+  });
+
+  test("rejects an unknown status", async () => {
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/release-alerts?status=maybe");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/release-alerts/mark-seen", () => {
+  test("clears the badge without forcing a decision on each card", async () => {
+    const { alertId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request("http://localhost/api/release-alerts/mark-seen", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    const row = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(row?.status).toBe("seen");
+  });
+});
+
+describe("POST /api/release-alerts/:id/add", () => {
+  test("creates the item and files it in the New Releases stack", async () => {
+    const { alertId } = await makeAlert({ title: "Accepted Record" });
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.item.title).toBe("Accepted Record");
+    // Already out, so nothing to schedule.
+    expect(body.remindAt).toBeNull();
+
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("added");
+    expect(alert?.musicItemId).toBe(body.item.id);
+
+    const stackId = await ensureNewReleasesStack();
+    const membership = await db
+      .select()
+      .from(musicItemStacks)
+      .where(
+        and(eq(musicItemStacks.musicItemId, body.item.id), eq(musicItemStacks.stackId, stackId)),
+      )
+      .get();
+    expect(membership).toBeDefined();
+  });
+
+  test("an announced release is handed to the reminder cron via remind_at", async () => {
+    const { alertId } = await makeAlert({
+      firstReleaseDate: "2099-09-18",
+      reason: "announced",
+    });
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(body.remindAt).toBe("2099-09-18T00:00:00.000Z");
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, body.item.id)).get();
+    expect(item?.remindAt?.toISOString()).toBe("2099-09-18T00:00:00.000Z");
+    expect(item?.reminderPending).toBe(false);
+  });
+
+  test("scheduling can be turned off, leaving the item in To Listen", async () => {
+    await setArtistWatchSettings({ scheduleAnnouncedReleases: false });
+    const { alertId } = await makeAlert({ firstReleaseDate: "2099-09-18", reason: "announced" });
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(body.remindAt).toBeNull();
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, body.item.id)).get();
+    expect(item?.remindAt).toBeNull();
+  });
+
+  test("accepting the same alert twice is a 404 rather than a second item", async () => {
+    const { alertId } = await makeAlert();
+    const app = makeApp();
+
+    await app.request(`http://localhost/api/release-alerts/${alertId}/add`, { method: "POST" });
+    const second = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+
+    expect(second.status).toBe(404);
+  });
+
+  test("404s for an alert that doesn't exist", async () => {
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/release-alerts/999999/add", {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/release-alerts/:id/dismiss", () => {
+  test("marks the alert dismissed", async () => {
+    const { alertId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/dismiss`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    const row = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(row?.status).toBe("dismissed");
+    expect(row?.resolvedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("ensureNewReleasesStack", () => {
+  test("is referenced by id, so renaming the stack doesn't fork it", async () => {
+    const stackId = await ensureNewReleasesStack();
+    await db.update(stacks).set({ name: "Fresh Cuts" }).where(eq(stacks.id, stackId));
+
+    expect(await ensureNewReleasesStack()).toBe(stackId);
+
+    // Restore so later runs in this file see the canonical name.
+    await db.update(stacks).set({ name: NEW_RELEASES_STACK_NAME }).where(eq(stacks.id, stackId));
+  });
+});
+
+describe("PUT /api/artists/:id/follow", () => {
+  test("muting an artist also clears the alerts already queued for them", async () => {
+    const { alertId, artistId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/artists/${artistId}/follow`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ followState: "muted" }),
+    });
+    expect(res.status).toBe(200);
+
+    const artist = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(artist?.followState).toBe("muted");
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("dismissed");
+  });
+
+  test("rejects an unknown follow state", async () => {
+    const { artistId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/artists/${artistId}/follow`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ followState: "sometimes" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /api/artists/:id/mbid", () => {
+  test("confirming an MBID marks it confirmed", async () => {
+    const { artistId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/artists/${artistId}/mbid`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ musicbrainzArtistId: "picked-by-hand" }),
+    });
+    expect(res.status).toBe(200);
+
+    const artist = await db.select().from(artists).where(eq(artists.id, artistId)).get();
+    expect(artist?.musicbrainzArtistId).toBe("picked-by-hand");
+    expect(artist?.mbidConfidence).toBe("confirmed");
+  });
+
+  test("rejects a missing MBID", async () => {
+    const { artistId } = await makeAlert();
+    const app = makeApp();
+
+    const res = await app.request(`http://localhost/api/artists/${artistId}/mbid`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/artists/tracked", () => {
+  test("lists tracked artists with their confidence and poll state", async () => {
+    const name = `Tracked Panel ${Date.now()}`;
+    const [artist] = await db
+      .insert(artists)
+      .values({
+        name,
+        normalizedName: normalize(name),
+        musicbrainzArtistId: "mbid-panel",
+        mbidConfidence: "probable",
+        followState: "always",
+      })
+      .returning({ id: artists.id });
+
+    const app = makeApp();
+    const body = await (await app.request("http://localhost/api/artists/tracked")).json();
+    const row = body.artists.find((entry: { id: number }) => entry.id === artist.id);
+
+    expect(row.mbid_confidence).toBe("probable");
+    expect(row.follow_state).toBe("always");
+    expect(row.last_polled_at).toBeNull();
+  });
+});

--- a/tests/unit/rss-route.test.ts
+++ b/tests/unit/rss-route.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { createRssRoutes } from "../../server/routes/rss";
 import type { MusicItemFull } from "../../src/types";
 import type { PrimaryFeedKey } from "../../shared/rss";
+import type { ReleaseAlertView } from "../../server/release-alerts";
 
 type StackInfo = { id: number; name: string };
 
@@ -39,13 +40,39 @@ function makeItem(overrides: Partial<MusicItemFull> = {}): MusicItemFull {
   };
 }
 
+function makeAlert(overrides: Partial<ReleaseAlertView> = {}): ReleaseAlertView {
+  return {
+    id: 1,
+    status: "pending",
+    reason: "announced",
+    created_at: "2026-07-31T09:00:00.000Z",
+    resolved_at: null,
+    music_item_id: null,
+    artist_id: 1,
+    artist_name: "Neil Young",
+    musicbrainz_artist_id: "mb-artist",
+    release_id: 1,
+    mb_release_group_id: "mb-release-group",
+    title: "On the Beach",
+    primary_type: "Album",
+    secondary_types: [],
+    first_release_date: "2026-09-18",
+    first_release_year: 2026,
+    ...overrides,
+  };
+}
+
 function makeApp(
   fetchStack: (stackId: number) => Promise<StackInfo | null>,
   fetchStackItems: (stackId: number) => Promise<MusicItemFull[]>,
   fetchPrimaryFeedItems: (feed: PrimaryFeedKey) => Promise<MusicItemFull[]>,
+  fetchReleaseAlerts: () => Promise<ReleaseAlertView[]> = async () => [],
 ): Hono {
   const app = new Hono();
-  app.route("/feed", createRssRoutes(fetchStack, fetchStackItems, fetchPrimaryFeedItems));
+  app.route(
+    "/feed",
+    createRssRoutes(fetchStack, fetchStackItems, fetchPrimaryFeedItems, fetchReleaseAlerts),
+  );
   return app;
 }
 
@@ -101,6 +128,72 @@ describe("GET /feed/:filter.rss", () => {
     const body = await res.text();
 
     expect(body).toContain("<title>Four Tet — Rounds</title>");
+  });
+});
+
+describe("GET /feed/new-releases.rss", () => {
+  const noStacks = mock(async (_id: number) => null);
+  const noItems = mock(async (_id: number) => []);
+  const noFeedItems = mock(async (_feed: PrimaryFeedKey) => []);
+
+  test("renders one entry per alert, artist and title combined", async () => {
+    const app = makeApp(noStacks, noItems, noFeedItems, async () => [
+      makeAlert({ artist_name: "Four Tet", title: "Three" }),
+    ]);
+
+    const res = await app.request("http://localhost/feed/new-releases.rss");
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    expect(body).toContain("<title>On the Beach — New Releases</title>");
+    expect(body).toContain("<title>Four Tet — Three</title>");
+  });
+
+  test("guid is stable per alert", async () => {
+    const app = makeApp(noStacks, noItems, noFeedItems, async () => [makeAlert({ id: 42 })]);
+
+    const body = await (await app.request("http://localhost/feed/new-releases.rss")).text();
+
+    expect(body).toContain('<guid isPermaLink="false">release-alert-42</guid>');
+  });
+
+  test("pubDate is when the alert fired, not when the record came out", async () => {
+    // A 1978 record surfacing today is news today, and belongs at the top of
+    // the reader rather than buried in 1978.
+    const app = makeApp(noStacks, noItems, noFeedItems, async () => [
+      makeAlert({
+        created_at: "2026-07-31T09:00:00.000Z",
+        first_release_date: "1978-04-01",
+        reason: "catalogue-addition",
+      }),
+    ]);
+
+    const body = await (await app.request("http://localhost/feed/new-releases.rss")).text();
+
+    expect(body).toContain("<pubDate>Fri, 31 Jul 2026");
+    expect(body).not.toContain("<pubDate>Sat, 01 Apr 1978");
+  });
+
+  test("the description says why the alert fired", async () => {
+    const app = makeApp(noStacks, noItems, noFeedItems, async () => [
+      makeAlert({ reason: "announced", first_release_date: "2026-09-18" }),
+    ]);
+
+    const body = await (await app.request("http://localhost/feed/new-releases.rss")).text();
+
+    expect(body).toContain("Announced release");
+    expect(body).toContain("Album · 2026-09-18");
+    expect(body).toContain("https://musicbrainz.org/release-group/mb-release-group");
+  });
+
+  test("an empty queue is still a valid feed", async () => {
+    const app = makeApp(noStacks, noItems, noFeedItems, async () => []);
+
+    const body = await (await app.request("http://localhost/feed/new-releases.rss")).text();
+
+    expect(body).not.toContain("<item>");
+    expect(body).toContain("</rss>");
   });
 });
 

--- a/tests/unit/settings-route.test.ts
+++ b/tests/unit/settings-route.test.ts
@@ -3,12 +3,16 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { createSettingsRoutes } from "../../server/routes/settings";
 import { db } from "../../server/db/index";
-import { itemSuggestions, musicItems } from "../../server/db/schema";
+import { appSettings, itemSuggestions, musicItems } from "../../server/db/schema";
 import {
   getLookupService,
   setLookupService,
   getReleaseLengthPreference,
   setReleaseLengthPreference,
+  getArtistWatchSettings,
+  setArtistWatchSettings,
+  DEFAULT_ARTIST_WATCH_SETTINGS,
+  ARTIST_WATCH_KEYS,
 } from "../../server/settings";
 
 function makeApp(): Hono {
@@ -104,7 +108,7 @@ describe("PUT /api/settings", () => {
       body: JSON.stringify({ lookupService: "spotify" }),
     });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
+    expect(await res.json()).toMatchObject({
       lookupService: "spotify",
       releaseLengthPreference: "longer",
       changed: true,
@@ -120,7 +124,7 @@ describe("PUT /api/settings", () => {
       body: JSON.stringify({ releaseLengthPreference: "shorter" }),
     });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
+    expect(await res.json()).toMatchObject({
       lookupService: "apple_music",
       releaseLengthPreference: "shorter",
       changed: true,
@@ -136,7 +140,7 @@ describe("PUT /api/settings", () => {
       body: JSON.stringify({ lookupService: "apple_music", releaseLengthPreference: "longer" }),
     });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
+    expect(await res.json()).toMatchObject({
       lookupService: "apple_music",
       releaseLengthPreference: "longer",
       changed: false,
@@ -183,5 +187,72 @@ describe("PUT /api/settings", () => {
       body: "{not json",
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("artist watch settings", () => {
+  beforeEach(async () => {
+    await setArtistWatchSettings(DEFAULT_ARTIST_WATCH_SETTINGS);
+  });
+
+  test("an unset freshness window falls back to the default, not to zero", async () => {
+    // `Number(null)` is 0 — a valid window — so "unset" has to be ruled out
+    // before parsing or every fresh install alerts on nothing.
+    await db.delete(appSettings).where(eq(appSettings.key, ARTIST_WATCH_KEYS.freshnessMonths));
+
+    expect((await getArtistWatchSettings()).freshnessMonths).toBe(18);
+  });
+
+  test("an explicit zero window is honoured", async () => {
+    await setArtistWatchSettings({ freshnessMonths: 0 });
+
+    expect((await getArtistWatchSettings()).freshnessMonths).toBe(0);
+  });
+
+  test("GET exposes the artist watch block with its defaults", async () => {
+    const app = makeApp();
+    const body = await (await app.request("http://localhost/api/settings")).json();
+
+    expect(body.artistWatch.enabled).toBe(true);
+    expect(body.artistWatch.freshnessMonths).toBe(18);
+    // Conservative by default: alerting on every archival edit is noise.
+    expect(body.artistWatch.alertOnCatalogueAdditions).toBe(false);
+    expect(body.artistWatch.scheduleAnnouncedReleases).toBe(true);
+    expect(body.artistWatch.excludedSecondaryTypes).toContain("compilation");
+  });
+
+  test("PUT round-trips the artist watch toggles", async () => {
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        artistWatchEnabled: false,
+        alertFreshnessMonths: 6,
+        alertOnCatalogueAdditions: true,
+        alertExcludedSecondaryTypes: ["Live", "Remix"],
+        scheduleAnnouncedReleases: false,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const stored = await getArtistWatchSettings();
+    expect(stored.enabled).toBe(false);
+    expect(stored.freshnessMonths).toBe(6);
+    expect(stored.alertOnCatalogueAdditions).toBe(true);
+    expect(stored.excludedSecondaryTypes).toEqual(["live", "remix"]);
+    expect(stored.scheduleAnnouncedReleases).toBe(false);
+  });
+
+  test("rejects a non-numeric freshness window rather than coercing it", async () => {
+    const app = makeApp();
+    const res = await app.request("http://localhost/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ alertFreshnessMonths: "soon" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await getArtistWatchSettings()).freshnessMonths).toBe(18);
   });
 });


### PR DESCRIPTION
## Summary

This PR implements a complete artist tracking and new-release alert system. The app now watches MusicBrainz for new releases by artists the user has listened to, surfaces them as alerts in the UI, and allows users to accept them into their library with optional scheduling for future release dates.

## Key Changes

**Core Features:**
- **Artist identity resolution** (`server/artist-identity.ts`): Establishes stable MusicBrainz identities for artists using a three-tier resolution ladder (existing items → known releases → name search), with confidence markers to avoid false positives
- **Release polling** (`server/artist-watch.ts`): Daily background sweep that queries MusicBrainz for release groups by tracked artists, diffs against stored snapshots, and generates alerts for new releases
- **Alert queue** (`server/release-alerts.ts`): Manages the alert lifecycle—accepting alerts creates music items (with optional scheduling for future releases), dismissing removes them, and marking as seen tracks user engagement
- **API routes** (`server/routes/artists.ts`, `server/routes/release-alerts.ts`): Endpoints for listing tracked artists, managing follow states, searching MusicBrainz candidates, and triaging alerts
- **UI pages** (`src/routes/new-releases/+page.svelte`, settings panel): Alert queue view with artwork, release info, and action buttons; artist management panel in settings with MBID confidence and follow-state controls

**Database:**
- New tables: `artist_releases` (snapshot of seen release groups), `release_alerts` (pending/resolved alerts)
- Extended `artists` table with MusicBrainz fields (`musicbrainz_artist_id`, `mbid_confidence`, `follow_state`, polling metadata)
- Migration: `0013_melodic_malice.sql`

**Implementation Details:**
- Uses release *groups* (album-level) rather than releases (individual pressings) to avoid false positives from reissues
- First poll per artist is a silent baseline to avoid dumping alerts for well-documented artists
- Shared MusicBrainz request gate (`musicbrainz.ts`) serializes all outbound requests to stay within rate limits across concurrent sweeps
- Alert reasons tracked (`announced`, `new-release`, `catalogue-addition`) to explain why each alert fired
- Partial date handling for MusicBrainz dates (year-only, year-month, full dates) with intelligent reminder scheduling
- Noise filters (excluded primary types, secondary types) configurable in settings
- RSS feed support for new releases (`/feed/new-releases.rss`)

**Testing:**
- Comprehensive unit tests for date parsing, release filtering, polling logic, and alert lifecycle
- Integration tests for API routes and alert acceptance flow
- E2E test for alert queue triage

**UI/UX:**
- Taskbar badge showing pending alert count
- Start menu link to new-releases view
- Alert cards with artwork, artist/release info, and action buttons
- Settings panel for artist follow-state management and MBID resolution
- Graceful handling of missing artwork via Cover Art Archive

https://claude.ai/code/session_01X2Da4WRvLSCA9SxYmFoQFS