### PR TITLE
Move Settings from the footer to the start menu

### DIFF
--- a/playwright/start-menu.spec.ts
+++ b/playwright/start-menu.spec.ts
@@ -10,8 +10,9 @@ test("start menu opens, runs an action, and closes", async ({ page }) => {
   await startBtn.click();
   await expect(menu).toBeVisible();
   await expect(startBtn).toHaveAttribute("aria-expanded", "true");
-  // Add, Pick One, Search, Manage stacks, New releases, RSS feed
-  await expect(menu.locator(".start-menu__item")).toHaveCount(6);
+  // Add, Pick One, Search, Manage stacks, New releases, Settings, RSS feed
+  await expect(menu.locator(".start-menu__item")).toHaveCount(7);
+  await expect(menu.locator('.start-menu__item[href="/settings"]')).toBeVisible();
 
   // "Add a release" focuses the add input and closes the menu
   await menu.locator('[data-start-action="add"]').click();

--- a/src/lib/components/Taskbar.svelte
+++ b/src/lib/components/Taskbar.svelte
@@ -243,6 +243,9 @@
           {/if}
         </a>
         <div class="start-menu__divider" role="separator"></div>
+        <a class="start-menu__item" role="menuitem" href="/settings" onclick={closeStartMenu}>
+          <span class="start-menu__icon" aria-hidden="true">⚙️</span>Settings
+        </a>
         <a class="start-menu__item" role="menuitem" href="/feed/to-listen.rss" onclick={closeStartMenu}>
           <span class="start-menu__icon" aria-hidden="true">📡</span>RSS feed
         </a>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,7 +37,6 @@
 {#if !isReleasePage}
   <footer class="footer">
     <span id="app-version">v{__APP_VERSION__}</span>
-    <a class="footer__settings-link" href="/settings">Settings</a>
   </footer>
 {/if}
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3762,16 +3762,6 @@ a:hover {
 }
 
 /* ── Settings page ──────────────────────────────────────────────────────── */
-.footer__settings-link {
-  margin-left: auto;
-  color: var(--chrome-darker);
-  text-decoration: none;
-}
-
-.footer__settings-link:hover {
-  text-decoration: underline;
-}
-
 .settings {
   max-width: 560px;
   margin: 0 auto;


### PR DESCRIPTION
Moves the Settings link out of the footer status bar and into the start menu, which is already the canonical home for primary actions.

## Changes

- `src/lib/components/Taskbar.svelte` — adds a ⚙️ Settings item to the start menu, below the divider alongside RSS feed.
- `src/routes/+layout.svelte` — removes the Settings link from the footer, leaving it to carry the version alone.
- `src/styles/main.css` — drops the now-unused `.footer__settings-link` rules.
- `playwright/start-menu.spec.ts` — item count 6 → 7, plus an assertion that the Settings item is present.

## Notes

The start menu (and the footer) are both hidden on release pages, so this doesn't change reachability there.

## Testing

- `bun run test` — 704 pass, 0 fail
- `bun run typecheck` — 0 errors
- `bunx playwright test playwright/start-menu.spec.ts` — passes
- `bun run test:visual` — all 6 desktop/mobile baselines pass unchanged
- Checked the open menu at 1280px and 390px widths; the new item sits in the existing list with no wrapping or overflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nknd7p4NcNeo2txcRQivvC)_