### PR TITLE
Support multi-release pages from the share sheet

### DIFF
--- a/docs/areas/server/routes.md
+++ b/docs/areas/server/routes.md
@@ -6,7 +6,7 @@
 - `server/routes/music-items.ts` owns listing, create/update/delete, filtering, sorting, stack-aware queries, and saved ordering.
 - `server/routes/stacks.ts` owns stack CRUD, item membership, and parent/child stack hierarchy rules.
 - `server/routes/release.ts` owns image upload, cover scanning, MusicBrainz lookup, and Apple Music enrichment.
-- `server/routes/ingest.ts` owns authenticated email, single-link, and photo ingestion endpoints (the share sheet posts links to `/link` and images to `/photo`, both of which can file the item into lists and set a reminder).
+- `server/routes/ingest.ts` owns authenticated email, single-link, and photo ingestion endpoints (the share sheet posts links to `/link` and images to `/photo`, both of which can file the item into lists and set a reminder). When a shared page names several releases, `/link` returns `409 ambiguous_link` with the candidates — the same payload shape as `POST /api/music-items` — and the share sheet re-posts with `selectedCandidateIds` to create one item per chosen release.
 - `server/routes/rss.ts` exposes the feed surfaces.
 
 ## Page data (SvelteKit)

--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -39,6 +39,15 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
   a trip back to the first screen just to post. Whichever Add you tap, the same note,
   lists, and reminder are sent, and the in-flight spinner / error alert appear on the
   screen you're on.
+- **Sharing a page with several releases** (e.g. a best-of-the-year blog post) works
+  like the web app's link picker. The server answers `POST /api/ingest/link` with
+  `409 ambiguous_link` and the extracted candidates instead of adding anything; the
+  extension pushes a **release picker** (same Winamp-playlist styling as the list
+  picker) listing each release with a checkmark toggle and a "Select all" row. Its
+  Add button re-posts the same link with `selectedCandidateIds`, and the server
+  creates one item per chosen release — all filed into the same lists, with the same
+  note and reminder. Going back instead keeps everything typed so far and adds
+  nothing.
 - **Sharing an image** works the same way. When the payload is a photo rather than a
   link (e.g. a record cover shared from Photos), the extension shows the same compose
   form — with an image preview in place of the URL line — and the same note, list,

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -51,10 +51,29 @@ final class ShareViewController: UIViewController {
         }
     }
 
-    /// Outcome of a post attempt: a confirmation or error message to show the user.
+    /// The `409 ambiguous_link` response from `POST /api/ingest/link`: the
+    /// shared page names several releases and the server wants the user to
+    /// pick which ones to add. Same payload shape the web app's link picker
+    /// consumes from `POST /api/music-items`.
+    struct AmbiguousLinkResponse: Decodable {
+        struct Candidate: Decodable {
+            let candidateId: String
+            let artist: String?
+            let title: String
+        }
+
+        let kind: String
+        let message: String?
+        let candidates: [Candidate]
+    }
+
+    /// Outcome of a post attempt: a confirmation or error message to show the
+    /// user, or — for a link only — a page with several releases on it that
+    /// needs the user to pick which to add before posting again.
     private enum PostResult {
         case success(String)
         case failure(String)
+        case needsReleaseSelection(message: String, candidates: [AmbiguousLinkResponse.Candidate])
     }
 
     /// What the user is sharing: a link (posted to `/api/ingest/link`) or an
@@ -99,6 +118,9 @@ final class ShareViewController: UIViewController {
     /// The list picker while it's on screen, so posting state and the Add gate
     /// can be kept in step with the compose form's.
     private weak var listPicker: ListPickerViewController?
+    /// The release picker while it's on screen (after a multi-release page came
+    /// back ambiguous), so posting state locks it like the other screens.
+    private weak var releasePicker: ReleasePickerViewController?
 
     // Read from the extension's Info.plist. `OTBBaseURL` is committed; the API
     // key is injected from a gitignored xcconfig at build time (see
@@ -184,9 +206,15 @@ final class ShareViewController: UIViewController {
     // MARK: - Submit / cancel
 
     /// Posts the shared content with whatever the compose form currently holds.
-    /// Called from the form's Add button and from the list picker's, so both
-    /// send exactly the same note, lists, and reminder.
-    private func submit() {
+    /// Called from the form's Add button, the list picker's, and — with the
+    /// chosen candidate ids — the release picker's, so all send exactly the
+    /// same note, lists, and reminder.
+    ///
+    /// `selectedCandidateIds` is empty on a first post. When the shared page
+    /// names several releases the server answers 409 with the candidates
+    /// instead of adding anything; we show the release picker and come back
+    /// through here with the user's selection.
+    private func submit(selectedCandidateIds: [String] = []) {
         guard let sharedContent else {
             // Add is disabled without content, so this shouldn't be reachable —
             // but silently dismissing the sheet would look like a successful add.
@@ -204,6 +232,9 @@ final class ShareViewController: UIViewController {
             case .failure(let message):
                 self.setPosting(false)
                 self.presentError(message)
+            case .needsReleaseSelection(let message, let candidates):
+                self.setPosting(false)
+                self.pushReleasePicker(message: message, candidates: candidates)
             }
         }
 
@@ -215,6 +246,7 @@ final class ShareViewController: UIViewController {
                 note: note,
                 listNames: selectedListNames,
                 remindAt: remindAt,
+                selectedCandidateIds: selectedCandidateIds,
                 completion: handle
             )
         case .image(let data):
@@ -234,6 +266,21 @@ final class ShareViewController: UIViewController {
     private func setPosting(_ posting: Bool) {
         compose.setPosting(posting)
         listPicker?.setPosting(posting)
+        releasePicker?.setPosting(posting)
+    }
+
+    /// Pushes the release picker after the server reported the shared page
+    /// mentions several releases. Add posts the link again with the chosen
+    /// candidate ids; back returns to whatever screen the user submitted from
+    /// with everything they'd already filled in intact.
+    private func pushReleasePicker(
+        message: String,
+        candidates: [AmbiguousLinkResponse.Candidate]
+    ) {
+        let picker = ReleasePickerViewController(message: message, candidates: candidates)
+        picker.onAdd = { [weak self] ids in self?.submit(selectedCandidateIds: ids) }
+        releasePicker = picker
+        navController.pushViewController(picker, animated: true)
     }
 
     /// Flashes a checkmark toast over the form, then closes the sheet. Completing
@@ -553,6 +600,7 @@ final class ShareViewController: UIViewController {
         note: String,
         listNames: [String],
         remindAt: Date?,
+        selectedCandidateIds: [String] = [],
         completion: @escaping (PostResult) -> Void
     ) {
         guard let endpoint = URL(string: baseURL + "/api/ingest/link") else {
@@ -570,6 +618,8 @@ final class ShareViewController: UIViewController {
         // Send the schedule as a plain yyyy-MM-dd date, matching the web reminder
         // control; the server parses it with `new Date(...)`.
         if let remindAt { payload["remindAt"] = Self.scheduleFormatter.string(from: remindAt) }
+        // The user's answer to an earlier ambiguous (multi-release) response.
+        if !selectedCandidateIds.isEmpty { payload["selectedCandidateIds"] = selectedCandidateIds }
 
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
@@ -590,12 +640,28 @@ final class ShareViewController: UIViewController {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? 0
                 if (200...299).contains(status) {
                     result = .success(Self.successMessage(from: data))
+                } else if status == 409, let ambiguous = Self.ambiguousResponse(from: data) {
+                    result = .needsReleaseSelection(
+                        message: ambiguous.message ?? "This link mentions several releases. Pick one or more to add.",
+                        candidates: ambiguous.candidates
+                    )
                 } else {
                     result = .failure(Self.failureMessage(status: status, data: data, isPhoto: false))
                 }
             }
             DispatchQueue.main.async { completion(result) }
         }.resume()
+    }
+
+    /// Decodes a 409 body as the multi-release payload, or nil when the
+    /// conflict is something else (so it falls through to the error alert).
+    private nonisolated static func ambiguousResponse(from data: Data?) -> AmbiguousLinkResponse? {
+        guard let data,
+              let payload = try? JSONDecoder().decode(AmbiguousLinkResponse.self, from: data),
+              payload.kind == "ambiguous_link",
+              !payload.candidates.isEmpty
+        else { return nil }
+        return payload
     }
 
     /// Posts a shared image to `/api/ingest/photo`. The image is sent as base64
@@ -694,6 +760,7 @@ final class ShareViewController: UIViewController {
     }
 
     /// Builds the confirmation toast text from the ingest response: "Added",
+    /// "Added 3 releases" when a multi-release selection created several items,
     /// "Added to Jazz, Chill", or "Already saved" when the link was a duplicate
     /// (still worth confirming — a re-share still files it into lists and sets
     /// the reminder). An unparseable body is still a 2xx, so fall back to "Added".
@@ -701,8 +768,16 @@ final class ShareViewController: UIViewController {
         guard let data, let payload = try? JSONDecoder().decode(LinkResponse.self, from: data) else {
             return "Added"
         }
-        let duplicate = (payload.itemsCreated ?? 0) == 0 && (payload.itemsSkipped ?? 0) > 0
-        let base = duplicate ? "Already saved" : "Added"
+        let created = payload.itemsCreated ?? 0
+        let duplicate = created == 0 && (payload.itemsSkipped ?? 0) > 0
+        let base: String
+        if created > 1 {
+            base = "Added \(created) releases"
+        } else if duplicate {
+            base = "Already saved"
+        } else {
+            base = "Added"
+        }
         let names = (payload.lists ?? []).map(\.name)
         return names.isEmpty ? base : "\(base) to \(names.joined(separator: ", "))"
     }
@@ -1154,6 +1229,201 @@ private final class ListPickerViewController: UITableViewController {
             self.tableView.reloadData()
         })
         present(alert, animated: true)
+    }
+}
+
+/// A multi-select release picker pushed when the shared page mentions several
+/// releases — the native twin of the web app's LinkPickerModal.
+///
+/// The server answered `409 ambiguous_link` instead of adding anything, so
+/// nothing is saved until the user picks. Every candidate row toggles a
+/// checkmark; a "Select all" row above them checks the lot (or clears it when
+/// everything is already checked). **Add** re-posts the link with the chosen
+/// candidate ids and is disabled until at least one release is picked. Going
+/// back returns to the compose form / list picker with the note, lists, and
+/// reminder untouched — the next Add just asks the server again.
+private final class ReleasePickerViewController: UITableViewController {
+    /// Called with the selected candidate ids when the user taps Add.
+    var onAdd: (([String]) -> Void)?
+
+    private let message: String
+    private let candidates: [ShareViewController.AmbiguousLinkResponse.Candidate]
+    // Selection order is preserved so the posted ids match the tap order.
+    private var selectedIds: [String] = []
+
+    private lazy var addButton = UIBarButtonItem(
+        title: "Add", style: .done, target: self, action: #selector(didTapAdd)
+    )
+    private let spinner = UIActivityIndicatorView(style: .medium)
+    private var isPosting = false
+
+    init(message: String, candidates: [ShareViewController.AmbiguousLinkResponse.Candidate]) {
+        self.message = message
+        self.candidates = candidates
+        super.init(style: .plain)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Releases"
+        // Same Winamp black playlist treatment as the list picker.
+        tableView.backgroundColor = OTBTheme.playlistBg
+        tableView.separatorColor = OTBTheme.navyBorder
+        tableView.tintColor = OTBTheme.accent // checkmark colour
+
+        // The server's "pick one or more" prompt, as a chrome banner above the
+        // playlist so the sudden extra screen explains itself.
+        let banner = UILabel()
+        banner.text = message
+        banner.font = OTBTheme.ui(13)
+        banner.textColor = .black
+        banner.numberOfLines = 0
+        let bannerWrap = BeveledView(style: .raised, fill: OTBTheme.chromePanel)
+        banner.translatesAutoresizingMaskIntoConstraints = false
+        bannerWrap.addSubview(banner)
+        NSLayoutConstraint.activate([
+            banner.topAnchor.constraint(equalTo: bannerWrap.topAnchor, constant: 10),
+            banner.bottomAnchor.constraint(equalTo: bannerWrap.bottomAnchor, constant: -10),
+            banner.leadingAnchor.constraint(equalTo: bannerWrap.leadingAnchor, constant: 12),
+            banner.trailingAnchor.constraint(equalTo: bannerWrap.trailingAnchor, constant: -12),
+        ])
+        bannerWrap.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: tableView.bounds.width,
+            height: 1 // resized below once Auto Layout knows the text height
+        )
+        tableView.tableHeaderView = bannerWrap
+
+        navigationItem.rightBarButtonItem = addButton
+        addButton.isEnabled = false
+        // The bar is the blue title-bar gradient, so a default grey spinner all
+        // but disappears on it.
+        spinner.color = .white
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Size the header banner to its text: table header views don't get
+        // Auto Layout for free, so measure and re-set when the height changes.
+        guard let header = tableView.tableHeaderView else { return }
+        let height = header.systemLayoutSizeFitting(
+            CGSize(width: tableView.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        if abs(header.frame.height - height) > 0.5 {
+            header.frame.size = CGSize(width: tableView.bounds.width, height: height)
+            tableView.tableHeaderView = header
+        }
+    }
+
+    /// While a post is in flight, swap Add for a spinner and lock the screen —
+    /// including the back button, so the request can't be re-entered.
+    func setPosting(_ posting: Bool) {
+        isPosting = posting
+        tableView.isUserInteractionEnabled = !posting
+        navigationItem.hidesBackButton = posting
+        if posting {
+            spinner.startAnimating()
+            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinner)
+        } else {
+            spinner.stopAnimating()
+            navigationItem.rightBarButtonItem = addButton
+            addButton.isEnabled = !selectedIds.isEmpty
+        }
+    }
+
+    @objc private func didTapAdd() {
+        guard !selectedIds.isEmpty else { return }
+        onAdd?(selectedIds)
+    }
+
+    // Section 0: "Select all". Section 1: the candidates (checkmark = will be added).
+    override func numberOfSections(in tableView: UITableView) -> Int { 2 }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        section == 0 ? 1 : candidates.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == 0 {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "selectAll")
+                ?? UITableViewCell(style: .default, reuseIdentifier: "selectAll")
+            cell.backgroundColor = .clear
+            cell.textLabel?.font = OTBTheme.ui(14)
+            cell.textLabel?.textColor = OTBTheme.accent
+            cell.textLabel?.text = selectedIds.count == candidates.count ? "Select none" : "Select all"
+            cell.accessoryType = .none
+            let highlight = UIView()
+            highlight.backgroundColor = OTBTheme.playlistSelectedBg
+            cell.selectedBackgroundView = highlight
+            return cell
+        }
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "candidate")
+            ?? UITableViewCell(style: .subtitle, reuseIdentifier: "candidate")
+
+        cell.backgroundColor = .clear
+        let highlight = UIView()
+        highlight.backgroundColor = OTBTheme.playlistSelectedBg
+        cell.selectedBackgroundView = highlight
+
+        let candidate = candidates[indexPath.row]
+        cell.textLabel?.text = candidate.title
+        cell.textLabel?.font = OTBTheme.ui(14)
+        cell.textLabel?.textColor = OTBTheme.playlistText
+        cell.detailTextLabel?.text = candidate.artist
+        cell.detailTextLabel?.font = OTBTheme.ui(11)
+        cell.detailTextLabel?.textColor = OTBTheme.accent
+        cell.accessoryType = selectedIds.contains(candidate.candidateId) ? .checkmark : .none
+        return cell
+    }
+
+    /// Zebra-stripe the candidate rows, matching the playlist's alternating
+    /// row backgrounds (--playlist-bg / --playlist-bg-alt).
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard indexPath.section == 1 else {
+            cell.backgroundColor = OTBTheme.playlistBg
+            return
+        }
+        cell.backgroundColor = indexPath.row.isMultiple(of: 2) ? OTBTheme.playlistBg : OTBTheme.playlistBgAlt
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        if indexPath.section == 0 {
+            // Toggle between everything and nothing.
+            if selectedIds.count == candidates.count {
+                selectedIds = []
+            } else {
+                selectedIds = candidates.map(\.candidateId)
+            }
+            tableView.reloadData()
+            addButton.isEnabled = !selectedIds.isEmpty && !isPosting
+            return
+        }
+
+        toggle(candidates[indexPath.row].candidateId)
+        tableView.reloadRows(at: [indexPath], with: .none)
+        // The "Select all" label flips to "Select none" once everything's checked.
+        tableView.reloadSections(IndexSet(integer: 0), with: .none)
+    }
+
+    /// Add or remove a candidate id from the selection and re-gate Add.
+    private func toggle(_ id: String) {
+        if let index = selectedIds.firstIndex(of: id) {
+            selectedIds.remove(at: index)
+        } else {
+            selectedIds.append(id)
+        }
+        addButton.isEnabled = !selectedIds.isEmpty && !isPosting
     }
 }
 

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -200,15 +200,27 @@ async function insertMusicItemWithLink(
   return item;
 }
 
-function resolveSelectedCandidate(
+/**
+ * The candidates a client explicitly picked, in selection order. Accepts both
+ * the single `selectedCandidateId` (web link picker resubmits one at a time)
+ * and the plural `selectedCandidateIds` (the share sheet's release picker
+ * posts its whole selection in one request). Unknown ids are dropped — a
+ * candidate list is regenerated per scrape, so a stale id just falls through
+ * to the ambiguous flow again rather than erroring.
+ */
+function resolveSelectedCandidates(
   candidates: ReleaseCandidateInput[],
-  selectedCandidateId: string | undefined,
-): ReleaseCandidateInput | null {
-  if (!selectedCandidateId) {
-    return null;
+  overrides: Partial<CreateMusicItemInput> | undefined,
+): ReleaseCandidateInput[] {
+  const ids: string[] = [];
+  if (overrides?.selectedCandidateId) ids.push(overrides.selectedCandidateId);
+  for (const id of overrides?.selectedCandidateIds ?? []) {
+    if (typeof id === "string" && id && !ids.includes(id)) ids.push(id);
   }
 
-  return candidates.find((candidate) => candidate.candidateId === selectedCandidateId) ?? null;
+  return ids
+    .map((id) => candidates.find((candidate) => candidate.candidateId === id))
+    .filter((candidate): candidate is ReleaseCandidateInput => candidate != null);
 }
 
 async function resolveReleaseCandidates(
@@ -260,12 +272,10 @@ async function resolveReleaseCandidates(
     throw new UnsupportedMusicLinkError("Couldn't extract a release from this link");
   }
 
-  const selectedCandidate = resolveSelectedCandidate(
-    extractedCandidates,
-    overrides?.selectedCandidateId,
-  );
+  const selectedCandidates = resolveSelectedCandidates(extractedCandidates, overrides);
 
-  if (selectedCandidate) {
+  if (selectedCandidates.length === 1) {
+    const selectedCandidate = selectedCandidates[0]!;
     return {
       normalizedUrl: parsed.normalizedUrl,
       source: parsed.source,
@@ -277,6 +287,17 @@ async function resolveReleaseCandidates(
           itemType: overrides?.itemType ?? selectedCandidate.itemType,
         },
       ],
+    };
+  }
+
+  if (selectedCandidates.length > 1) {
+    // Several releases picked from one page: create each as extracted. The
+    // title/artist/itemType overrides are per-item corrections, so they only
+    // make sense for a single selection and are ignored here.
+    return {
+      normalizedUrl: parsed.normalizedUrl,
+      source: parsed.source,
+      candidates: selectedCandidates,
     };
   }
 

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -1,7 +1,11 @@
 import { Hono } from "hono";
 import { asc, count, eq } from "drizzle-orm";
 import { extractMusicUrls } from "../email-parser";
-import { createMusicItemDirect, createMusicItemsFromUrl } from "../music-item-creator";
+import {
+  AmbiguousLinkSelectionError,
+  createMusicItemDirect,
+  createMusicItemsFromUrl,
+} from "../music-item-creator";
 import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
 import { isValidUrl } from "../utils";
 import { saveImageFromBase64, validateImageBase64 } from "../uploads";
@@ -137,6 +141,28 @@ function parseRemindAt(body: unknown): { date: Date | null } | { error: string }
   const date = new Date(remindAt);
   if (isNaN(date.getTime())) return { error: "remindAt must be a valid date" };
   return { date };
+}
+
+/**
+ * Gather the release candidate ids a /link request selected — the share
+ * sheet's second POST after a multi-release page came back as 409
+ * `ambiguous_link`. Trims each, drops blanks/non-strings, and de-dupes.
+ */
+function collectSelectedCandidateIds(body: unknown): string[] {
+  if (!body || typeof body !== "object") return [];
+  const { selectedCandidateIds } = body as Record<string, unknown>;
+  if (!Array.isArray(selectedCandidateIds)) return [];
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const value of selectedCandidateIds) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ids.push(trimmed);
+  }
+  return ids;
 }
 
 /**
@@ -331,6 +357,11 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
     const overrides: Partial<CreateMusicItemInput> = {};
     if (notes) overrides.notes = notes;
 
+    // The share sheet's answer to an earlier `ambiguous_link` response: which
+    // of the page's releases to add. One item is created per selected id.
+    const selectedCandidateIds = collectSelectedCandidateIds(body);
+    if (selectedCandidateIds.length) overrides.selectedCandidateIds = selectedCandidateIds;
+
     try {
       const results = Object.keys(overrides).length
         ? await createMusicItemsFromUrl(url, overrides)
@@ -375,6 +406,13 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
         lists,
       });
     } catch (err) {
+      if (err instanceof AmbiguousLinkSelectionError) {
+        // The page names several releases and none stood out as primary. Hand
+        // the candidates back (same 409 shape as POST /api/music-items) so the
+        // share sheet can show its release picker and re-post a selection.
+        return c.json(err.payload, 409);
+      }
+
       console.error(`[api] POST /api/ingest/link failed for ${url}:`, err);
       return c.json({ error: "Failed to create item" }, 422);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,12 @@ export interface CreateMusicItemInput {
   musicbrainzReleaseId?: string;
   musicbrainzArtistId?: string;
   selectedCandidateId?: string;
+  /**
+   * Multi-select counterpart to `selectedCandidateId`, used when a page names
+   * several releases and the client picked more than one — the share sheet's
+   * release picker sends these. One item is created per resolved candidate.
+   */
+  selectedCandidateIds?: string[];
 }
 
 export interface UpdateMusicItemInput {

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -372,6 +372,115 @@ describe("POST /api/ingest/link with list and notes", () => {
   });
 });
 
+describe("POST /api/ingest/link with multiple releases", () => {
+  const originalEnv = { ...process.env };
+  const url = "https://blog.example.com/best-albums-2026";
+
+  const ambiguousPayload = {
+    kind: "ambiguous_link" as const,
+    url,
+    message: "This link mentions several releases. Pick one or more to add.",
+    candidates: [
+      { candidateId: "first-album", artist: "Artist A", title: "First Album" },
+      { candidateId: "second-album", artist: "Artist B", title: "Second Album" },
+    ],
+  };
+
+  beforeEach(() => {
+    process.env.INGEST_API_KEY = "test-secret";
+    delete process.env.INGEST_ENABLED;
+    mockCreateMany.mockReset();
+    mockResolveOrCreateStack.mockReset();
+    mockAttachItemToStack.mockReset();
+    mockSetItemReminder.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns 409 with the candidates when the page is ambiguous", async () => {
+    mockCreateMany.mockRejectedValue(new realCreator.AmbiguousLinkSelectionError(ambiguousPayload));
+
+    const app = makeApp();
+    const res = await makeLinkRequest(app, { url }, { apiKey: "test-secret" });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.kind).toBe("ambiguous_link");
+    expect(body.url).toBe(url);
+    expect(body.candidates).toHaveLength(2);
+    expect(body.candidates[0].candidateId).toBe("first-album");
+  });
+
+  it("passes selectedCandidateIds through to the item creator", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 1, title: "First Album", primary_url: url } as any, created: true },
+      { item: { id: 2, title: "Second Album", primary_url: url } as any, created: true },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      { url, selectedCandidateIds: ["first-album", "second-album"] },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(mockCreateMany).toHaveBeenCalledWith(url, {
+      selectedCandidateIds: ["first-album", "second-album"],
+    });
+    expect(body.items_created).toBe(2);
+    expect(body.items).toHaveLength(2);
+  });
+
+  it("trims, drops blanks, and de-dupes the selected candidate ids", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 1, title: "First Album", primary_url: url } as any, created: true },
+    ]);
+
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      { url, selectedCandidateIds: ["first-album", " first-album ", "", 7, null] },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateMany).toHaveBeenCalledWith(url, {
+      selectedCandidateIds: ["first-album"],
+    });
+  });
+
+  it("files every created item into the chosen lists and applies the reminder", async () => {
+    mockCreateMany.mockResolvedValue([
+      { item: { id: 1, title: "First Album", primary_url: url } as any, created: true },
+      { item: { id: 2, title: "Second Album", primary_url: url } as any, created: true },
+    ]);
+    mockResolveOrCreateStack.mockResolvedValue({ id: 3, name: "Jazz finds" });
+
+    const app = makeApp();
+    const res = await makeLinkRequest(
+      app,
+      {
+        url,
+        selectedCandidateIds: ["first-album", "second-album"],
+        listName: "Jazz finds",
+        remindAt: "2026-08-15",
+      },
+      { apiKey: "test-secret" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(1, 3);
+    expect(mockAttachItemToStack).toHaveBeenCalledWith(2, 3);
+    expect(mockSetItemReminder).toHaveBeenCalledTimes(2);
+    expect(mockSetItemReminder).toHaveBeenCalledWith(1, new Date("2026-08-15"));
+    expect(mockSetItemReminder).toHaveBeenCalledWith(2, new Date("2026-08-15"));
+  });
+});
+
 describe("POST /api/ingest/link with a scheduled date", () => {
   const originalEnv = { ...process.env };
   const url = "https://artist.bandcamp.com/album/cool-album";
@@ -1133,7 +1242,11 @@ describe("POST /api/ingest/photo", () => {
     mockCreateDirect.mockResolvedValue({ item: { id: 1, title: "Untitled" }, created: true });
 
     const app = makeApp();
-    const res = await makePhotoRequest(app, { imageBase64: validBase64 }, { apiKey: "test-secret" });
+    const res = await makePhotoRequest(
+      app,
+      { imageBase64: validBase64 },
+      { apiKey: "test-secret" },
+    );
 
     expect(res.status).toBe(200);
     const body = await res.json();


### PR DESCRIPTION
## What

Sharing a webpage that names several releases (e.g. a best-of-the-year blog post) failed from the share sheet with a generic error, even though the web app already resolves the same pages through its link picker. This wires the existing multi-release flow into the share sheet end to end.

## Server

- `POST /api/ingest/link` now returns the `AmbiguousLinkSelectionError` payload as a **409** (`kind: "ambiguous_link"`, same shape as `POST /api/music-items`) instead of swallowing it into a 422, and accepts a `selectedCandidateIds` array on re-post.
- `resolveReleaseCandidates` in `music-item-creator.ts` understands a plural selection (alongside the web picker's singular `selectedCandidateId`) and returns every chosen candidate, so a single request creates one item per picked release. Unknown/stale ids are dropped rather than erroring.
- Lists, the note, and the reminder apply to every created item, matching the existing single-release behaviour.

## Share extension

- `ShareViewController` decodes the 409 payload and pushes a multi-select **release picker** — same Winamp-playlist styling as the list picker — with a checkmark toggle per release, a "Select all" row, and its own Add button that re-posts the link with the chosen ids.
- Going back keeps the note, lists, and reminder intact; nothing is saved until the user picks.
- The confirmation toast reports "Added N releases" (plus lists) when several items were created.

## Tests

- New `POST /api/ingest/link with multiple releases` unit tests: 409 payload, `selectedCandidateIds` pass-through with trimming/de-duping, and list/reminder fan-out to every created item.
- `bun run test`: 704 pass, 0 fail. `bun run typecheck`: 0 errors. (Swift changes rely on the ios-build CI workflow — no Swift toolchain in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1cQ7HSSEu5eqo7fb3z7bE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1cQ7HSSEu5eqo7fb3z7bE)_