### PR TITLE
Add a minimum star rating bar for watched artists

### DIFF
--- a/server/artist-watch.ts
+++ b/server/artist-watch.ts
@@ -210,21 +210,39 @@ export interface TrackedArtistRow {
  * wanting an artist's whole future output — a record sits in To Listen
  * precisely because you haven't formed that opinion yet. Listening is the
  * signal, and this predicate is the one place to widen it.
+ *
+ * With `min_artist_rating` set, the auto rule also demands a release rated at
+ * or above the bar — having merely listened stops being enough. The rated item
+ * needn't be the listened one; any release good enough to earn the rating
+ * vouches for the artist. `always` is an explicit user choice and bypasses the
+ * bar, exactly as it bypasses the listened-item rule.
  */
-function trackedArtistPredicate() {
+function trackedArtistPredicate(minArtistRating: number) {
   const hasListenedItem = sql`EXISTS (
     SELECT 1 FROM ${musicItems}
     WHERE ${musicItems.artistId} = ${artists.id}
       AND ${musicItems.listenStatus} = 'listened'
   )`;
 
+  const hasQualifyingRating = sql`EXISTS (
+    SELECT 1 FROM ${musicItems}
+    WHERE ${musicItems.artistId} = ${artists.id}
+      AND ${musicItems.rating} >= ${minArtistRating}
+  )`;
+
+  const autoTracked =
+    minArtistRating > 0 ? and(hasListenedItem, hasQualifyingRating) : hasListenedItem;
+
   return and(
     sql`${artists.followState} != 'muted'`,
-    or(eq(artists.followState, "always"), hasListenedItem),
+    or(eq(artists.followState, "always"), autoTracked),
   );
 }
 
-export async function listTrackedArtists(): Promise<TrackedArtistRow[]> {
+export async function listTrackedArtists(
+  settings?: ArtistWatchSettings,
+): Promise<TrackedArtistRow[]> {
+  const { minArtistRating } = settings ?? (await getArtistWatchSettings());
   return db
     .select({
       id: artists.id,
@@ -237,12 +255,16 @@ export async function listTrackedArtists(): Promise<TrackedArtistRow[]> {
       pollFailureCount: artists.pollFailureCount,
     })
     .from(artists)
-    .where(trackedArtistPredicate())
+    .where(trackedArtistPredicate(minArtistRating))
     .orderBy(asc(artists.name));
 }
 
 /** Tracked, identified artists whose `next_poll_at` has come round. */
-async function artistsDueForPoll(now: Date, limit: number): Promise<TrackedArtistRow[]> {
+async function artistsDueForPoll(
+  now: Date,
+  limit: number,
+  minArtistRating: number,
+): Promise<TrackedArtistRow[]> {
   return (
     db
       .select({
@@ -258,7 +280,7 @@ async function artistsDueForPoll(now: Date, limit: number): Promise<TrackedArtis
       .from(artists)
       .where(
         and(
-          trackedArtistPredicate(),
+          trackedArtistPredicate(minArtistRating),
           isNotNull(artists.musicbrainzArtistId),
           sql`${artists.musicbrainzArtistId} != ${VARIOUS_ARTISTS_MBID}`,
           inArray(artists.mbidConfidence, ["confirmed", "probable"]),
@@ -600,7 +622,7 @@ export async function sweepArtistReleases(now: Date = new Date()): Promise<Sweep
 
   // Tracked artists we still can't identify get a network resolution attempt,
   // at most once every 30 days each, sharing the sweep's request budget.
-  const trackedIds = new Set((await listTrackedArtists()).map((artist) => artist.id));
+  const trackedIds = new Set((await listTrackedArtists(settings)).map((artist) => artist.id));
   const resolutionQueue = (await artistsDueForResolution(now)).filter((id) => trackedIds.has(id));
 
   for (const artistId of resolutionQueue) {
@@ -616,7 +638,11 @@ export async function sweepArtistReleases(now: Date = new Date()): Promise<Sweep
     }
   }
 
-  const due = await artistsDueForPoll(now, MAX_ARTISTS_PER_SWEEP - requests);
+  const due = await artistsDueForPoll(
+    now,
+    MAX_ARTISTS_PER_SWEEP - requests,
+    settings.minArtistRating,
+  );
 
   for (const artist of due) {
     if (requests >= MAX_ARTISTS_PER_SWEEP) break;

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -10,6 +10,7 @@ import {
   RELEASE_LENGTH_PREFERENCES,
   getArtistWatchSettings,
   setArtistWatchSettings,
+  MAX_STAR_RATING,
   type ArtistWatchSettings,
 } from "../settings";
 import { ensureSuggestionsForToListenArtists } from "../suggestions";
@@ -42,6 +43,19 @@ function readArtistWatchUpdate(
       return { error: "alertFreshnessMonths must be a non-negative number" };
     }
     update.freshnessMonths = months;
+  }
+
+  if (body.alertMinArtistRating !== undefined) {
+    const rating = body.alertMinArtistRating;
+    if (
+      typeof rating !== "number" ||
+      !Number.isFinite(rating) ||
+      rating < 0 ||
+      rating > MAX_STAR_RATING
+    ) {
+      return { error: `alertMinArtistRating must be a number between 0 and ${MAX_STAR_RATING}` };
+    }
+    update.minArtistRating = rating;
   }
 
   if (body.alertExcludedSecondaryTypes !== undefined) {

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -115,7 +115,11 @@ export const ARTIST_WATCH_KEYS = {
   excludedSecondaryTypes: "alert_excluded_secondary_types",
   newReleasesStackId: "new_releases_stack_id",
   scheduleAnnounced: "schedule_announced_releases",
+  minArtistRating: "alert_min_artist_rating",
 } as const;
+
+/** Star ratings run 0.5–5 in half steps (see src/ui/components/star-rating.ts). */
+export const MAX_STAR_RATING = 5;
 
 export interface ArtistWatchSettings {
   /** Master switch for the sweep. */
@@ -128,6 +132,11 @@ export interface ArtistWatchSettings {
   excludedSecondaryTypes: string[];
   /** Set `remind_at` from a future release date when an alert is accepted. */
   scheduleAnnouncedReleases: boolean;
+  /**
+   * Only auto-track artists with at least one release rated this many stars
+   * or higher. 0 disables the bar (any listened artist qualifies).
+   */
+  minArtistRating: number;
 }
 
 // The noise filter defaults: archival editing churn the user did not ask about.
@@ -146,6 +155,7 @@ export const DEFAULT_ARTIST_WATCH_SETTINGS: ArtistWatchSettings = {
   alertOnCatalogueAdditions: false,
   excludedSecondaryTypes: DEFAULT_EXCLUDED_SECONDARY_TYPES,
   scheduleAnnouncedReleases: true,
+  minArtistRating: 0,
 };
 
 function parseBoolean(value: string | null, fallback: boolean): boolean {
@@ -154,17 +164,19 @@ function parseBoolean(value: string | null, fallback: boolean): boolean {
 }
 
 export async function getArtistWatchSettings(): Promise<ArtistWatchSettings> {
-  const [enabled, freshness, catalogue, excluded, schedule] = await Promise.all([
+  const [enabled, freshness, catalogue, excluded, schedule, minRating] = await Promise.all([
     getSetting(ARTIST_WATCH_KEYS.enabled),
     getSetting(ARTIST_WATCH_KEYS.freshnessMonths),
     getSetting(ARTIST_WATCH_KEYS.catalogueAdditions),
     getSetting(ARTIST_WATCH_KEYS.excludedSecondaryTypes),
     getSetting(ARTIST_WATCH_KEYS.scheduleAnnounced),
+    getSetting(ARTIST_WATCH_KEYS.minArtistRating),
   ]);
 
   // `Number(null)` is 0, which is a perfectly valid freshness window — so the
   // unset case has to be ruled out before parsing, or the default never applies.
   const months = freshness === null ? Number.NaN : Number(freshness);
+  const rating = minRating === null ? Number.NaN : Number(minRating);
 
   return {
     enabled: parseBoolean(enabled, DEFAULT_ARTIST_WATCH_SETTINGS.enabled),
@@ -187,6 +199,10 @@ export async function getArtistWatchSettings(): Promise<ArtistWatchSettings> {
       schedule,
       DEFAULT_ARTIST_WATCH_SETTINGS.scheduleAnnouncedReleases,
     ),
+    minArtistRating:
+      Number.isFinite(rating) && rating >= 0 && rating <= MAX_STAR_RATING
+        ? rating
+        : DEFAULT_ARTIST_WATCH_SETTINGS.minArtistRating,
   };
 }
 
@@ -217,6 +233,9 @@ export async function setArtistWatchSettings(
   }
   if (update.scheduleAnnouncedReleases !== undefined) {
     await putSetting(ARTIST_WATCH_KEYS.scheduleAnnounced, String(update.scheduleAnnouncedReleases));
+  }
+  if (update.minArtistRating !== undefined) {
+    await putSetting(ARTIST_WATCH_KEYS.minArtistRating, String(update.minArtistRating));
   }
 
   return getArtistWatchSettings();

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -365,6 +365,21 @@
           />
           <span>months</span>
         </label>
+        <label class="settings__option settings__option--field">
+          <span>Only watch artists with a release rated at least</span>
+          <input
+            type="number"
+            class="settings__number"
+            name="min-artist-rating"
+            min="0"
+            max="5"
+            step="0.5"
+            value={watch.minArtistRating}
+            onchange={(event) =>
+              saveWatch({ alertMinArtistRating: Number(event.currentTarget.value) })}
+          />
+          <span>stars (0 = any artist you've listened to)</span>
+        </label>
       </form>
       <p id="artist-watch-status" class="settings__status" role="status" aria-live="polite">
         {watchStatusMessage}

--- a/tests/unit/artist-watch.test.ts
+++ b/tests/unit/artist-watch.test.ts
@@ -43,7 +43,12 @@ function group(overrides: Partial<musicbrainz.MbReleaseGroup> = {}): musicbrainz
 /** An artist with one listened item — the derived tracking rule's happy path. */
 async function makeTrackedArtist(
   name: string,
-  options: { listenStatus?: "to-listen" | "listened"; followState?: string; mbid?: string } = {},
+  options: {
+    listenStatus?: "to-listen" | "listened";
+    followState?: string;
+    mbid?: string;
+    rating?: number;
+  } = {},
 ): Promise<TrackedArtistRow> {
   const [artist] = await db
     .insert(artists)
@@ -61,6 +66,7 @@ async function makeTrackedArtist(
     normalizedTitle: normalize(`${name} Debut`),
     artistId: artist.id,
     listenStatus: options.listenStatus ?? "listened",
+    rating: options.rating ?? null,
   });
 
   return (await db
@@ -661,6 +667,43 @@ describe("tracked artists", () => {
 
     expect((await listTrackedArtists()).map((a) => a.id)).not.toContain(muted.id);
   });
+
+  test("the rating bar drops listened artists whose releases fall below it", async () => {
+    const loved = await makeTrackedArtist(`Loved Band ${Date.now()}`, { rating: 4.5 });
+    const middling = await makeTrackedArtist(`Middling Band ${Date.now()}`, { rating: 2 });
+    const unrated = await makeTrackedArtist(`Unrated Band ${Date.now()}`);
+
+    const gated = (await listTrackedArtists(settings({ minArtistRating: 4 }))).map((a) => a.id);
+    expect(gated).toContain(loved.id);
+    expect(gated).not.toContain(middling.id);
+    expect(gated).not.toContain(unrated.id);
+
+    // With the bar off (the default), having listened is still enough.
+    const open = (await listTrackedArtists(settings())).map((a) => a.id);
+    expect(open).toContain(loved.id);
+    expect(open).toContain(middling.id);
+    expect(open).toContain(unrated.id);
+  });
+
+  test("a rating alone doesn't track an artist nothing was listened to by", async () => {
+    // The bar narrows the listened rule; it doesn't replace it.
+    const ratedButQueued = await makeTrackedArtist(`Rated Queue ${Date.now()}`, {
+      listenStatus: "to-listen",
+      rating: 5,
+    });
+
+    const tracked = (await listTrackedArtists(settings({ minArtistRating: 4 }))).map((a) => a.id);
+    expect(tracked).not.toContain(ratedButQueued.id);
+  });
+
+  test("follow_state 'always' bypasses the rating bar", async () => {
+    const forced = await makeTrackedArtist(`Always Unrated ${Date.now()}`, {
+      followState: "always",
+    });
+
+    const tracked = (await listTrackedArtists(settings({ minArtistRating: 5 }))).map((a) => a.id);
+    expect(tracked).toContain(forced.id);
+  });
 });
 
 describe("sweepArtistReleases", () => {
@@ -718,5 +761,27 @@ describe("sweepArtistReleases", () => {
     expect(mbSpy).toHaveBeenCalledWith("mbid-sweep-due");
     expect(mbSpy).not.toHaveBeenCalledWith("mbid-sweep-later");
     expect((await reload(due.id)).lastPolledAt).not.toBeNull();
+  });
+
+  test("the rating bar keeps below-bar artists out of the poll queue", async () => {
+    await setArtistWatchSettings({ minArtistRating: 4 });
+    const mbSpy = spyOn(musicbrainz, "fetchArtistReleaseGroups").mockResolvedValue([
+      group({ id: "rg-rated-sweep" }),
+    ]);
+    spyOn(musicbrainz, "searchArtistCandidates").mockResolvedValue([]);
+
+    await makeTrackedArtist(`Sweep Loved ${Date.now()}`, {
+      mbid: "mbid-sweep-loved",
+      rating: 4.5,
+    });
+    await makeTrackedArtist(`Sweep Middling ${Date.now()}`, {
+      mbid: "mbid-sweep-middling",
+      rating: 2,
+    });
+
+    await sweepArtistReleases(NOW);
+
+    expect(mbSpy).toHaveBeenCalledWith("mbid-sweep-loved");
+    expect(mbSpy).not.toHaveBeenCalledWith("mbid-sweep-middling");
   });
 });

--- a/tests/unit/settings-route.test.ts
+++ b/tests/unit/settings-route.test.ts
@@ -219,6 +219,8 @@ describe("artist watch settings", () => {
     expect(body.artistWatch.alertOnCatalogueAdditions).toBe(false);
     expect(body.artistWatch.scheduleAnnouncedReleases).toBe(true);
     expect(body.artistWatch.excludedSecondaryTypes).toContain("compilation");
+    // Off by default: every listened artist is watched until a bar is set.
+    expect(body.artistWatch.minArtistRating).toBe(0);
   });
 
   test("PUT round-trips the artist watch toggles", async () => {
@@ -232,6 +234,7 @@ describe("artist watch settings", () => {
         alertOnCatalogueAdditions: true,
         alertExcludedSecondaryTypes: ["Live", "Remix"],
         scheduleAnnouncedReleases: false,
+        alertMinArtistRating: 3.5,
       }),
     });
 
@@ -242,6 +245,20 @@ describe("artist watch settings", () => {
     expect(stored.alertOnCatalogueAdditions).toBe(true);
     expect(stored.excludedSecondaryTypes).toEqual(["live", "remix"]);
     expect(stored.scheduleAnnouncedReleases).toBe(false);
+    expect(stored.minArtistRating).toBe(3.5);
+  });
+
+  test("rejects a minimum rating outside the star scale", async () => {
+    const app = makeApp();
+    for (const alertMinArtistRating of [-1, 6, "four"]) {
+      const res = await app.request("http://localhost/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alertMinArtistRating }),
+      });
+      expect(res.status).toBe(400);
+    }
+    expect((await getArtistWatchSettings()).minArtistRating).toBe(0);
   });
 
   test("rejects a non-numeric freshness window rather than coercing it", async () => {


### PR DESCRIPTION
## What

Adds an artist-watch setting to only look for new releases by artists with a release rated at or above a chosen number of stars.

- **`min_artist_rating` setting** (`server/settings.ts`): 0–5 in half steps, default 0 (off). Validated and persisted alongside the other artist-watch keys.
- **Tracking rule** (`server/artist-watch.ts`): with the bar set, an auto-tracked artist must have a listened item *and* at least one release rated ≥ the bar. The rated release needn't be the listened one. `always` follows bypass the bar (it's an explicit user choice, same as it bypasses the listened-item rule), and muted still beats everything. The bar gates both the tracked-artists list and the poll queue, so below-bar artists are neither shown as tracked nor polled against MusicBrainz.
- **API** (`server/routes/settings.ts`): `alertMinArtistRating` on `PUT /api/settings`, rejected with a 400 outside 0–5 or when non-numeric.
- **UI** (`src/routes/settings/+page.svelte`): a number field (0–5, step 0.5) in the New release alerts section — "Only watch artists with a release rated at least ___ stars (0 = any artist you've listened to)".

Setting the bar is fully reversible: artists dropped by it keep their release snapshots and poll schedule, so lowering it later picks them straight back up.

## Tests

- `tests/unit/artist-watch.test.ts`: bar drops below-bar/unrated artists, rating alone doesn't track an unlistened artist, `always` bypasses the bar, and a sweep-level test that below-bar artists are never polled.
- `tests/unit/settings-route.test.ts`: default of 0, round-trip through the API, and rejection of out-of-range/non-numeric values.

All 699 unit tests pass; `svelte-check` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mxLkP8AKptmuVKjeiAuwb

---
_Generated by [Claude Code](https://claude.ai/code/session_013mxLkP8AKptmuVKjeiAuwb)_