### PR TITLE
Show the logo on the home-screen widget instead of a to-listen count

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -96,16 +96,16 @@ jobs:
         # genuinely compiled by the xcodebuild steps below.
         run: ruby scripts/add-widget-extension.rb
 
-      - name: Verify Widget macOS entitlements
-        # Same regression guard as the Share Extension: macOS always sandboxes an
-        # app extension, so without com.apple.security.network.client the widget's
-        # stats GET is silently denied and the count never loads. Assert the
-        # entitlements file grants network and the injector wired it (macOS-scoped)
-        # onto the widget target.
+      - name: Verify Widget sandbox + bundled logo
+        # macOS always sandboxes an app extension, so assert the entitlements
+        # file declares the sandbox and the injector wired it (macOS-scoped) onto
+        # the widget target. The widget's whole content is assets/logo.png, which
+        # it loads by filename, so also assert the injector copied it into the
+        # bundle — without it the widget falls back to a bare wordmark.
         run: |
-          grep -q 'com.apple.security.network.client' native/Widget/OTBWidget.entitlements
           grep -q 'com.apple.security.app-sandbox' native/Widget/OTBWidget.entitlements
           grep -q 'native/Widget/OTBWidget.entitlements' ios/App/App.xcodeproj/project.pbxproj
+          grep -q 'logo.png in Resources' ios/App/App.xcodeproj/project.pbxproj
 
       - name: Verify Share Extension macOS entitlements
         # Regression guard for a bug that only bit the real Mac app: macOS always

--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -145,36 +145,39 @@ To rebrand: replace `assets/logo.png` and run `bun run brand:assets` (then
 
 ## Home-screen Widget
 
-A small (square) **WidgetKit** widget shows how many releases are still queued
-**To Listen** — the one glanceable number for a listening tracker. It's the
-widget sibling of the Share Extension: hand-authored SwiftUI in
+A small (square) **WidgetKit** widget shows the logo — the surfing capybara on
+the black playlist well — and opens the app when tapped. That's all it does on
+purpose: the app is about enjoying music, not about clearing a queue, so the
+widget is a shortcut and a bit of character rather than a number to drive down.
+It's the widget sibling of the Share Extension: hand-authored SwiftUI in
 `native/Widget/OTBWidget.swift`, injected into the generated Xcode project by
 `scripts/add-widget-extension.rb` (extension point
 `com.apple.widgetkit-extension`), and compiled in CI by the same `ios-build.yml`
 job that builds the app and Share Extension.
 
-- **Data.** The widget fetches `GET /api/ingest/stats` (added in
-  `server/routes/ingest.ts`), which returns `{ "to_listen": N }`. It's
-  Bearer-authed with the **same** ingest key the Share Extension uses, so there's
-  nothing new to configure: the widget's `Info.plist` carries `OTBBaseURL`
-  (committed) and `OTBIngestAPIKey` (`$(OTB_INGEST_API_KEY)`, substituted at
-  build time), and its target reuses `native/ShareExtension/Secrets.xcconfig` as
-  its base configuration — one gitignored secret for the whole app. Any failure
-  (no key, offline, server error) renders a dash rather than an error.
-- **Refresh.** The timeline refreshes roughly every 30 minutes; WidgetKit budgets
-  background reloads, so the count is eventually-consistent, not live.
+- **Data: none.** The widget makes no network requests and needs no ingest key,
+  session or App Group. Its timeline is a single entry with a `.never` refresh
+  policy — there's nothing to reload.
+- **The image.** `scripts/add-widget-extension.rb` copies the brand master
+  `assets/logo.png` into the extension bundle (referenced in place, so the master
+  stays the single source of truth), and the view loads it by filename with
+  `UIImage(named: "logo")`. If that resource ever goes missing the view falls
+  back to a text wordmark rather than an empty tile.
+- **Families.** Home Screen `systemSmall` only. The Lock Screen accessory
+  families are rendered monochrome by the system, which reduces the logo to an
+  unreadable silhouette.
 - **Styling.** Like the Share Extension, the widget can't reach the web app's
   stylesheet, so the Windows 98 / Winamp look (black playlist well, electric-blue
-  accent, Verdana chrome type) is mirrored in the file's `OTBTheme`.
+  accent, Courier chrome type) is mirrored in the file's `OTBTheme`.
 - **Mac Catalyst + sandbox.** `SUPPORTS_MACCATALYST` is enabled and
-  `native/Widget/OTBWidget.entitlements` grants the sandboxed extension outbound
-  network (macOS always sandboxes an app extension; without
-  `com.apple.security.network.client` the stats GET is silently denied) — exactly
-  as the Share Extension does. It's wired via `CODE_SIGN_ENTITLEMENTS[sdk=macosx*]`
-  so iOS device signing is untouched.
+  `native/Widget/OTBWidget.entitlements` declares the App Sandbox (macOS always
+  sandboxes an app extension). Unlike the Share Extension it grants no
+  `com.apple.security.network.client` — the widget never makes a request. It's
+  wired via `CODE_SIGN_ENTITLEMENTS[sdk=macosx*]` so iOS device signing is
+  untouched.
 
 To add it to your home screen: long-press the home screen ▸ **+** ▸ search **On
-The Beach** ▸ pick the small **To Listen** widget. Tapping it opens the app.
+The Beach** ▸ pick the small **On The Beach** widget. Tapping it opens the app.
 
 ## Prerequisites (mac only)
 

--- a/native/Widget/Info.plist
+++ b/native/Widget/Info.plist
@@ -19,13 +19,8 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 
-	<!-- App configuration, shared with the Share Extension. OTBBaseURL is safe to
-	     commit; OTBIngestAPIKey resolves from Secrets.xcconfig at build time
-	     (gitignored) via the $(OTB_INGEST_API_KEY) substitution. -->
-	<key>OTBBaseURL</key>
-	<string>https://onthebeach.ricojam.es</string>
-	<key>OTBIngestAPIKey</key>
-	<string>$(OTB_INGEST_API_KEY)</string>
+	<!-- No OTBBaseURL / OTBIngestAPIKey here: the widget draws the bundled logo
+	     and makes no requests, so it needs no server config or ingest key. -->
 
 	<!-- A WidgetKit extension has a SwiftUI @main entry point (OTBWidgetBundle),
 	     so there's no NSExtensionPrincipalClass / storyboard — just the point id. -->

--- a/native/Widget/OTBWidget.entitlements
+++ b/native/Widget/OTBWidget.entitlements
@@ -6,14 +6,13 @@
 	     scripts/add-widget-extension.rb, so iOS device signing is untouched).
 
 	     macOS ALWAYS runs an app extension inside the "plugin" App Sandbox, and a
-	     WidgetKit extension is no exception. Without network.client the widget's
-	     URLSession GET to /api/ingest/stats is silently denied and the count never
-	     loads (the widget just shows a dash). These two keys grant the extension
-	     outbound network inside its sandbox. Same rationale as the Share
-	     Extension's entitlements. -->
+	     WidgetKit extension is no exception, so declare it explicitly rather than
+	     leaning on whatever the signing step infers.
+
+	     Unlike the Share Extension there's no network.client here: the widget
+	     draws a logo bundled with it and never makes a request, so it asks for
+	     nothing beyond the sandbox itself. -->
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>
 </plist>

--- a/native/Widget/OTBWidget.swift
+++ b/native/Widget/OTBWidget.swift
@@ -1,191 +1,84 @@
-import WidgetKit
 import SwiftUI
+import UIKit
+import WidgetKit
 
 /// Home-screen widget for On The Beach.
 ///
-/// A single small (square) widget that shows how many releases are still queued
-/// "To Listen" — the one glanceable number for a listening tracker. It fetches
-/// `GET /api/ingest/stats` with the same `Bearer` ingest key the Share Extension
-/// uses (read from the widget's Info.plist: `OTBBaseURL` committed, the key
-/// injected from the gitignored `Secrets.xcconfig` at build time), so no session
-/// or App Group is needed. Tapping the widget opens the app.
+/// A single small (square) widget that shows the app's logo — the surfing
+/// capybara — on the black playlist well. That's deliberately all it is: the app
+/// is about enjoying music, not about clearing a queue, so the widget is a
+/// shortcut and a bit of character rather than a number to be driven down.
+///
+/// Because there's nothing to load, the widget needs no network, no ingest key
+/// and no App Group: it draws a bundled image and renders the same forever.
+/// Tapping it opens the app.
 ///
 /// Like the Share Extension, this is native SwiftUI with no access to the web
 /// app's stylesheet, so the Windows 98 / Winamp look (black playlist well,
-/// electric-blue accent, Verdana chrome type) is mirrored here in `OTBTheme`.
+/// electric-blue accent, Courier chrome type) is mirrored here in `OTBTheme`.
 
-// MARK: - Config read from Info.plist
+// MARK: - Logo
 
-/// Reads a non-empty string from the widget's Info.plist, or nil. `OTBBaseURL`
-/// is committed; `OTBIngestAPIKey` resolves from `$(OTB_INGEST_API_KEY)` in
-/// Secrets.xcconfig at build time (mirrors ShareViewController.infoValue).
-private func infoValue(_ key: String) -> String? {
-    guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
-          !value.isEmpty else { return nil }
-    return value
-}
+/// The brand master `assets/logo.png`, added to this target's resources by
+/// `scripts/add-widget-extension.rb` (referenced in place — `assets/logo.png`
+/// stays the single source of truth for every icon in the project).
+///
+/// `UIImage(named:)` finds a loose resource by filename in the extension's own
+/// bundle. Nil means the resource wasn't wired into the target; the view falls
+/// back to a wordmark so the widget always renders something.
+private let otbLogo: UIImage? = UIImage(named: "logo")
 
 // MARK: - Timeline model
 
-/// One rendered state of the widget. `toListen == nil` means the count couldn't
-/// be loaded (no key wired, offline, server error) — the view shows a dash.
+/// The widget has no data, so the entry carries nothing but its date.
 struct OTBEntry: TimelineEntry {
     let date: Date
-    let toListen: Int?
-}
-
-// MARK: - Networking
-
-private struct StatsResponse: Decodable {
-    let toListen: Int
-
-    enum CodingKeys: String, CodingKey {
-        case toListen = "to_listen"
-    }
-}
-
-/// Fetches the "To Listen" count. Any failure (missing key, network, decode)
-/// resolves to nil rather than throwing, so the widget always renders something.
-private func fetchToListen(completion: @escaping (Int?) -> Void) {
-    guard let base = infoValue("OTBBaseURL"),
-          let key = infoValue("OTBIngestAPIKey"),
-          let endpoint = URL(string: base + "/api/ingest/stats") else {
-        completion(nil)
-        return
-    }
-
-    var request = URLRequest(url: endpoint)
-    request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-    request.timeoutInterval = 15
-
-    URLSession.shared.dataTask(with: request) { data, _, _ in
-        guard let data,
-              let payload = try? JSONDecoder().decode(StatsResponse.self, from: data) else {
-            completion(nil)
-            return
-        }
-        completion(payload.toListen)
-    }.resume()
 }
 
 // MARK: - Provider
 
 struct OTBProvider: TimelineProvider {
-    /// Shown in the gallery / while the real entry loads.
     func placeholder(in context: Context) -> OTBEntry {
-        OTBEntry(date: Date(), toListen: 12)
+        OTBEntry(date: Date())
     }
 
     func getSnapshot(in context: Context, completion: @escaping (OTBEntry) -> Void) {
-        // The widget gallery preview shouldn't make a network call; show a sample.
-        if context.isPreview {
-            completion(OTBEntry(date: Date(), toListen: 12))
-            return
-        }
-        fetchToListen { count in
-            completion(OTBEntry(date: Date(), toListen: count))
-        }
+        completion(OTBEntry(date: Date()))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<OTBEntry>) -> Void) {
-        fetchToListen { count in
-            let entry = OTBEntry(date: Date(), toListen: count)
-            // Refresh roughly every 30 minutes. WidgetKit budgets background
-            // refreshes, so asking for more just gets throttled; the count is
-            // also refreshed whenever the system reloads the timeline.
-            let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())
-                ?? Date().addingTimeInterval(1800)
-            completion(Timeline(entries: [entry], policy: .after(next)))
-        }
+        // One entry that never changes: nothing to refresh, so don't ask
+        // WidgetKit to wake us again.
+        completion(Timeline(entries: [OTBEntry(date: Date())], policy: .never))
     }
 }
 
 // MARK: - View
 
 struct OTBWidgetEntryView: View {
-    // Which family this instance is rendering — drives the per-surface layout.
-    // The Home Screen family keeps the full app look; the Lock Screen accessory
-    // families use compact layouts the system draws in monochrome (custom colors
-    // are ignored there), so they carry the app's *type* and wording instead.
-    @Environment(\.widgetFamily) private var family
     var entry: OTBEntry
 
-    private var countText: String {
-        guard let n = entry.toListen else { return "—" }
-        return "\(n)"
-    }
-
-    private var releaseWord: String {
-        entry.toListen == 1 ? "release" : "releases"
-    }
-
     var body: some View {
-        switch family {
-        case .accessoryInline:
-            // A single line beside the Lock Screen clock, e.g. "12 to listen".
-            Text("\(countText) to listen")
-                .font(OTBTheme.mono(11))
-
-        case .accessoryCircular:
-            // Circular Lock Screen slot: the glanceable number over the standard
-            // translucent accessory background.
-            ZStack {
-                AccessoryWidgetBackground()
-                VStack(spacing: 0) {
-                    Text(countText)
-                        .font(OTBTheme.number(22))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.4)
-                    Text("QUEUED")
-                        .font(OTBTheme.mono(8))
-                }
+        Group {
+            if let logo = otbLogo {
+                Image(uiImage: logo)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    // The system's default content margins (~16pt) would leave
+                    // the capybara small and adrift in the tile, so they're
+                    // switched off on the configuration and the logo gets a
+                    // tighter inset that keeps it clear of the rounded corners.
+                    .padding(10)
+            } else {
+                // Resource missing — draw the wordmark rather than an empty tile.
+                Text("ON THE\nBEACH")
+                    .font(OTBTheme.mono(15))
+                    .foregroundStyle(OTBTheme.accent)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.5)
             }
-            .containerBackground(for: .widget) { Color.clear }
-
-        case .accessoryRectangular:
-            // Wide Lock Screen slot: number + the same TO LISTEN / releases lines
-            // the Home Screen widget uses, so it reads as the same app.
-            HStack(spacing: 10) {
-                Text(countText)
-                    .font(OTBTheme.number(34))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.4)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("TO LISTEN").font(OTBTheme.mono(11))
-                    Text(releaseWord).font(OTBTheme.ui(11))
-                }
-            }
-            .containerBackground(for: .widget) { Color.clear }
-
-        default:
-            homeScreen
         }
-    }
-
-    // The original Home Screen (systemSmall) layout — the full app aesthetic:
-    // black playlist well, electric-blue count, Verdana/Courier chrome.
-    private var homeScreen: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("TO LISTEN")
-                .font(OTBTheme.mono(11))
-                .foregroundStyle(OTBTheme.playlistText)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-
-            Spacer(minLength: 0)
-
-            Text(countText)
-                .font(OTBTheme.number(44))
-                .foregroundStyle(OTBTheme.accent)
-                .lineLimit(1)
-                .minimumScaleFactor(0.4)
-
-            Text(releaseWord)
-                .font(OTBTheme.ui(11))
-                .foregroundStyle(OTBTheme.playlistText.opacity(0.7))
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .containerBackground(for: .widget) {
             OTBTheme.playlistBg
         }
@@ -195,23 +88,22 @@ struct OTBWidgetEntryView: View {
 // MARK: - Widget
 
 struct OTBWidget: Widget {
-    // Stable kind identifier; changing it drops users' installed widgets.
+    // Stable kind identifier; changing it drops users' installed widgets, so it
+    // keeps the name it was first shipped under even though the content changed.
     let kind = "OTBToListenWidget"
 
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: OTBProvider()) { entry in
             OTBWidgetEntryView(entry: entry)
         }
-        .configurationDisplayName("To Listen")
-        .description("How many releases are queued to listen to.")
-        // Home Screen (systemSmall) keeps the full app look; the accessory
-        // families put the same count on the Lock Screen (rendered monochrome).
-        .supportedFamilies([
-            .systemSmall,
-            .accessoryCircular,
-            .accessoryRectangular,
-            .accessoryInline,
-        ])
+        .configurationDisplayName("On The Beach")
+        .description("The capybara on your home screen. Tap to open On The Beach.")
+        // Home Screen only. The Lock Screen accessory families are rendered
+        // monochrome by the system, which turns the logo into an unreadable
+        // silhouette, and there's no number to put there instead.
+        .supportedFamilies([.systemSmall])
+        // The tile is one image on a black well; the view sets its own inset.
+        .contentMarginsDisabled()
     }
 }
 
@@ -230,21 +122,9 @@ struct OTBWidgetBundle: WidgetBundle {
 
 enum OTBTheme {
     static let playlistBg = Color(red: 0, green: 0, blue: 0)             // --playlist-bg
-    static let playlistText = Color(rgb: 0xADC8FF)                       // --playlist-text
     static let accent = Color(rgb: 0x6699FF)                            // --accent: electric blue
 
-    /// UI chrome type. The web uses Tahoma; iOS ships Verdana (the same
-    /// designer's near-identical face), so use it with a system fallback.
-    static func ui(_ size: CGFloat) -> Font {
-        Font.custom("Verdana", size: size)
-    }
-
-    /// Bold Verdana for the big number.
-    static func number(_ size: CGFloat) -> Font {
-        Font.custom("Verdana-Bold", size: size)
-    }
-
-    /// Mono/terminal type for the label — the web's Share Tech Mono stand-in,
+    /// Mono/terminal type for the wordmark — the web's Share Tech Mono stand-in,
     /// using Courier New (always present on iOS).
     static func mono(_ size: CGFloat) -> Font {
         Font.custom("CourierNewPSMT", size: size)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-the-beach",
-  "version": "1.0.215",
+  "version": "1.0.216",
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",
   "scripts": {

--- a/scripts/add-widget-extension.rb
+++ b/scripts/add-widget-extension.rb
@@ -32,9 +32,10 @@ NATIVE_DIR = File.join(REPO_ROOT, "native", "Widget")
 SWIFT_SOURCE = File.join(NATIVE_DIR, "OTBWidget.swift")
 INFO_PLIST = File.join(NATIVE_DIR, "Info.plist")
 ENTITLEMENTS = File.join(NATIVE_DIR, "OTBWidget.entitlements")
-# The widget reuses the Share Extension's ingest key (OTB_INGEST_API_KEY), so
-# there's a single gitignored Secrets.xcconfig to maintain for the whole app.
-SECRETS_XCCONFIG = File.join(REPO_ROOT, "native", "ShareExtension", "Secrets.xcconfig")
+# The widget draws the brand master itself, so the PNG is copied into the
+# extension's bundle (referenced in place — assets/logo.png stays the one
+# source of truth for every icon in the project).
+LOGO = File.join(REPO_ROOT, "assets", "logo.png")
 
 EXT_NAME = "OTBWidget"
 APP_TARGET_NAME = "App"
@@ -52,6 +53,7 @@ end
 die "no Xcode project at #{PROJECT_PATH} — run `bun run cap:add` first" unless File.exist?(PROJECT_PATH)
 die "missing #{SWIFT_SOURCE}" unless File.exist?(SWIFT_SOURCE)
 die "missing #{INFO_PLIST}" unless File.exist?(INFO_PLIST)
+die "missing #{LOGO}" unless File.exist?(LOGO)
 
 project = Xcodeproj::Project.open(PROJECT_PATH)
 
@@ -127,10 +129,10 @@ ext_target.build_configurations.each do |config|
     # Also build the widget for Mac Catalyst so it can appear as a macOS widget.
     # Xcode derives MACOSX_DEPLOYMENT_TARGET from the iOS floor.
     "SUPPORTS_MACCATALYST" => "YES",
-    # macOS ALWAYS sandboxes an app extension, and without network.client the
-    # widget's URLSession GET to /api/ingest/stats is silently denied. Grant the
-    # sandbox + outbound network via an entitlements file, scoped to the macOS
-    # SDK (what Mac Catalyst builds against) so iOS device signing is untouched.
+    # macOS ALWAYS sandboxes an app extension, so declare the sandbox explicitly
+    # via an entitlements file, scoped to the macOS SDK (what Mac Catalyst builds
+    # against) so iOS device signing is untouched. The widget draws a bundled
+    # image and makes no requests, so it asks for no network access.
     "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" => "../../native/Widget/OTBWidget.entitlements",
   )
 end
@@ -146,18 +148,11 @@ ext_target.add_file_references([swift_ref])
 group.new_file(INFO_PLIST)
 group.new_file(ENTITLEMENTS) if File.exist?(ENTITLEMENTS)
 
-# --- Wire the shared ingest-key xcconfig -------------------------------------
-# Secrets.xcconfig (in native/ShareExtension/) provides OTB_INGEST_API_KEY,
-# substituted into the widget's Info.plist at build time. It's gitignored, so it
-# may be absent on a fresh checkout / in CI; the caller creates it (docs for
-# local, a dummy in CI). A missing base config is a warning, not a hard failure —
-# the target still builds with an empty key (the widget then shows a dash).
-secrets_ref = group.new_file(SECRETS_XCCONFIG)
-ext_target.build_configurations.each do |config|
-  config.base_configuration_reference = secrets_ref
-end
-warn "add-widget-extension: note — #{SECRETS_XCCONFIG} not found; " \
-     "build will use an empty OTB_INGEST_API_KEY" unless File.exist?(SECRETS_XCCONFIG)
+# --- Bundle the logo ----------------------------------------------------------
+# The widget's only content is the brand master, which it loads by filename
+# (`UIImage(named: "logo")`), so copy assets/logo.png into the extension bundle.
+logo_ref = group.new_file(LOGO)
+ext_target.add_resources([logo_ref])
 
 # --- Embed the widget in the app ---------------------------------------------
 app_target.add_dependency(ext_target)

--- a/server/routes/ingest.ts
+++ b/server/routes/ingest.ts
@@ -228,9 +228,10 @@ export function createIngestRoutes(deps: IngestRoutesDeps = {}): Hono {
     return c.json({ stacks: await listStacks() });
   });
 
-  // GET /stats — glanceable counts for the iOS home-screen widget. Bearer-authed
-  // with the ingest key (same as /stacks) because the widget extension can't use
-  // the session-authed app API. Kept tiny on purpose: one number the widget draws.
+  // GET /stats — the to-listen count for clients that can't use the
+  // session-authed app API, so it's Bearer-authed with the ingest key (same as
+  // /stacks). Originally fed the iOS home-screen widget, which now just shows the
+  // logo; kept as a tiny, generally useful counter.
   routes.get("/stats", async (c) => {
     const apiKey = process.env.INGEST_API_KEY;
     if (!apiKey) {


### PR DESCRIPTION
The widget counted how many releases were still queued to listen to, which framed the app as a backlog to clear. It isn't — it's for enjoying music, so the widget is now just the logo: the surfing capybara on the black playlist well, opening the app when tapped.

## What changed

- **`native/Widget/OTBWidget.swift`** — no stats fetch, no `StatsResponse`, no count. The timeline is a single entry with a `.never` refresh policy, and the view draws the bundled logo (falling back to a text wordmark if the resource is ever missing). Default content margins are disabled so the logo fills the tile; `systemSmall` is the only supported family now, since the Lock Screen accessory families render monochrome and would reduce the logo to a silhouette. The widget `kind` is unchanged, so anyone with it installed keeps it.
- **`scripts/add-widget-extension.rb`** — copies `assets/logo.png` into the extension bundle (referenced in place, so the brand master stays the one source of truth) and drops the `Secrets.xcconfig` base configuration the ingest key needed.
- **`native/Widget/Info.plist`** — `OTBBaseURL` / `OTBIngestAPIKey` removed.
- **`native/Widget/OTBWidget.entitlements`** — declares only the App Sandbox; no `network.client`, as the widget never makes a request.
- **`.github/workflows/ios-build.yml`** — the entitlements guard now asserts the sandbox key and that the injector wired the logo into the widget's Resources phase, instead of asserting a network entitlement that no longer applies.
- **`docs/ios-native-app.md`** — widget section rewritten to match.
- **`server/routes/ingest.ts`** — `/api/ingest/stats` is left in place as a small Bearer-authed counter; only its comment changed, since the widget was its consumer.

## Testing

- `bun run test` — 753 pass, 0 fail.
- `bun run lint` — clean (3 pre-existing warnings elsewhere in the repo).
- `ruby scripts/add-widget-extension.rb` run twice against a synthetic Capacitor-shaped project: the widget target comes out with `OTBWidget.swift` in Sources, `../../assets/logo.png` in Resources, the macOS-scoped entitlements setting, no base configuration, and the embed phase + dependency on `App`. The CI grep guard passes against the generated `project.pbxproj`.
- Swift itself isn't compiled here (no Xcode on Linux) — the `ios-build.yml` job is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLV5vZNHyW8uTQQ3VdtaW9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLV5vZNHyW8uTQQ3VdtaW9)_