### PR TITLE
Record the source page on releases lifted from multi-release pages

### DIFF
--- a/docs/areas/integrations/ingest.md
+++ b/docs/areas/integrations/ingest.md
@@ -12,6 +12,11 @@
 - Extracted URLs are normalized through `parseUrl()` so duplicate links collapse before creation.
 - Unknown sources can still be passed through when ingest opts into `includeUnknown`.
 
+## Provenance notes
+
+- A page that names several releases (a round-up, chart, or label page) stamps every item created from it with `From <page title> (<url>)`, appended to any note the request supplied with the same ` — ` separator the photo ingest uses.
+- The note is skipped when the page named a single release, and when one candidate is auto-picked as the page's own subject — in both cases the item's link already says where it came from.
+
 ## Result shape
 
 Both ingest paths return or log created-versus-skipped counts. Duplicate links are treated as skips instead of hard failures.

--- a/server/music-item-creator.ts
+++ b/server/music-item-creator.ts
@@ -87,6 +87,40 @@ interface ReleaseCandidateInput {
   embedMetadata?: Record<string, string>;
   year?: number;
   genre?: string;
+  /** Provenance line for a release lifted off a page that named several — see `formatPageSourceNote`. */
+  sourceNote?: string;
+}
+
+const MAX_SOURCE_NOTE_TITLE_CHARS = 120;
+
+/**
+ * The provenance line stamped on items pulled off a page listing several
+ * releases. A single item's title says nothing about the round-up, chart, or
+ * label page it came from, so record the page itself: its title when the
+ * scrape found one, and the URL either way.
+ */
+export function formatPageSourceNote(url: string, pageTitle?: string): string {
+  const title = pageTitle?.replace(/\s+/g, " ").trim();
+  if (!title) return `From ${url}`;
+
+  const truncated =
+    title.length > MAX_SOURCE_NOTE_TITLE_CHARS
+      ? `${title.slice(0, MAX_SOURCE_NOTE_TITLE_CHARS - 1).trimEnd()}…`
+      : title;
+  return `From ${truncated} (${url})`;
+}
+
+/**
+ * Join whatever note the request supplied with the page's provenance line,
+ * using the same " — " separator the photo ingest uses for its "Via photo
+ * from …" suffix. Returns null when there's nothing to store.
+ */
+function composeNotes(notes: string | null | undefined, sourceNote?: string): string | null {
+  const parts = [notes, sourceNote]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+
+  return parts.length ? parts.join(" — ") : null;
 }
 
 export class AmbiguousLinkSelectionError extends Error {
@@ -166,7 +200,7 @@ async function insertMusicItemWithLink(
       artistId,
       listenStatus: overrides?.listenStatus ?? "to-listen",
       purchaseIntent: overrides?.purchaseIntent ?? "no",
-      notes: overrides?.notes ?? null,
+      notes: composeNotes(overrides?.notes, candidate.sourceNote),
       artworkUrl: overrides?.artworkUrl ?? candidate.artworkUrl ?? null,
       label: overrides?.label ?? null,
       year: overrides?.year ?? candidate.year ?? null,
@@ -256,17 +290,28 @@ async function resolveReleaseCandidates(
     };
   }
 
-  const extractedCandidates =
-    scraped?.releases?.map((release) => ({
-      candidateId: release.candidateId,
-      title: release.title || "Untitled",
-      artistName: release.artist,
-      itemType: release.itemType ?? "album",
-      artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
-      confidence: release.confidence,
-      evidence: release.evidence,
-      isPrimary: release.isPrimary,
-    })) ?? [];
+  const releases = scraped?.releases ?? [];
+
+  // A page naming several releases is a round-up, chart, or label page rather
+  // than a release page: which page an item came off is worth keeping, so every
+  // item created from it gets the page stamped on its notes. A page that named
+  // just the one release needs no such note — its link says it all.
+  const sourceNote =
+    releases.length > 1
+      ? formatPageSourceNote(parsed.normalizedUrl, scraped?.pageTitle)
+      : undefined;
+
+  const extractedCandidates = releases.map((release) => ({
+    candidateId: release.candidateId,
+    title: release.title || "Untitled",
+    artistName: release.artist,
+    itemType: release.itemType ?? "album",
+    artworkUrl: overrides?.artworkUrl ?? scraped?.imageUrl ?? null,
+    confidence: release.confidence,
+    evidence: release.evidence,
+    isPrimary: release.isPrimary,
+    sourceNote,
+  }));
 
   if (extractedCandidates.length === 0) {
     throw new UnsupportedMusicLinkError("Couldn't extract a release from this link");
@@ -311,6 +356,7 @@ async function resolveReleaseCandidates(
           artistName: overrides.artistName?.trim() || undefined,
           itemType: overrides.itemType ?? "album",
           artworkUrl: overrides.artworkUrl ?? scraped?.imageUrl ?? null,
+          sourceNote,
         },
       ],
     };
@@ -329,7 +375,10 @@ async function resolveReleaseCandidates(
       return {
         normalizedUrl: parsed.normalizedUrl,
         source: parsed.source,
-        candidates: [chosen],
+        // The page mentioned others but is mainly about this release — it *is*
+        // the release's page, so its link already says where the item came
+        // from and a provenance note would only repeat it.
+        candidates: [{ ...chosen, sourceNote: undefined }],
       };
     }
   }

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -23,6 +23,8 @@ export interface ScrapedMetadata {
   itemType?: ItemType;
   imageUrl?: string;
   releases?: ExtractedReleaseCandidate[];
+  /** The page's own title (og:title, else <title>) — names the page a release was lifted from. */
+  pageTitle?: string;
   embedMetadata?: Record<string, string>;
   year?: number;
   genre?: string;
@@ -226,6 +228,7 @@ async function scrapeUnknownUrl(url: string, html: string, og: OgData): Promise<
     potentialTitle: primary?.title,
     itemType: primary?.itemType,
     imageUrl: og.ogImage,
+    pageTitle: og.ogTitle || og.title,
     releases,
   };
 }

--- a/tests/unit/creator-page-source-notes.test.ts
+++ b/tests/unit/creator-page-source-notes.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, spyOn, mock, afterEach } from "bun:test";
+import { createMusicItemsFromUrl, formatPageSourceNote } from "../../server/music-item-creator";
+
+// Unsupported pages go through the Mistral extractor, and freshly created items
+// kick off background lookups — keep both off the network.
+process.env.MISTRAL_API_KEY = "test-key";
+process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+
+/** The shape `@mistralai/mistralai` expects back from chat.complete. */
+function mockChatCompletionResponse(content: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "cmpl_test_1",
+      object: "chat.completion",
+      created: 1,
+      model: "mistral-small-latest",
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content } }],
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+}
+
+function pageHtml(title: string): string {
+  return `
+    <html>
+      <head>
+        <meta property="og:title" content="${title}">
+      </head>
+      <body>
+        <h1>${title}</h1>
+        <p>Our favourite album releases of the year, on vinyl and cassette.</p>
+      </body>
+    </html>
+  `;
+}
+
+/** Serve the page HTML, then the extractor's JSON, to one scrape. */
+function mockScrape(title: string, releasesJson: string) {
+  const fetchSpy = spyOn(globalThis, "fetch");
+  fetchSpy.mockResolvedValueOnce(
+    new Response(pageHtml(title), { headers: { "content-type": "text/html; charset=utf-8" } }),
+  );
+  fetchSpy.mockResolvedValueOnce(mockChatCompletionResponse(releasesJson));
+  return fetchSpy;
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("formatPageSourceNote", () => {
+  test("names the page and its URL", () => {
+    expect(formatPageSourceNote("https://example.com/best-of", "Best of 2026")).toBe(
+      "From Best of 2026 (https://example.com/best-of)",
+    );
+  });
+
+  test("falls back to the bare URL when the page had no title", () => {
+    expect(formatPageSourceNote("https://example.com/best-of")).toBe(
+      "From https://example.com/best-of",
+    );
+    expect(formatPageSourceNote("https://example.com/best-of", "   ")).toBe(
+      "From https://example.com/best-of",
+    );
+  });
+
+  test("collapses whitespace and truncates an overlong title", () => {
+    const note = formatPageSourceNote(
+      "https://example.com/x",
+      `The\n  best   albums ${"a".repeat(200)}`,
+    );
+    expect(note.startsWith("From The best albums ")).toBe(true);
+    expect(note.endsWith("… (https://example.com/x)")).toBe(true);
+    expect(note.length).toBeLessThan(160);
+  });
+});
+
+describe("createMusicItemsFromUrl: multi-release page provenance", () => {
+  test("stamps the page on every release picked off it", async () => {
+    mockScrape(
+      "Best albums of 2026",
+      '{"releases":[{"artist":"Kalte Sterne","title":"Nachtfahrt","itemType":"album"},{"artist":"Rue Basse","title":"Onze","itemType":"ep"}]}',
+    );
+
+    const results = await createMusicItemsFromUrl("https://roundup.example/best-of-2026", {
+      selectedCandidateIds: ["cand-1-kalte-sterne-nachtfahrt", "cand-2-rue-basse-onze"],
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.created)).toBe(true);
+    for (const result of results) {
+      expect(result.item.notes).toBe(
+        "From Best albums of 2026 (https://roundup.example/best-of-2026)",
+      );
+    }
+  });
+
+  test("keeps the shared note and appends the page to it", async () => {
+    mockScrape(
+      "Shop update: new arrivals",
+      '{"releases":[{"artist":"Halbe Zeit","title":"Tagwerk","itemType":"album"},{"artist":"Ninth Hour","title":"Slow Tide","itemType":"album"}]}',
+    );
+
+    const results = await createMusicItemsFromUrl("https://shop.example/new-arrivals", {
+      notes: "Via email from noreply@shop.example",
+      selectedCandidateIds: ["cand-1-halbe-zeit-tagwerk", "cand-2-ninth-hour-slow-tide"],
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.item.notes).toBe(
+      "Via email from noreply@shop.example — From Shop update: new arrivals (https://shop.example/new-arrivals)",
+    );
+  });
+
+  test("leaves a single-release page's item unnoted", async () => {
+    mockScrape(
+      "Marta Vega — Bajamar",
+      '{"releases":[{"artist":"Marta Vega","title":"Bajamar","itemType":"album","isPrimary":true}]}',
+    );
+
+    const results = await createMusicItemsFromUrl("https://label.example/bajamar");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.created).toBe(true);
+    expect(results[0]!.item.notes).toBeNull();
+  });
+
+  test("leaves the page's own release unnoted when it is picked automatically", async () => {
+    mockScrape(
+      "Ora Lune — Vent Debout",
+      '{"releases":[{"artist":"Ora Lune","title":"Vent Debout","itemType":"album","isPrimary":true,"confidence":0.9},{"artist":"Ora Lune","title":"Premier Jour","itemType":"album","confidence":0.3}]}',
+    );
+
+    const results = await createMusicItemsFromUrl("https://label.example/vent-debout");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.item.title).toBe("Vent Debout");
+    expect(results[0]!.item.notes).toBeNull();
+  });
+});

--- a/tests/unit/ingest.test.ts
+++ b/tests/unit/ingest.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from "bun:test";
 import { Hono } from "hono";
 // Imported before mock.module so the real exports can be passed through below.
 import * as realCreator from "../../server/music-item-creator";
+
+// Held before mock.module runs: it mutates the imported namespace in place, so
+// after mocking `realCreator.createMusicItemsFromUrl` *is* the stub. These are
+// what the afterAll below restores.
+const realCreateMusicItemsFromUrl = realCreator.createMusicItemsFromUrl;
+const realCreateMusicItemDirect = realCreator.createMusicItemDirect;
 
 const mockCreateMany = mock();
 const mockCreateDirect = mock();
@@ -26,6 +32,18 @@ mock.module("../../server/music-item-creator", () => ({
   createMusicItemsFromUrl: mockCreateMany,
   createMusicItemDirect: mockCreateDirect,
 }));
+
+// …and hand the real module back when this file is done. The mock outlives the
+// file otherwise, and test files run in no guaranteed order, so a later file
+// that drives the real creator (creator-page-source-notes.test.ts) would
+// otherwise get these stubs instead.
+afterAll(() => {
+  mock.module("../../server/music-item-creator", () => ({
+    ...realCreator,
+    createMusicItemsFromUrl: realCreateMusicItemsFromUrl,
+    createMusicItemDirect: realCreateMusicItemDirect,
+  }));
+});
 
 // Import after mocks are set up
 const { createIngestRoutes } = await import("../../server/routes/ingest");


### PR DESCRIPTION
Sharing a round-up ("best of 2026", a shop's new-arrivals page, a label
index) creates one item per picked release, and once created nothing on
the item says which page it came off — the title is just the release, and
a fortnight later the link is the only clue.

Stamp the page on every item created from a page that named several
releases: `From <page title> (<url>)`, appended to whatever note the
request already carried with the same " — " separator the photo ingest
uses for its "Via photo from …" suffix. The scraper now returns the
unknown page's own title (og:title, else <title>) for the note to use,
falling back to the bare URL when the page had none.

Pages naming a single release are left alone, as is the case where one
candidate is auto-picked as the page's own subject: there the page *is*
the release's page, so the item's link already says it.

Restore the real music-item-creator module after the ingest tests run —
bun's mock.module persists process-wide and mutates the imported
namespace in place, so the new creator test got the ingest stubs
depending on file order.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018K76kMJ5iJZhod5L6B1CCK