### PR TITLE
Open the mobile sort panel upward so it isn't hidden by the taskbar

### DIFF
--- a/playwright/mobile-sort-panel.spec.ts
+++ b/playwright/mobile-sort-panel.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "./fixtures/parallel-test";
+
+// On mobile the browse controls live in a dock fixed to the bottom of the
+// screen, so the sort panel has to open upward. Anchoring it below the row
+// (top: 100%) put it under the taskbar — visible only as a sliver of the
+// select — and left it over-constrained (top + bottom both set), collapsing
+// its height so the select and direction button spilled out of the frame.
+test.use({
+  viewport: { width: 390, height: 844 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+test("mobile sort panel opens fully on screen", async ({ page, request }) => {
+  for (const n of [1, 2, 3]) {
+    const res = await request.post("/api/music-items", {
+      data: { title: `Release ${n}`, artistName: `Artist ${n}` },
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+
+  await page.goto("/");
+  await expect(page.locator(".music-card").first()).toBeVisible();
+
+  await page.locator("#browse-sort-toggle").click();
+
+  const panel = page.locator("#browse-sort-panel");
+  await expect(panel).toBeInViewport({ ratio: 1 });
+
+  const select = page.locator("#browse-sort");
+  const direction = page.locator("#sort-direction-btn");
+  await expect(select).toBeInViewport({ ratio: 1 });
+  await expect(direction).toBeInViewport({ ratio: 1 });
+
+  // The panel must actually enclose its controls: a collapsed panel still
+  // reports its own box as on-screen while its contents overflow it.
+  const panelBox = (await panel.boundingBox())!;
+  for (const control of [select, direction]) {
+    const box = (await control.boundingBox())!;
+    expect(box.y).toBeGreaterThanOrEqual(panelBox.y);
+    expect(box.y + box.height).toBeLessThanOrEqual(panelBox.y + panelBox.height);
+    expect(box.x + box.width).toBeLessThanOrEqual(panelBox.x + panelBox.width);
+  }
+
+  // Sitting above the dock, not behind it.
+  const dockBox = (await page.locator(".filter-section").boundingBox())!;
+  expect(panelBox.y + panelBox.height).toBeLessThanOrEqual(dockBox.y);
+
+  // Both controls are still usable once shown.
+  await select.selectOption("artist-name");
+  await expect(page.locator(".music-card__artist").first()).toHaveText("Artist 3");
+  await direction.click();
+  await expect(page.locator(".music-card__artist").first()).toHaveText("Artist 1");
+});

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1586,10 +1586,15 @@ select.input {
     width: 100%;
   }
 
+  /* Full-bleed across the dock rather than a narrow overlay on the right, but
+     still opening upward: anchoring below the row (top: 100%) puts the panel
+     under the taskbar, off-screen. `top: auto` also un-does the
+     over-constrained top/bottom pair, which otherwise collapses the height. */
   .browse-tools__panel--sort {
-    top: 100%;
-    left: 0;
-    right: 0;
+    top: auto;
+    bottom: calc(100% + 8px);
+    left: -2px;
+    right: -2px;
     width: auto;
     min-width: 0;
   }


### PR DESCRIPTION
## Problem

Tapping the sort (↕) button on mobile appeared to do nothing — at most a sliver of the select peeked out from behind the taskbar.

Two things went wrong in the mobile breakpoint, both in `.browse-tools__panel--sort`:

1. **Anchored the wrong way.** The panel used `top: 100%`, i.e. *below* the browse-controls row. That made sense when the controls sat at the top of the page, but the row now lives in a dock fixed to the bottom of the screen, so "below" is under the taskbar and off-screen.
2. **Over-constrained, so it collapsed.** It set `top` without clearing the `bottom: calc(100% + 8px)` inherited from `.browse-tools__panel`. With both edges pinned and `height: auto`, the computed height solved negative and clamped — the panel rendered as a 16px box with the select and direction button spilling out of it.

The search panel and the Pick One rating menu already open upward for exactly this reason; the sort panel was the odd one out.

## Fix

CSS only, inside `@media (max-width: 520px)`:

- `top: auto` + `bottom: calc(100% + 8px)` — opens upward, and clearing `top` un-does the over-constrained pair so the height resolves from content again.
- `left: -2px; right: -2px` — spans the dock so the select and direction button stay side by side, aligned to the dock's bevel.

Measured at 390×844: the panel goes from a 386×16 box at y=812 (behind the taskbar) to a full 386×56 box at y=644, sitting above the dock.

| Before | After |
| --- | --- |
| Sliver of the select clipped by the taskbar | Full-width panel above the dock, select + `↓ Newest first` both usable |

Desktop is untouched — these rules only apply below 520px.

## Testing

- Added `playwright/mobile-sort-panel.spec.ts`, which opens the panel at a mobile viewport and asserts it is fully in the viewport, that it actually *encloses* the select and direction button (a collapsed panel still reports its own box as on-screen while its contents overflow), that it sits above the dock, and that both controls still drive the sort. Confirmed it fails against the previous CSS and passes with the fix.
- `bun run test` — 753 pass, 0 fail.
- `bun run typecheck` — 0 errors.
- `bun run test:e2e` — 46 pass. The 3 failures in `persistent-player.spec.ts` are pre-existing and unrelated: they add a real Bandcamp URL, which this sandbox can't reach. Verified they fail identically on the base commit.
- `bun run lint` — 3 warnings, 0 errors (pre-existing).

Note: `bun run format:check` flags 68 files repo-wide, including `main.css` before this change. I left that alone rather than fold an unrelated reformat into this diff; the new spec file is correctly formatted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2bszMNGknuXfqW75dNadj)_