### PR TITLE
Fix the 9 unit tests failing on main

### DIFF
--- a/tests/unit/creator-page-source-notes.test.ts
+++ b/tests/unit/creator-page-source-notes.test.ts
@@ -1,10 +1,28 @@
-import { describe, test, expect, spyOn, mock, afterEach } from "bun:test";
+import { describe, test, expect, spyOn, mock, afterEach, afterAll } from "bun:test";
 import { createMusicItemsFromUrl, formatPageSourceNote } from "../../server/music-item-creator";
 
 // Unsupported pages go through the Mistral extractor, and freshly created items
-// kick off background lookups — keep both off the network.
+// kick off background lookups — keep both off the network. Set at module scope
+// because the Mistral client reads its key when this file's imports evaluate,
+// which is before any hook can run.
+const ENV_BEFORE = {
+  MISTRAL_API_KEY: process.env.MISTRAL_API_KEY,
+  OTB_DISABLE_EXTERNAL_LOOKUPS: process.env.OTB_DISABLE_EXTERNAL_LOOKUPS,
+};
 process.env.MISTRAL_API_KEY = "test-key";
 process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+
+// `bun test` runs every file in one process, so anything left in `process.env`
+// here leaks into whichever file runs next — and file order isn't stable across
+// machines. Leaving OTB_DISABLE_EXTERNAL_LOOKUPS set is what turned the Apple
+// Music lookup tests in scraper.test.ts red on CI while they stayed green
+// locally: those code paths no-op under the flag, so they returned null.
+afterAll(() => {
+  for (const [key, value] of Object.entries(ENV_BEFORE)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 /** The shape `@mistralai/mistralai` expects back from chat.complete. */
 function mockChatCompletionResponse(content: string): Response {

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import {
   lookupRelease,
   findSuggestedRelease,
@@ -19,6 +19,18 @@ function makeMbArtistReleasesResponse(releases: unknown[]): Response {
     headers: { "content-type": "application/json" },
   });
 }
+
+// `bun test` runs every file in one process, so `globalThis.fetch` can arrive
+// here still spied on — with responses another file queued and never spent. A
+// `mockResolvedValueOnce` set below would then queue *behind* those, and the
+// first request in this file gets served someone else's body: that's how
+// "returns the release closest in year to sourceYear" came to see zero releases
+// on CI (a `{ artists: [...] }` shape has no `releases` key) while passing
+// locally, where the file order put it first. Start every test from an
+// unmocked fetch rather than trusting whatever ran before.
+beforeEach(() => {
+  mock.restore();
+});
 
 describe("findSuggestedRelease", () => {
   afterEach(() => {

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, spyOn, mock } from "bun:test";
+import { describe, test, expect, spyOn, mock, beforeEach, afterEach } from "bun:test";
 import {
   parseOgTags,
   decodeHtmlEntities,
@@ -1007,6 +1007,23 @@ function mockItunesResponse(results: object[]): Response {
 }
 
 describe("searchAppleMusic", () => {
+  // Both lookup paths behind searchAppleMusic no-op under
+  // OTB_DISABLE_EXTERNAL_LOOKUPS, so a stray copy of the flag — left in the
+  // shared process by whichever test file `bun test` happened to run first —
+  // makes every assertion here read `undefined`. Guarantee it's off for these
+  // tests rather than depending on file order.
+  let flagBefore: string | undefined;
+
+  beforeEach(() => {
+    flagBefore = process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+  });
+
+  afterEach(() => {
+    if (flagBefore === undefined) delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+    else process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = flagBefore;
+  });
+
   test("returns URL for exact title and artist match", async () => {
     spyOn(globalThis, "fetch").mockResolvedValueOnce(
       mockItunesResponse([


### PR DESCRIPTION
`main` has been red on the `unit` job: 759 pass / **9 fail**, all in `searchAppleMusic` (8) and `findSuggestedRelease` (1). They pass on every machine I ran them on and fail on every GitHub runner, which is why nothing caught them locally.

Neither is a bug in the code under test. `bun test` runs all 48 files in **one process** and doesn't fix their order, so whatever a file leaves behind in `process.env` or on a global spy becomes the next file's starting state — and the order differs between a runner and a laptop.

## The two leaks

**1. A leaked env flag (the 8 Apple Music failures).** `creator-page-source-notes.test.ts` sets `OTB_DISABLE_EXTERNAL_LOOKUPS=1` at module scope and never clears it. Both lookup paths behind `searchAppleMusic` — the catalogue API and the iTunes fallback — return `null` immediately under that flag, so when `scraper.test.ts` runs after it, every assertion there reads `undefined`. The runner log shows those tests failing in **0.2ms**: they never reached their mocked `fetch` at all.

Fixed by restoring the previous values in `afterAll`, and by having the `searchAppleMusic` describe clear the flag itself rather than trusting the file order.

**2. A leaked mock queue (the `findSuggestedRelease` failure).** `musicbrainz.test.ts` inherited a `globalThis.fetch` spy still holding a response some earlier file had queued and never spent. `mockResolvedValueOnce` **appends**, so the file's first request was served that stale body — an `{ artists: [...] }` shape, which has no `releases` key. Hence the failure's tell in the log:

```
[musicbrainz] No suggestible releases { …, releaseCount: 0, trackedCount: 1 }
Expected: "Tri Repetae"
Received: undefined
```

Fixed by restoring mocks **before** each test, not only after. I verified both halves of that mechanism in a scratch test: a leftover `Once` value really is served to the next caller, and `mock.restore()` really does clear the queue.

## Verification

- On a runner, `scraper.test.ts` **alone** passes 91/91 while the same file fails 8 inside the full suite — that's what pointed at cross-file state rather than a bad assertion.
- Full suite on a runner with these fixes: **768 pass / 0 fail** ([run 31877371754](https://github.com/richpjames/on-the-beach/actions/runs/31877371754), `unit` and `e2e` both green). The same suite on `main` at `63a7459` fails the 9 ([run 31875213165](https://github.com/richpjames/on-the-beach/actions/runs/31875213165)).
- Locally: 768 pass on Bun 1.3.11 and 1.3.14.

Three test files change; no server or app code is touched.

Found while checking CI on #295 (the share-sheet list search), which was red only because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VueU9BkwG82HqQzJGCgrm8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VueU9BkwG82HqQzJGCgrm8)_