### PR TITLE
Show a hand-added Bandcamp link on the release page

### DIFF
--- a/playwright/bandcamp-link.spec.ts
+++ b/playwright/bandcamp-link.spec.ts
@@ -54,3 +54,42 @@ test("links without https", async ({ page }) => {
   // The source badge should link to the full URL with protocol
   await expect(card.locator(".badge--source")).toHaveAttribute("href", expectedNormalizedUrl);
 });
+
+test("a Bandcamp link added by hand is reachable from the release page", async ({ page }) => {
+  const bandcampUrl =
+    "https://seekersinternational.bandcamp.com/album/thewherebetweenyou-me-reissue";
+
+  // A release with no link at all — the case where the added link becomes the
+  // primary one, and so is left out of the secondary "🔗" list in view mode.
+  await page.goto("/");
+  const addButton = page.getByRole("button", { name: "Add" });
+  await addButton.click(); // reveals artist/release fields
+  await page.locator('input[name="title"]').fill("Hand Linked Release");
+  await addButton.click(); // submits
+
+  const card = page.locator(".music-card").first();
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  await card.locator("a.music-card__link").click();
+  await expect(page).toHaveURL(/\/r\/\d+/, { timeout: 10_000 });
+
+  await page.locator("#edit-btn").click();
+  await page.locator("#link-source-input").click();
+  await page.locator('#source-dropdown [data-value="Bandcamp"]').click();
+  await page.locator("#link-url-input").fill(bandcampUrl);
+  await page.locator("#add-link-btn").click();
+
+  // Adding the link scrapes it for the ids the Bandcamp player needs.
+  await expect(page.locator("#link-list .release-page__link-row")).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await page.locator("#cancel-btn").click();
+
+  // Exactly one control in view mode reaches the link: the ▶ Bandcamp button
+  // when the scrape found an album id, the plain source link when it didn't
+  // (whether it does is left to the route's own test, which doesn't depend on
+  // Bandcamp being up). Before, a first Bandcamp link produced neither.
+  const actions = page.locator(".release-page__actions");
+  await expect(
+    actions.locator(`[data-href="${bandcampUrl}"], a[href="${bandcampUrl}"]`),
+  ).toHaveCount(1, { timeout: 15_000 });
+});

--- a/server/link-embed-metadata.ts
+++ b/server/link-embed-metadata.ts
@@ -1,0 +1,35 @@
+import { scrapeUrl } from "./scraper";
+import { parseUrl } from "./utils";
+
+/**
+ * Player metadata for a link added by hand on the release page.
+ *
+ * A link that arrives with a new release is scraped as part of creating it, and
+ * the player-specific part of that scrape — Bandcamp's `album_id` — is stored
+ * on the link. A link added later got none of that, so the release page was
+ * left holding a Bandcamp URL it had no way to build a player from. Scraping
+ * here puts both paths on the same footing.
+ *
+ * Bandcamp is the only source that needs it: every other embed the release page
+ * builds is derived from the URL itself.
+ *
+ * Returns the JSON to store in `music_links.metadata`, or null when there is
+ * nothing to store. `scrape` is injectable for tests.
+ */
+export async function scrapeLinkEmbedMetadata(
+  url: string,
+  scrape: typeof scrapeUrl = scrapeUrl,
+): Promise<string | null> {
+  const { source, normalizedUrl } = parseUrl(url);
+  if (source !== "bandcamp") return null;
+
+  try {
+    const embedMetadata = (await scrape(normalizedUrl, source))?.embedMetadata;
+    if (!embedMetadata || Object.keys(embedMetadata).length === 0) return null;
+    return JSON.stringify(embedMetadata);
+  } catch {
+    // A link we can't reach is still worth keeping — it just doesn't get a
+    // player.
+    return null;
+  }
+}

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -23,6 +23,7 @@ import {
   createMusicItemDirect,
 } from "../music-item-creator";
 import { hydrateItemStacks } from "../hydrate-item-stacks";
+import { scrapeLinkEmbedMetadata } from "../link-embed-metadata";
 import { UnsupportedMusicLinkError } from "../scraper";
 import { ensureSuggestionForItemNow, findPendingSuggestionForItem } from "../suggestions";
 import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
@@ -686,9 +687,14 @@ musicItemRoutes.post("/:id/links", async (c) => {
 
   const isPrimary = existing.length === 0;
 
+  // Scraped here rather than at creation time, because this link never went
+  // through the creation path — without it a hand-added Bandcamp link can't
+  // produce a player. Null for every other source, and on any scrape failure.
+  const metadata = await scrapeLinkEmbedMetadata(url);
+
   const [link] = await db
     .insert(musicLinks)
-    .values({ musicItemId: id, sourceId: source.id, url, isPrimary })
+    .values({ musicItemId: id, sourceId: source.id, url, isPrimary, metadata })
     .onConflictDoNothing()
     .returning({ id: musicLinks.id, url: musicLinks.url, isPrimary: musicLinks.isPrimary });
 

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { goto, invalidateAll } from "$app/navigation";
   import { onMount } from "svelte";
   import type { PageData } from "../../routes/r/[id]/$types";
   import type { AppleMusicListen, ListenEmbed } from "../../routes/r/[id]/+page.server";
@@ -297,10 +297,19 @@
       : allSources,
   );
 
+  // The play buttons and the source link are built server-side from the
+  // *primary* link, so editing the link list has to re-run the page load for
+  // view mode to catch up. Re-running it (rather than reloading the window)
+  // keeps whatever else is half-typed in the edit fields.
+  async function refreshListenOptions(): Promise<void> {
+    await invalidateAll();
+  }
+
   async function removeLink(linkId: number): Promise<void> {
     const res = await apiFetch(`/api/music-items/${item.id}/links/${linkId}`, { method: "DELETE" });
     if (res.ok) {
       itemLinks = itemLinks.filter((l) => l.id !== linkId);
+      await refreshListenOptions();
     }
   }
 
@@ -318,6 +327,7 @@
       itemLinks = [...itemLinks, link];
       sourceQuery = "";
       linkUrl = "";
+      await refreshListenOptions();
     } else {
       const err = await res.json().catch(() => ({}) as { error?: string });
       alert(err.error || "Failed to add link");

--- a/src/routes/r/[id]/+page.server.ts
+++ b/src/routes/r/[id]/+page.server.ts
@@ -170,13 +170,19 @@ export const load: PageServerLoad = async ({ params, url }) => {
     error(404, "Not found — this release doesn't exist.");
   }
 
-  const sourceLink =
-    item.primary_url && !item.primary_url.includes("bandcamp.com")
-      ? {
-          href: item.primary_url,
-          label: sourceDisplayName(item.primary_source ?? parseUrl(item.primary_url).source),
-        }
-      : null;
+  // The plain link out to wherever the release came from. Bandcamp used to be
+  // excluded here, on the assumption that the ▶ Bandcamp button always stands
+  // in for it — but that button needs a scraped `album_id` the link may not
+  // have, and a release whose scrape came up empty was then left with no way to
+  // reach its own URL at all. The page hides this link whenever a play button
+  // already points at the same href, which covers the case the exclusion was
+  // there for.
+  const sourceLink = item.primary_url
+    ? {
+        href: item.primary_url,
+        label: sourceDisplayName(item.primary_source ?? parseUrl(item.primary_url).source),
+      }
+    : null;
 
   const appleMusicConfigured = isAppleMusicConfigured();
 

--- a/tests/unit/link-embed-metadata.test.ts
+++ b/tests/unit/link-embed-metadata.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { scrapeLinkEmbedMetadata } from "../../server/link-embed-metadata";
+
+const BANDCAMP_URL = "https://seekersinternational.bandcamp.com/album/thewherebetweenyou-me";
+
+const scrape = mock();
+
+beforeEach(() => {
+  scrape.mockReset();
+  scrape.mockResolvedValue(null);
+});
+
+describe("scrapeLinkEmbedMetadata", () => {
+  test("stores the embed metadata scraped from a Bandcamp link", async () => {
+    scrape.mockResolvedValueOnce({
+      potentialTitle: "Where Between You & Me",
+      embedMetadata: { album_id: "123456", item_type: "album" },
+    });
+
+    const metadata = await scrapeLinkEmbedMetadata(BANDCAMP_URL, scrape as never);
+
+    expect(JSON.parse(metadata!)).toEqual({ album_id: "123456", item_type: "album" });
+  });
+
+  test("scrapes the normalized URL, without its query string", async () => {
+    await scrapeLinkEmbedMetadata(`${BANDCAMP_URL}?from=embed`, scrape as never);
+
+    expect(scrape).toHaveBeenCalledWith(BANDCAMP_URL, "bandcamp");
+  });
+
+  test("skips the scrape entirely for other sources", async () => {
+    const metadata = await scrapeLinkEmbedMetadata(
+      "https://open.spotify.com/album/1A2B3C",
+      scrape as never,
+    );
+
+    expect(metadata).toBeNull();
+    expect(scrape).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the page has no embed metadata to give", async () => {
+    scrape.mockResolvedValueOnce({ potentialTitle: "Where Between You & Me" });
+
+    expect(await scrapeLinkEmbedMetadata(BANDCAMP_URL, scrape as never)).toBeNull();
+  });
+
+  test("returns null when the scrape finds nothing at all", async () => {
+    scrape.mockResolvedValueOnce(null);
+
+    expect(await scrapeLinkEmbedMetadata(BANDCAMP_URL, scrape as never)).toBeNull();
+  });
+
+  test("returns null rather than failing the link add when the scrape throws", async () => {
+    scrape.mockRejectedValueOnce(new Error("network unreachable"));
+
+    expect(await scrapeLinkEmbedMetadata(BANDCAMP_URL, scrape as never)).toBeNull();
+  });
+});

--- a/tests/unit/music-item-links-route.test.ts
+++ b/tests/unit/music-item-links-route.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { eq, inArray } from "drizzle-orm";
+import { Hono } from "hono";
+
+import { db } from "../../server/db/index";
+import { musicItems, musicLinks } from "../../server/db/schema";
+import { musicItemRoutes } from "../../server/routes/music-items";
+
+// A link added by hand on the release page never went through the scrape that
+// creating a release from a URL performs, so the route has to do it itself.
+// Without the player ids it collects, the release page holds a Bandcamp URL it
+// can't build a player from.
+
+const BANDCAMP_URL = "https://seekersinternational.bandcamp.com/album/where-between-you-me";
+
+const BANDCAMP_HTML = `<html><head>
+<meta property="og:title" content="Where Between You &amp; Me, by Seekersinternational">
+<meta name="bc-page-properties" content='{"item_type":"album","item_id":998877}'>
+</head><body></body></html>`;
+
+const insertedItemIds: number[] = [];
+const realFetch = globalThis.fetch;
+let fetchCalls = 0;
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/music-items", musicItemRoutes);
+  return app;
+}
+
+async function insertItem(): Promise<number> {
+  const [inserted] = await db
+    .insert(musicItems)
+    .values({
+      title: "Where Between You & Me",
+      normalizedTitle: "where between you & me",
+      listenStatus: "to-listen",
+    })
+    .returning({ id: musicItems.id });
+
+  insertedItemIds.push(inserted.id);
+  return inserted.id;
+}
+
+function addLink(id: number, body: Record<string, unknown>) {
+  return makeApp().request(`http://localhost/api/music-items/${id}/links`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readLinks(id: number) {
+  return db
+    .select({
+      url: musicLinks.url,
+      isPrimary: musicLinks.isPrimary,
+      metadata: musicLinks.metadata,
+    })
+    .from(musicLinks)
+    .where(eq(musicLinks.musicItemId, id));
+}
+
+beforeEach(() => {
+  fetchCalls = 0;
+  // Stand in for the release page itself — the scraper streams the response
+  // body, so a real Response keeps that path intact without going online.
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    return new Response(BANDCAMP_HTML, { headers: { "content-type": "text/html" } });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = realFetch;
+  if (insertedItemIds.length === 0) return;
+  await db.delete(musicItems).where(inArray(musicItems.id, insertedItemIds));
+  insertedItemIds.length = 0;
+});
+
+describe("POST /api/music-items/:id/links", () => {
+  test("stores the Bandcamp player ids alongside a hand-added link", async () => {
+    const id = await insertItem();
+
+    const res = await addLink(id, { sourceName: "Bandcamp", url: BANDCAMP_URL });
+
+    expect(res.status).toBe(201);
+    const [link] = await readLinks(id);
+    expect(link.url).toBe(BANDCAMP_URL);
+    expect(JSON.parse(link.metadata!)).toEqual({ album_id: "998877", item_type: "album" });
+  });
+
+  test("makes the first link on a release its primary one", async () => {
+    const id = await insertItem();
+
+    await addLink(id, { sourceName: "Bandcamp", url: BANDCAMP_URL });
+
+    const [link] = await readLinks(id);
+    expect(link.isPrimary).toBe(true);
+  });
+
+  test("stores no metadata, and scrapes nothing, for a source with no player ids", async () => {
+    const id = await insertItem();
+
+    const res = await addLink(id, {
+      sourceName: "Spotify",
+      url: "https://open.spotify.com/album/1A2B3C4D5E",
+    });
+
+    expect(res.status).toBe(201);
+    const [link] = await readLinks(id);
+    expect(link.metadata).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("rejects a second copy of a link the release already has", async () => {
+    const id = await insertItem();
+    await addLink(id, { sourceName: "Bandcamp", url: BANDCAMP_URL });
+
+    const res = await addLink(id, { sourceName: "Bandcamp", url: BANDCAMP_URL });
+
+    expect(res.status).toBe(409);
+    expect(await readLinks(id)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
A Bandcamp link added from the release page's edit panel showed up in the link list but nowhere in view mode. Three separate things had to decline to render it, and all three did:

- **The ▶ Bandcamp button** needs a scraped `album_id`, stored as link metadata. That was only ever collected on the release-creation path (`music-item-creator.ts`) — `POST /:id/links` stored a bare URL, so `bandcampEmbed()` bailed.
- **The plain source link** was suppressed for any `primary_url` containing `bandcamp.com`, on the assumption that the play button always stands in for it. When the button isn't there, nothing was.
- **The "🔗" row** lists secondary links only. A link added to a release that had none — a scanned cover, say — becomes the primary one, so it was filtered out.

## Changes

- `server/link-embed-metadata.ts` (new): scrapes a Bandcamp link for the ids the player needs, reusing `scrapeUrl` and `extractBandcampEmbedMetadata`. Returns null for every other source (without going online) and on any scrape failure — an unreachable link is still worth keeping, it just doesn't get a player.
- `POST /api/music-items/:id/links` stores that metadata alongside the link, putting hand-added links on the same footing as ones that arrive with a new release.
- `src/routes/r/[id]/+page.server.ts` no longer special-cases Bandcamp out of `sourceLink`. The page already hides that link whenever a play button points at the same href (`playHrefs`), which covers the duplication the exclusion was there to prevent — so a release whose scrape came up empty now falls back to a plain link instead of showing nothing.
- `ReleasePage.svelte` re-runs the page load (`invalidateAll`) after adding or removing a link, since the play buttons and source link are computed server-side from the primary link. Re-running the load rather than reloading the window keeps half-typed edit fields intact.

## Tests

- `tests/unit/link-embed-metadata.test.ts` — the scrape helper, with the scrape injected: metadata stored, query string dropped, other sources skipped entirely, and null on an empty page, a missed scrape, or a throw.
- `tests/unit/music-item-links-route.test.ts` — the route end to end against the temp DB with `fetch` stubbed to canned Bandcamp HTML: player ids land in `music_links.metadata`, a first link is primary, a non-Bandcamp link stores nothing and scrapes nothing, duplicates still 409.
- `playwright/bandcamp-link.spec.ts` — adds a Bandcamp link by hand to a manually created (linkless) release and asserts exactly one control in view mode reaches it. Passes locally; whether that control is the play button or the plain link is left to the route test, so this one doesn't depend on Bandcamp being up.

`bun run test:unit` (768 pass), `typecheck`, `oxlint` and `oxfmt --check` are clean; the release-page e2e specs (`replace-image`, `list-nav-state`, `manual-add`, `add-link`, and the new one) pass locally.

Visual baselines are unaffected — `release-page-view` snapshots a scanned item with no links, where `sourceLink` was and stays null.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177ZNdqP9debp4MN5V4AHqp)_