### PR TITLE
Hide the primary-source link when a play button already targets it

### DIFF
--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -372,6 +372,20 @@
       .filter(Boolean)
       .join(" · "),
   );
+
+  // The primary-source link (e.g. "Spotify", "Discogs") is a plain external
+  // link. Hide it when a play button already targets the same URL — otherwise
+  // it just duplicates that button (e.g. the "▶ YouTube" play button already
+  // links to the same YouTube page).
+  const playHrefs = $derived(
+    new Set(
+      [data.bandcampEmbed?.href, data.youtubeEmbed?.href, data.appleMusicListen?.href].filter(
+        (href): href is string => !!href,
+      ),
+    ),
+  );
+
+  const showSourceLink = $derived(!!data.sourceLink && !playHrefs.has(data.sourceLink.href));
 </script>
 
 <svelte:head>
@@ -456,14 +470,6 @@
               await api.updateMusicItem(item.id, { rating: next });
             }}
           />
-          {#if data.sourceLink}
-            <a
-              class="release-page__source-link"
-              href={data.sourceLink.href}
-              target="_blank"
-              rel="noopener noreferrer">{data.sourceLink.label}</a
-            >
-          {/if}
           <div class="release-page__actions">
             {#if data.bandcampEmbed}
               <button
@@ -503,6 +509,16 @@
                 data-am-mode="musickit"
                 onclick={() => listenLookupAppleMusic(lookupLink!.url)}
                 >▶ Apple Music</button
+              >
+            {/if}
+            {#if showSourceLink}
+              <a
+                class="release-page__link-btn"
+                href={data.sourceLink!.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={data.sourceLink!.label}
+                aria-label={data.sourceLink!.label}>🔗</a
               >
             {/if}
             {#if lookupLink && !lookupIsPlayableAppleMusic}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3184,19 +3184,6 @@ a:hover {
   align-items: center;
 }
 
-.release-page__source-link {
-  display: inline-block;
-  margin-top: var(--space-3);
-  font-size: var(--text-base);
-  color: #000080;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.release-page__source-link:hover {
-  color: #0000cc;
-}
-
 .release-page__actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Follow-up to #271 (merged). On the release page, the primary-source link (e.g. "YouTube") was still rendered as a standalone underlined text link above the play row. When the primary source is YouTube, Bandcamp, or a primary Apple Music URL, it pointed to the **same URL** as the corresponding play button — showing a visible duplicate link right above the "▶ YouTube" button.

## Changes

- The primary-source link (`data.sourceLink`) is now **hidden** whenever a play button already targets the same URL, computed from the Bandcamp / YouTube / Apple Music embed hrefs (`showSourceLink` derived state).
- When the primary source has **no** play button (Spotify, SoundCloud, Discogs, physical, etc.), it now renders as the same compact link-icon button (🔗) in the play row — consistent with the secondary links introduced in #271 — instead of a separate text link.
- Removed the now-unused `.release-page__source-link` CSS.

Links keep `title`/`aria-label` carrying the full source name for accessibility.

## Verification

- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (3 pre-existing warnings in unrelated test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnDaT8VjZP6XR1Sbzv8KcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnDaT8VjZP6XR1Sbzv8KcD)_