### PR TITLE
Keep the manual-add enrichment lookup off the network in tests

### DIFF
--- a/playwright/scan-cover.spec.ts
+++ b/playwright/scan-cover.spec.ts
@@ -55,6 +55,17 @@ test("scan prefill opens details and fills artist/release title", async ({ page 
     });
   });
 
+  // Submitting with artist + title filled triggers a MusicBrainz enrichment
+  // lookup before the create; keep it out of the loop so the test never rides
+  // on third-party availability.
+  await page.route("**/api/release/lookup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
   const fixturePath = path.join(process.cwd(), "playwright/fixtures/cover-sample.png");
 
   await page.locator("#scan-file-input").setInputFiles(fixturePath);

--- a/server/cover-art-archive.ts
+++ b/server/cover-art-archive.ts
@@ -1,5 +1,9 @@
 const CAA_BASE = "https://coverartarchive.org/release";
 
+// fetch has no default timeout, and a wedged Cover Art Archive connection
+// would hang the caller (and any add-form submit behind it) indefinitely.
+const CAA_FETCH_TIMEOUT_MS = 15_000;
+
 type SaveImageFn = (base64Image: string) => Promise<string>;
 
 export async function fetchAndSaveCoverArt(
@@ -9,7 +13,7 @@ export async function fetchAndSaveCoverArt(
   const url = `${CAA_BASE}/${releaseId}/front-500`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: AbortSignal.timeout(CAA_FETCH_TIMEOUT_MS) });
 
     if (!response.ok) {
       return null;

--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -38,10 +38,18 @@ const sleep = (ms: number): Promise<void> =>
 
 let gateTail: Promise<void> = Promise.resolve();
 
+// A wedged MusicBrainz connection would otherwise hang callers indefinitely —
+// fetch has no default timeout — and, worse, hold the gate shut for everyone
+// queued behind it.
+const MB_FETCH_TIMEOUT_MS = 15_000;
+
 function mbFetch(url: string): Promise<Response> {
   const gap = minRequestGapMs();
   const turn = gateTail.then(() =>
-    fetch(url, { headers: { "User-Agent": USER_AGENT, Accept: "application/json" } }),
+    fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(MB_FETCH_TIMEOUT_MS),
+    }),
   );
   // The next caller waits for this request to finish plus the minimum gap.
   // Failures must not wedge the queue, so the tail swallows them — the

--- a/server/routes/release.ts
+++ b/server/routes/release.ts
@@ -136,6 +136,12 @@ export function createReleaseRoutes(
 
     const yearHint = typeof year === "string" && year.trim() ? year.trim() : undefined;
 
+    // Enrichment is best-effort, so under OTB_DISABLE_EXTERNAL_LOOKUPS (tests)
+    // answer "nothing found" rather than reaching MusicBrainz/Cover Art Archive.
+    if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) {
+      return c.json({}, 200);
+    }
+
     try {
       const mbFields = await lookupReleaseFn(artist.trim(), title.trim(), yearHint);
       if (!mbFields) {

--- a/tests/unit/release-route.test.ts
+++ b/tests/unit/release-route.test.ts
@@ -294,6 +294,24 @@ describe("POST /api/release/lookup", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({});
   });
+
+  test("no-ops under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+    try {
+      const app = makeApp();
+      const res = await app.request("http://localhost/api/release/lookup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artist: "Radiohead", title: "OK Computer" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({});
+      expect(mockLookupRelease).not.toHaveBeenCalled();
+      expect(mockFetchCoverArt).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+    }
+  });
 });
 
 describe("POST /api/release/secondary-link-lookup/:id", () => {


### PR DESCRIPTION
## Why

CI run [746](https://github.com/richpjames/on-the-beach/actions/runs/30690686897) failed on `scan-cover.spec.ts:36` with a 30s timeout on all three attempts. The trace: submitting the add form with artist + title filled makes the client call `POST /api/release/lookup` before creating the item, and the server handler performs a **live MusicBrainz / Cover Art Archive lookup** — it was the only external-lookup path that didn't honour `OTB_DISABLE_EXTERNAL_LOOKUPS`, the flag the e2e fixture sets precisely to keep third parties out of tests. When MusicBrainz was slow from the runner, the lookup hung (no fetch timeout), the create never fired, and the test timed out. The commit on that run was unrelated CSS.

## What

- `server/routes/release.ts`: the `/lookup` handler returns `{}` under `OTB_DISABLE_EXTERNAL_LOOKUPS`, matching every other lookup site (`suggestions`, `artist-watch`, `scraper`, `secondary-link-enrichment`, `apple-music-catalog`).
- `tests/unit/release-route.test.ts`: unit test pinning the no-op (no lookup, no cover-art fetch).
- `playwright/scan-cover.spec.ts`: mock `**/api/release/lookup` in the prefill test as belt-and-braces, so it stays deterministic even without the flag.
- `server/musicbrainz.ts`, `server/cover-art-archive.ts`: 15s `AbortSignal.timeout` on both external fetches — previously a wedged connection could hang a real submit (and everything queued behind the MusicBrainz request gate) indefinitely.

## Testing

- `bun test tests/unit`: 700 pass.
- `playwright/scan-cover.spec.ts`: both tests pass; the prefill test no longer spends ~7s inside the lookup.
- Lint clean (3 pre-existing warnings in untouched files), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNTKSLndaXQpJwahj4hua9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNTKSLndaXQpJwahj4hua9)_