### PR TITLE
Reset lookup marker when music item title or artist changes

### DIFF
--- a/docs/areas/integrations/apple-music.md
+++ b/docs/areas/integrations/apple-music.md
@@ -60,6 +60,14 @@ When Apple Music has no match at all, the enrichment falls back to a YouTube
 search and saves a link only when that match is unambiguous — see the YouTube
 fallback section of `docs/areas/integrations/scanning-and-enrichment.md`.
 
+A lookup stamps `music_items.apple_music_lookup_at` on both a hit and a miss, so
+a release the catalogue doesn't carry isn't re-queried on every page view. Since
+the search keys off nothing but the item's title and artist, editing either one
+(`PATCH /api/music-items/:id`) clears that marker, and the next release-page view
+searches again under the corrected name — the usual reason an item ends up with
+no listen link is a title that was wrong when it was first looked up. Re-saving
+the edit form without actually changing those fields leaves the marker alone.
+
 ## Browser playback
 
 - `src/lib/musickit.svelte.ts` loads MusicKit JS v3 on demand, configures it

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -167,6 +167,43 @@ async function applyArtistUpdate(
   setFields.artistId = null;
 }
 
+/**
+ * The streaming-service catalogue search keys off nothing but the item's title
+ * and artist, so correcting either invalidates an earlier miss: clear the
+ * attempt marker (`lookupAttemptedAt`) so the next release-page view re-queries
+ * under the new name instead of short-circuiting on "already attempted".
+ *
+ * Only a real change resets it — re-saving the edit form with the same title
+ * must not re-open the search. An item that already carries a link on the
+ * active service is unaffected either way: the lookup returns that existing
+ * link before it ever consults the marker.
+ */
+async function applyLookupMarkerReset(id: number, setFields: MusicItemUpdateSet): Promise<void> {
+  const titleChanging = setFields.title !== undefined;
+  const artistChanging = setFields.artistId !== undefined;
+  if (!titleChanging && !artistChanging) {
+    return;
+  }
+
+  const rows = await db
+    .select({ title: musicItems.title, artistId: musicItems.artistId })
+    .from(musicItems)
+    .where(eq(musicItems.id, id))
+    .limit(1);
+
+  const current = rows[0];
+  if (!current) {
+    return;
+  }
+
+  const renamed = titleChanging && setFields.title !== current.title;
+  const reattributed = artistChanging && setFields.artistId !== current.artistId;
+
+  if (renamed || reattributed) {
+    setFields.lookupAttemptedAt = null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // GET / — list music items
 // ---------------------------------------------------------------------------
@@ -479,6 +516,7 @@ musicItemRoutes.patch("/:id", async (c) => {
   }
 
   await applyArtistUpdate(setFields, input);
+  await applyLookupMarkerReset(id, setFields);
 
   if (Object.keys(setFields).length > 0) {
     setFields.updatedAt = new Date();

--- a/tests/unit/music-item-lookup-reset.test.ts
+++ b/tests/unit/music-item-lookup-reset.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+
+import { db } from "../../server/db/index";
+import { artists, musicItems } from "../../server/db/schema";
+import { musicItemRoutes } from "../../server/routes/music-items";
+
+// A previous secondary-link lookup that came up empty stamps `lookupAttemptedAt`
+// so the release page stops re-querying on every view. Because the catalogue
+// search keys off only the title and artist, editing either has to clear that
+// marker — otherwise correcting a mistyped release name can never produce the
+// listen link the corrected name would have found.
+
+const insertedItemIds: number[] = [];
+
+function makeApp() {
+  const app = new Hono();
+  app.route("/api/music-items", musicItemRoutes);
+  return app;
+}
+
+const ATTEMPTED_AT = new Date("2026-01-01T00:00:00Z");
+
+async function insertItem(
+  overrides: Partial<{ title: string; artistId: number | null }> = {},
+): Promise<number> {
+  const [inserted] = await db
+    .insert(musicItems)
+    .values({
+      title: overrides.title ?? "Untitled",
+      normalizedTitle: (overrides.title ?? "Untitled").toLowerCase(),
+      artistId: overrides.artistId ?? null,
+      listenStatus: "to-listen",
+      lookupAttemptedAt: ATTEMPTED_AT,
+    })
+    .returning({ id: musicItems.id });
+
+  insertedItemIds.push(inserted.id);
+  return inserted.id;
+}
+
+async function readLookupAttemptedAt(id: number): Promise<Date | null> {
+  const rows = await db
+    .select({ lookupAttemptedAt: musicItems.lookupAttemptedAt })
+    .from(musicItems)
+    .where(eq(musicItems.id, id))
+    .limit(1);
+
+  return rows[0]?.lookupAttemptedAt ?? null;
+}
+
+function patch(id: number, body: Record<string, unknown>) {
+  return makeApp().request(`http://localhost/api/music-items/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(async () => {
+  if (insertedItemIds.length === 0) return;
+  await db.delete(musicItems).where(inArray(musicItems.id, insertedItemIds));
+  insertedItemIds.length = 0;
+});
+
+describe("PATCH /api/music-items/:id — lookup marker reset", () => {
+  test("clears the marker when the title changes", async () => {
+    const id = await insertItem({ title: "Sun Ra - Lanquidity" });
+
+    const res = await patch(id, { title: "Lanquidity" });
+
+    expect(res.status).toBe(200);
+    expect(await readLookupAttemptedAt(id)).toBeNull();
+  });
+
+  test("keeps the marker when the title is re-saved unchanged", async () => {
+    const id = await insertItem({ title: "Lanquidity" });
+
+    const res = await patch(id, { title: "Lanquidity", notes: "reissue" });
+
+    expect(res.status).toBe(200);
+    expect(await readLookupAttemptedAt(id)).toEqual(ATTEMPTED_AT);
+  });
+
+  test("clears the marker when the artist changes", async () => {
+    const id = await insertItem({ title: "Lanquidity" });
+
+    const res = await patch(id, { artistName: "Sun Ra" });
+
+    expect(res.status).toBe(200);
+    expect(await readLookupAttemptedAt(id)).toBeNull();
+
+    const [artist] = await db
+      .select({ id: artists.id })
+      .from(artists)
+      .where(eq(artists.name, "Sun Ra"))
+      .limit(1);
+    expect(artist).toBeDefined();
+  });
+
+  test("keeps the marker when the artist is re-saved unchanged", async () => {
+    const [artist] = await db
+      .insert(artists)
+      .values({ name: "Alice Coltrane", normalizedName: "alice coltrane" })
+      .onConflictDoNothing()
+      .returning({ id: artists.id });
+    const artistId =
+      artist?.id ??
+      (
+        await db
+          .select({ id: artists.id })
+          .from(artists)
+          .where(eq(artists.name, "Alice Coltrane"))
+          .limit(1)
+      )[0]!.id;
+
+    const id = await insertItem({ title: "Journey in Satchidananda", artistId });
+
+    const res = await patch(id, { artistName: "Alice Coltrane" });
+
+    expect(res.status).toBe(200);
+    expect(await readLookupAttemptedAt(id)).toEqual(ATTEMPTED_AT);
+  });
+
+  test("keeps the marker when only unrelated fields change", async () => {
+    const id = await insertItem({ title: "Lanquidity" });
+
+    const res = await patch(id, { notes: "picked up in Bristol", year: 1978 });
+
+    expect(res.status).toBe(200);
+    expect(await readLookupAttemptedAt(id)).toEqual(ATTEMPTED_AT);
+  });
+});


### PR DESCRIPTION
## Summary
When a music item's title or artist is corrected via the PATCH endpoint, the `lookupAttemptedAt` marker is now cleared. This allows the streaming service catalogue search to re-query under the corrected name on the next release-page view, instead of short-circuiting based on a previous failed lookup.

## Key Changes
- Added `applyLookupMarkerReset()` function to detect and handle title/artist changes
  - Clears `lookupAttemptedAt` only when the title or artist actually changes
  - Preserves the marker when fields are re-saved unchanged or when only unrelated fields are modified
- Integrated the reset logic into the PATCH `/api/music-items/:id` endpoint
- Added comprehensive test suite covering all reset scenarios:
  - Title changes clear the marker
  - Artist changes clear the marker
  - Unchanged re-saves preserve the marker
  - Unrelated field changes preserve the marker

## Implementation Details
The reset function queries the current item state before applying updates to detect actual changes. This ensures that re-saving the edit form with identical title/artist values doesn't unnecessarily reset the lookup marker, while correcting either field properly invalidates stale lookup attempts.

Documentation updated to explain the lookup marker behavior and when it gets cleared.

https://claude.ai/code/session_01NYup4FbVmadUTGfdzxZkox