### PR TITLE
Scroll the settings and alert-queue pages inside the window

### DIFF
--- a/src/routes/new-releases/+page.svelte
+++ b/src/routes/new-releases/+page.svelte
@@ -122,7 +122,7 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<main class="main">
+<main class="main main--scroll">
   <div class="alerts">
     <a href="/" class="btn btn--ghost alerts__back">◄ Back</a>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -251,7 +251,7 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<main class="main">
+<main class="main main--scroll">
   <div class="settings">
     <a href="/" class="btn btn--ghost settings__back">◄ Back</a>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -265,6 +265,15 @@ body {
   min-height: 0;
 }
 
+/* Pages whose content is a single long column — settings, the alert queue —
+   scroll inside the window. The list on the main page brings its own scroll
+   container, but these don't, and `body` is a fixed-height window with
+   `overflow: hidden`: without this the overflow is clipped at the window's
+   edge and simply unreachable. */
+.main--scroll {
+  overflow-y: auto;
+}
+
 /* ═══════════════════════════════════════════════════
    ADD SECTION — Winamp-style input panel
 ═══════════════════════════════════════════════════ */
@@ -1351,6 +1360,13 @@ select.input {
 
   body:not(.release-page-body) .main {
     flex: 0 0 auto;
+  }
+
+  /* Small screens scroll the whole window instead of panes within it (see the
+     `body` rule above), so the long-column pages hand scrolling back to the
+     document rather than nesting a second scroll container inside it. */
+  .main--scroll {
+    overflow-y: visible;
   }
 
   .music-scrollbar {


### PR DESCRIPTION
`body` is a fixed-height window with `overflow: hidden`, and `.main` had no scroll container of its own. The main page gets away with it because its list brings one; the settings and new-releases pages are a single long column, so on a short viewport everything past the window's bottom edge was clipped and unreachable — the tracked-artists list ran out of the frame entirely.

Give those two pages a `.main--scroll` modifier that scrolls the pane, leaving the title bar and footer where they belong. Small screens already scroll the whole window rather than panes within it, so the modifier hands scrolling back to the document there instead of nesting a second scroll container.


Claude-Session: https://claude.ai/code/session_01X2Da4WRvLSCA9SxYmFoQFS