### PR TITLE
Set the artist watch rating bar with stars, not a number field

### DIFF
--- a/playwright/artist-rating-bar.spec.ts
+++ b/playwright/artist-rating-bar.spec.ts
@@ -1,0 +1,64 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures/parallel-test";
+
+// The minimum-artist-rating bar on the settings page uses the same star control
+// as an item's rating, so the gestures have to match: the right half of a star
+// sets it whole, the left half sets a half step, and clicking the selected
+// value again clears the bar back to "no bar".
+
+test.beforeEach(async ({ request }) => {
+  await request.post("/api/__test__/reset");
+});
+
+const STARS = '[aria-label="Minimum artist rating"]';
+const VALUE = "[data-min-artist-rating]";
+
+/**
+ * Click a star at a chosen point across its width. Playwright's own `.click()`
+ * aims at the centre — exactly the half/whole boundary — so sub-pixel layout
+ * decides the outcome. Every click here is deliberately off-centre.
+ */
+async function clickStar(page: Page, value: number, fraction: number): Promise<void> {
+  const star = page.locator(STARS).locator(`[data-rating-star="${value}"]`);
+  await expect(star).toBeVisible({ timeout: 10_000 });
+  const box = await star.boundingBox();
+  if (!box) throw new Error(`star ${value} has no bounding box`);
+
+  await Promise.all([
+    page.waitForResponse(
+      (resp) => resp.url().includes("/api/settings") && resp.request().method() === "PUT",
+    ),
+    page.mouse.click(box.x + box.width * fraction, box.y + box.height / 2),
+  ]);
+}
+
+test("the minimum artist rating bar is set with stars and persists", async ({ page }) => {
+  await page.goto("/settings");
+
+  await expect(page.locator(STARS)).toBeVisible({ timeout: 10_000 });
+  // Unset by default, so the value reads as off rather than as zero stars.
+  await expect(page.locator(VALUE)).toHaveAttribute("data-min-artist-rating", "0");
+
+  await clickStar(page, 4, 0.75);
+  await expect(page.locator(VALUE)).toHaveAttribute("data-min-artist-rating", "4");
+
+  await page.reload();
+  await expect(page.locator(STARS).locator('[data-rating-star="4"]')).toHaveClass(
+    /is-active-full/,
+    { timeout: 5_000 },
+  );
+
+  // Clicking the selected star again clears the bar back to "any artist".
+  await clickStar(page, 4, 0.75);
+  await expect(page.locator(VALUE)).toHaveAttribute("data-min-artist-rating", "0");
+  await expect(page.locator(STARS).locator('[data-rating-star="4"]')).not.toHaveClass(/is-active/);
+});
+
+test("the left half of a star sets a half-step bar", async ({ page }) => {
+  await page.goto("/settings");
+
+  await clickStar(page, 3, 0.25);
+
+  await expect(page.locator(VALUE)).toHaveAttribute("data-min-artist-rating", "2.5");
+  await expect(page.locator(STARS).locator('[data-rating-star="3"]')).toHaveClass(/is-active-half/);
+});

--- a/src/lib/components/StarRating.svelte
+++ b/src/lib/components/StarRating.svelte
@@ -10,11 +10,19 @@
     itemId,
     rating,
     className = "",
+    label = "Rating",
     onRate,
   }: {
-    itemId: number;
+    /**
+     * The item being rated, stamped as `data-item-id` for the list code that
+     * scrolls to a card. Omitted when the stars aren't attached to an item —
+     * the settings page uses them to pick a threshold, not to rate anything.
+     */
+    itemId?: number;
     rating: number | null;
     className?: string;
+    /** Group label for screen readers; override when it isn't an item rating. */
+    label?: string;
     /** Persist the new rating; throw to roll back the optimistic update. */
     onRate: (next: number | null) => Promise<void>;
   } = $props();
@@ -88,7 +96,7 @@
   data-item-id={itemId}
   data-rating-value={selected ?? ""}
   role="group"
-  aria-label="Rating"
+  aria-label={label}
   onpointerleave={onPointerLeave}
 >
   {#each stars as value (value)}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,6 +3,7 @@
   import { apiFetch } from "$lib/api";
   import { musickit, authorize, unauthorize, ensureConfigured } from "$lib/musickit.svelte";
   import { api } from "$lib/api";
+  import StarRating from "$lib/components/StarRating.svelte";
   import type { LookupService, ReleaseLengthPreference } from "../../../server/settings";
   import type { ArtistFollowState, MbArtistCandidateView, TrackedArtist } from "../../types";
 
@@ -121,6 +122,15 @@
   // svelte-ignore state_referenced_locally
   let watch = $state({ ...data.artistWatch });
   let watchStatusMessage = $state("");
+
+  // The stars can't paint 0 — the control's own "off" is null — so the bar's
+  // value is spelled out beside them. It also carries the only cue for how to
+  // get back to off, which is the same gesture as clearing a record's rating.
+  const minArtistRatingLabel = $derived(
+    watch.minArtistRating > 0
+      ? `${watch.minArtistRating} star${watch.minArtistRating === 1 ? "" : "s"} (click again to clear)`
+      : "no bar — any artist you've listened to"
+  );
 
   async function saveWatch(update: Record<string, unknown>): Promise<void> {
     watchStatusMessage = "Saving…";
@@ -365,21 +375,17 @@
           />
           <span>months</span>
         </label>
-        <label class="settings__option settings__option--field">
+        <div class="settings__option settings__option--field settings__option--stars">
           <span>Only watch artists with a release rated at least</span>
-          <input
-            type="number"
-            class="settings__number"
-            name="min-artist-rating"
-            min="0"
-            max="5"
-            step="0.5"
-            value={watch.minArtistRating}
-            onchange={(event) =>
-              saveWatch({ alertMinArtistRating: Number(event.currentTarget.value) })}
+          <StarRating
+            rating={watch.minArtistRating > 0 ? watch.minArtistRating : null}
+            label="Minimum artist rating"
+            onRate={(next) => saveWatch({ alertMinArtistRating: next ?? 0 })}
           />
-          <span>stars (0 = any artist you've listened to)</span>
-        </label>
+          <span class="settings__value" data-min-artist-rating={watch.minArtistRating}>
+            {minArtistRatingLabel}
+          </span>
+        </div>
       </form>
       <p id="artist-watch-status" class="settings__status" role="status" aria-live="polite">
         {watchStatusMessage}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4175,6 +4175,30 @@ a:hover {
   flex-wrap: wrap;
 }
 
+/* The stars are the only interactive part of the row, so the row itself no
+   longer offers a label's pointer. */
+.settings__option--stars {
+  cursor: default;
+}
+
+/* The bar's value in words, beside the stars: five glyphs can't show "off",
+   and "3.5" is quicker to read than it is to count. */
+.settings__value {
+  font-size: var(--text-sm);
+  color: var(--chrome-darker);
+}
+
+/* Narrow screens: give the sentence, the stars and the value a line each.
+   Left to wrap, the phrase breaks mid-clause around the star block and the
+   24px targets end up crowded against the text. */
+@media (max-width: 520px) {
+  .settings__option--stars {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+  }
+}
+
 .settings__number {
   width: 60px;
   padding: 2px 4px;


### PR DESCRIPTION
The minimum-artist-rating setting shipped as a 0–5 number spinner, sitting in a section where every other rating in the app is painted as stars. This swaps it for the existing `StarRating` control, so the bar is set with the same gesture as rating a record: right half of a star for a whole one, left half for a half step, and clicking the selected value again clears it.

**Before:** `Only watch artists with a release rated at least [ 3.5 ] stars (0 = any artist you've listened to)`

**After:** `Only watch artists with a release rated at least ★★★⯪☆ 3.5 stars (click again to clear)`

## Notes

- The control's "off" is `null` and the setting's is `0`, so the two are mapped at the edge of the component rather than teaching either side about the other. No server or API change — this is still `alertMinArtistRating`, still 0–5 in half steps.
- Five glyphs can't paint "no bar", and they can't tell you that clicking again is how you get back to it, so the value is spelled out beside them ("no bar — any artist you've listened to", or "3.5 stars (click again to clear)").
- `StarRating` gains an optional `itemId` — these stars pick a threshold rather than rate an item, so there's no id to stamp — and a `label` prop so the group doesn't announce itself to screen readers as "Rating".
- The row was a `<label>` wrapping a single input; with a button group inside, it's now a plain `<div>` and the group carries its own `aria-label`.

## Small screens

The row is three parts and a wrap broke the phrase mid-clause around the star block, so under 520px the sentence, the stars and the value each take a line. Star hit areas stay at 24px (WCAG 2.5.8).

| Desktop | Mobile (390px) |
| --- | --- |
| label, stars and value on one line | each on its own line |

## Testing

- `playwright/artist-rating-bar.spec.ts` (new) — setting the bar with a whole star, persistence across reload, clearing back to 0, and the left half of a star setting a half step. Both pass. Clicks are deliberately off-centre: Playwright's own `.click()` aims at the exact half/whole boundary, so sub-pixel layout would decide the outcome.
- `bun run test:unit` — 704 pass, 0 fail
- `bun run typecheck` — 0 errors over 1160 files
- `bun run lint` — 0 errors (3 pre-existing warnings, none in touched files)
- `bun run test:visual` — 6 pass; the settings page isn't in the visual snapshots and the card/release-page stars render unchanged
- `bun run test:e2e` — the 3 failures in `persistent-player.spec.ts` reproduce on `main` unchanged and are unrelated to this diff

---
_Generated by [Claude Code](https://claude.ai/code/session_018Jowv37phiForS2WMkRYQ7)_