### PR TITLE
Offer up to three releases in the "you might also like" prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A full-stack music tracker for collecting links and keeping tabs on listening st
 - Ingest music links automatically via HTTP webhook
 - Filter the list by status, stack, or source
 - Full-text search
-- "You may also like" suggestions (via Cover Art Archive) when marking items as listened
+- "You may also like" suggestions — up to three releases to pick from (via Cover Art Archive) when marking items as listened
 
 ## Tech Stack
 

--- a/playwright/suggestion-on-listened.spec.ts
+++ b/playwright/suggestion-on-listened.spec.ts
@@ -30,17 +30,19 @@ test("suggestion modal appears when a release is marked listened on the release 
       contentType: "application/json",
       body: JSON.stringify({
         item: { ...item, listen_status: "listened" },
-        suggestion: {
-          id: 999,
-          sourceItemId: item.id,
-          title: "Tri Repetae",
-          artistName: "Autechre",
-          itemType: "album",
-          year: 1995,
-          musicbrainzReleaseId: null,
-          status: "pending",
-          createdAt: new Date().toISOString(),
-        },
+        suggestions: [
+          {
+            id: 999,
+            sourceItemId: item.id,
+            title: "Tri Repetae",
+            artistName: "Autechre",
+            itemType: "album",
+            year: 1995,
+            musicbrainzReleaseId: null,
+            status: "pending",
+            createdAt: new Date().toISOString(),
+          },
+        ],
       }),
     });
   });
@@ -85,17 +87,19 @@ async function openSuggestionWithIds(
       contentType: "application/json",
       body: JSON.stringify({
         item: { ...item, listen_status: "listened" },
-        suggestion: {
-          id: 999,
-          sourceItemId: item.id,
-          title: "Tri Repetae",
-          artistName: "Autechre",
-          itemType: "album",
-          year: 1995,
-          status: "pending",
-          createdAt: new Date().toISOString(),
-          ...ids,
-        },
+        suggestions: [
+          {
+            id: 999,
+            sourceItemId: item.id,
+            title: "Tri Repetae",
+            artistName: "Autechre",
+            itemType: "album",
+            year: 1995,
+            status: "pending",
+            createdAt: new Date().toISOString(),
+            ...ids,
+          },
+        ],
       }),
     });
   });
@@ -173,6 +177,93 @@ test("suggestion artwork falls back to the release when the group has none", asy
   await expect
     .poll(() => artwork.evaluate((img: HTMLImageElement) => img.naturalWidth > 0))
     .toBe(true);
+});
+
+test("the prompt offers every stored suggestion, and adds the one picked", async ({
+  page,
+  request,
+}) => {
+  const res = await request.post("/api/music-items", {
+    data: { title: "Amber", artistName: "Autechre", listenStatus: "to-listen", year: 1994 },
+  });
+  const item = await res.json();
+
+  // Three prefetched suggestions, standing in for the MusicBrainz lookup.
+  for (const [title, year] of [
+    ["Tri Repetae", 1995],
+    ["Chiastic Slide", 1997],
+    ["Confield", 2001],
+  ] as const) {
+    await request.post("/api/__test__/suggestions", {
+      data: { sourceItemId: item.id, title, artistName: "Autechre", itemType: "album", year },
+    });
+  }
+
+  await page.goto(`/r/${item.id}`);
+  await page.locator("#status-select").selectOption("listened");
+
+  const modal = page.locator("#suggestion-picker-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  const candidates = modal.locator(".link-picker__candidate");
+  await expect(candidates).toHaveCount(3);
+
+  // The first is selected by default; picking another moves the selection.
+  await expect(candidates.first()).toHaveAttribute("aria-pressed", "true");
+  await candidates.nth(2).click();
+  await expect(candidates.nth(2)).toHaveAttribute("aria-pressed", "true");
+  await expect(candidates.first()).toHaveAttribute("aria-pressed", "false");
+
+  const acceptResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/music-items/${item.id}/suggestion/accept`) &&
+      response.request().method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#suggestion-picker-accept").click();
+  expect((await acceptResponse).status()).toBe(201);
+
+  const list = await (await request.get("/api/music-items?listenStatus=to-listen")).json();
+  const items = Array.isArray(list) ? list : list.items;
+  const titles = items.map((entry: { title: string }) => entry.title);
+  expect(titles).toContain("Confield");
+  expect(titles).not.toContain("Tri Repetae");
+});
+
+test("dismissing the prompt turns down every release it offered", async ({ page, request }) => {
+  const res = await request.post("/api/music-items", {
+    data: { title: "Amber", artistName: "Autechre", listenStatus: "to-listen", year: 1994 },
+  });
+  const item = await res.json();
+
+  for (const title of ["Tri Repetae", "Chiastic Slide"]) {
+    await request.post("/api/__test__/suggestions", {
+      data: { sourceItemId: item.id, title, artistName: "Autechre", itemType: "album" },
+    });
+  }
+
+  await page.goto(`/r/${item.id}`);
+  await page.locator("#status-select").selectOption("listened");
+
+  const modal = page.locator("#suggestion-picker-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+
+  const dismissResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/music-items/${item.id}/suggestion/dismiss`) &&
+      response.request().method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#suggestion-picker-dismiss").click();
+  expect((await dismissResponse).status()).toBe(200);
+  await expect(modal).toBeHidden();
+
+  // Nothing was added, and marking another item listened must not re-offer the
+  // releases the user just turned down.
+  const list = await (await request.get("/api/music-items?listenStatus=to-listen")).json();
+  const items = Array.isArray(list) ? list : list.items;
+  const titles = items.map((entry: { title: string }) => entry.title);
+  expect(titles).not.toContain("Tri Repetae");
+  expect(titles).not.toContain("Chiastic Slide");
 });
 
 test("accepting a suggestion adds the release to the to-listen list", async ({ page, request }) => {

--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -224,31 +224,41 @@ async function fetchArtistReleases(mbid: string): Promise<MbArtistRelease[]> {
 }
 
 /**
- * Find another release by the artist whose title neither matches nor is close
- * to anything in `trackedTitles`. Candidates are ranked by release length
+ * Find up to `limit` releases by the artist whose titles neither match nor are
+ * close to anything in `trackedTitles`. Candidates are ranked by release length
  * under `lengthPreference` (albums before EPs before singles by default,
  * reversed for "shorter"), then by year: closest to `sourceYear`, or most
- * recent when null.
+ * recent when null. The picks are distinct records, not editions of one — see
+ * the dedupe below.
  *
- * Returns null when the artist can't be found or has no untracked releases.
- * Network failures and non-2xx MusicBrainz responses THROW so callers can
- * tell "nothing to suggest" apart from "the lookup failed" — swallowing them
- * here made production failures (rate limiting, blocked UAs) invisible.
+ * Returns an empty array when the artist can't be found or has no untracked
+ * releases. Network failures and non-2xx MusicBrainz responses THROW so callers
+ * can tell "nothing to suggest" apart from "the lookup failed" — swallowing
+ * them here made production failures (rate limiting, blocked UAs) invisible.
  */
-export async function findSuggestedRelease(opts: {
+export async function findSuggestedReleases(opts: {
   mbArtistId: string | null;
   artistName: string;
   trackedTitles: Set<string>;
   sourceYear: number | null;
   lengthPreference?: ReleaseLengthPreference;
-}): Promise<SuggestedRelease | null> {
-  const { mbArtistId, artistName, trackedTitles, sourceYear, lengthPreference = "longer" } = opts;
-  const searchLog = { artistName, mbArtistId, sourceYear, lengthPreference };
+  /** How many distinct releases to return. */
+  limit?: number;
+}): Promise<SuggestedRelease[]> {
+  const {
+    mbArtistId,
+    artistName,
+    trackedTitles,
+    sourceYear,
+    lengthPreference = "longer",
+    limit = 1,
+  } = opts;
+  const searchLog = { artistName, mbArtistId, sourceYear, lengthPreference, limit };
 
   const mbid = mbArtistId ?? (await fetchArtistMbid(artistName));
   if (!mbid) {
     console.info("[musicbrainz] No artist match for suggestion lookup", searchLog);
-    return null;
+    return [];
   }
 
   const releases = await fetchArtistReleases(mbid);
@@ -267,7 +277,7 @@ export async function findSuggestedRelease(opts: {
       releaseCount: releases.length,
       trackedCount: trackedTitles.size,
     });
-    return null;
+    return [];
   }
 
   const ranked = candidates.map((r) => {
@@ -303,13 +313,34 @@ export async function findSuggestedRelease(opts: {
       byYear(a, b),
   );
 
-  const picked = ranked[0] ?? null;
+  // MB lists every pressing of a record separately — a reissue, a Japanese
+  // edition and the original are three entries with the same title. Taking the
+  // top `limit` rows straight off the ranking would offer the same album three
+  // times, so a pick is skipped when its release-group, or a title close to it,
+  // is already on the list.
+  const picked: typeof ranked = [];
+  const pickedGroups = new Set<string>();
+  const pickedTitles: string[] = [];
+  for (const candidate of ranked) {
+    if (picked.length >= limit) break;
+    if (
+      candidate.musicbrainzReleaseGroupId &&
+      pickedGroups.has(candidate.musicbrainzReleaseGroupId)
+    )
+      continue;
+    if (titleMatchesAny(candidate.title, pickedTitles)) continue;
+
+    picked.push(candidate);
+    if (candidate.musicbrainzReleaseGroupId) pickedGroups.add(candidate.musicbrainzReleaseGroupId);
+    pickedTitles.push(candidate.title);
+  }
+
   console.info("[musicbrainz] Suggestion lookup result", {
     ...searchLog,
     mbid,
     releaseCount: releases.length,
     candidateCount: candidates.length,
-    picked: picked ? { title: picked.title, year: picked.year, tracks: picked.trackCount } : null,
+    picked: picked.map((p) => ({ title: p.title, year: p.year, tracks: p.trackCount })),
   });
 
   return picked;

--- a/server/routes/music-items.ts
+++ b/server/routes/music-items.ts
@@ -26,7 +26,7 @@ import { hydrateItemStacks } from "../hydrate-item-stacks";
 import { scrapeAddedLink } from "../added-link-scrape";
 import { saveArtwork } from "../secondary-link-enrichment";
 import { UnsupportedMusicLinkError } from "../scraper";
-import { ensureSuggestionForItemNow, findPendingSuggestionForItem } from "../suggestions";
+import { ensureSuggestionsForItemNow, findPendingSuggestionsForItem } from "../suggestions";
 import { scheduleAppleMusicBackfill } from "../apple-music-backfill";
 import type {
   CreateMusicItemInput,
@@ -531,20 +531,22 @@ musicItemRoutes.patch("/:id", async (c) => {
     return c.json({ error: "Not found" }, 404);
   }
 
-  let suggestion = null;
+  let suggestions: Awaited<ReturnType<typeof ensureSuggestionsForItemNow>> = [];
   if (input.listenStatus === "listened") {
     try {
-      // Prefetched suggestion if one is ready, else a bounded on-demand
+      // Prefetched suggestions if any are ready, else a bounded on-demand
       // lookup — covers items marked listened before the background prefetch
       // finished (or whose prefetch failed).
-      suggestion = await ensureSuggestionForItemNow(id);
+      suggestions = await ensureSuggestionsForItemNow(id);
     } catch (err) {
       // Non-critical — suggestion lookup must not block the status update
       console.error("[api] suggestion lookup failed during PATCH", id, err);
     }
   }
 
-  return c.json({ item, suggestion });
+  // `suggestion` is the first of `suggestions`, kept for clients built before
+  // the prompt offered a choice (a bundled native build can lag the server).
+  return c.json({ item, suggestion: suggestions[0] ?? null, suggestions });
 });
 
 // ---------------------------------------------------------------------------
@@ -573,7 +575,14 @@ musicItemRoutes.post("/:id/suggestion/accept", async (c) => {
   const id = Number(c.req.param("id"));
   if (Number.isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
 
-  const suggestion = await findPendingSuggestionForItem(id);
+  // Which of the offered suggestions the user picked. Absent (older clients,
+  // which only ever saw one) means the first.
+  const body = (await c.req.json().catch(() => null)) as { suggestionId?: unknown } | null;
+  const suggestionId = typeof body?.suggestionId === "number" ? body.suggestionId : null;
+
+  const pending = await findPendingSuggestionsForItem(id);
+  const suggestion =
+    suggestionId === null ? pending[0] : pending.find((row) => row.id === suggestionId);
 
   if (!suggestion) return c.json({ error: "No pending suggestion" }, 404);
 
@@ -614,12 +623,30 @@ musicItemRoutes.post("/:id/suggestion/dismiss", async (c) => {
   const id = Number(c.req.param("id"));
   if (Number.isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
 
-  const suggestion = await findPendingSuggestionForItem(id);
-  if (suggestion) {
+  // Dismissing the prompt turns down everything it offered, so the client
+  // sends back the ids it showed. Without a list, only the first is dismissed
+  // — an older client can't have shown more than that.
+  const body = (await c.req.json().catch(() => null)) as { suggestionIds?: unknown } | null;
+  const requestedIds = Array.isArray(body?.suggestionIds)
+    ? body.suggestionIds.filter((value: unknown): value is number => typeof value === "number")
+    : null;
+
+  const pending = await findPendingSuggestionsForItem(id);
+  const toDismiss =
+    requestedIds === null
+      ? pending.slice(0, 1)
+      : pending.filter((row) => requestedIds.includes(row.id));
+
+  if (toDismiss.length > 0) {
     await db
       .update(itemSuggestions)
       .set({ status: "dismissed" })
-      .where(eq(itemSuggestions.id, suggestion.id));
+      .where(
+        inArray(
+          itemSuggestions.id,
+          toDismiss.map((row) => row.id),
+        ),
+      );
   }
 
   return c.json({ success: true });

--- a/server/suggestions.ts
+++ b/server/suggestions.ts
@@ -1,18 +1,19 @@
 import { and, desc, eq, isNotNull, isNull } from "drizzle-orm";
 import { db } from "./db/index";
 import { musicItems, artists, itemSuggestions } from "./db/schema";
-import { fetchReleaseGroupIdForRelease, findSuggestedRelease } from "./musicbrainz";
+import { fetchReleaseGroupIdForRelease, findSuggestedReleases } from "./musicbrainz";
 import { getReleaseLengthPreference } from "./settings";
 import { normalize } from "./utils";
 
 // ---------------------------------------------------------------------------
 // Suggestion prefetch
 //
-// Every artist with at least one 'to-listen' item should have exactly one
-// pending suggestion (another release by that artist, looked up on
-// MusicBrainz) stored ahead of time, so that when an item is marked
+// Every artist with at least one 'to-listen' item should have up to
+// SUGGESTION_TARGET pending suggestions (other releases by that artist, looked
+// up on MusicBrainz) stored ahead of time, so that when an item is marked
 // 'listened' the "you might also like" prompt has something to show
-// instantly. The prefetch runs in three places:
+// instantly — and enough of it that the user gets a choice rather than a
+// single take-it-or-leave-it release. The prefetch runs in three places:
 //   1. Eagerly, fire-and-forget, when an item is created (music-item-creator)
 //      — this covers the web add form and all ingest paths (share extension,
 //      email, photo).
@@ -22,6 +23,13 @@ import { normalize } from "./utils";
 //   3. Indirectly, when a suggestion is accepted: the newly created item
 //      re-enters path 1 and queues up the next release by that artist.
 // ---------------------------------------------------------------------------
+
+/**
+ * How many pending suggestions an artist should have on file — and therefore
+ * how many options the "you might also like" prompt offers. Artists with fewer
+ * suggestible releases than this simply get what MusicBrainz has.
+ */
+export const SUGGESTION_TARGET = 3;
 
 interface ItemSummary {
   id: number;
@@ -50,29 +58,30 @@ async function suggestionsForArtist(artistName: string): Promise<StoredSuggestio
   return rows.filter((row) => normalize(row.artistName) === target);
 }
 
-/** The artist's single pending suggestion, if one is stored. */
-export async function findPendingSuggestionForArtist(
+/** The artist's pending suggestions, oldest first. */
+export async function findPendingSuggestionsForArtist(
   artistName: string,
-): Promise<StoredSuggestion | null> {
+): Promise<StoredSuggestion[]> {
   const rows = await suggestionsForArtist(artistName);
-  return rows.find((row) => row.status === "pending") ?? null;
+  return rows.filter((row) => row.status === "pending").sort((a, b) => a.id - b.id);
 }
 
 /**
- * Resolve the pending suggestion to surface for an item: one keyed to the
- * item itself wins, otherwise fall back to the artist's pending suggestion —
- * items created before the prefetch existed (or whose sibling triggered it)
- * still get the artist-level one.
+ * Resolve the pending suggestions to surface for an item, best first and at
+ * most `limit` of them: those keyed to the item itself lead, and the artist's
+ * other pending suggestions fill the remaining slots — items created before
+ * the prefetch existed (or whose sibling triggered it) still get the
+ * artist-level ones.
  */
-export async function findPendingSuggestionForItem(
+export async function findPendingSuggestionsForItem(
   itemId: number,
-): Promise<StoredSuggestion | null> {
+  limit = SUGGESTION_TARGET,
+): Promise<StoredSuggestion[]> {
   const own = await db
     .select()
     .from(itemSuggestions)
     .where(and(eq(itemSuggestions.sourceItemId, itemId), eq(itemSuggestions.status, "pending")))
-    .get();
-  if (own) return own;
+    .orderBy(itemSuggestions.id);
 
   const itemRow = await db
     .select({ artistName: artists.name })
@@ -80,15 +89,25 @@ export async function findPendingSuggestionForItem(
     .innerJoin(artists, eq(musicItems.artistId, artists.id))
     .where(eq(musicItems.id, itemId))
     .get();
-  if (!itemRow?.artistName) return null;
 
-  return findPendingSuggestionForArtist(itemRow.artistName);
+  const forArtist = itemRow?.artistName
+    ? await findPendingSuggestionsForArtist(itemRow.artistName)
+    : [];
+
+  const seen = new Set<number>();
+  const combined: StoredSuggestion[] = [];
+  for (const row of [...own, ...forArtist]) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    combined.push(row);
+  }
+  return combined.slice(0, limit);
 }
 
 export type SuggestionFetchOutcome =
-  // A new pending suggestion was stored.
+  // At least one new pending suggestion was stored.
   | "stored"
-  // The artist already has a pending suggestion — nothing to do.
+  // The artist already has a full set of pending suggestions — nothing to do.
   | "already-pending"
   // MusicBrainz has no untracked release to suggest; retried after a day.
   | "no-candidates"
@@ -111,9 +130,9 @@ const EMPTY_LOOKUP_BACKOFF_MS = 24 * 60 * 60 * 1000;
 const inFlightByArtist = new Map<string, Promise<SuggestionFetchOutcome>>();
 
 /**
- * Look up one extra release by the item's artist on MusicBrainz and store it
- * as a pending suggestion. Skips artists that already have a pending
- * suggestion (one "extra" per artist) and never re-suggests a release that is
+ * Look up extra releases by the item's artist on MusicBrainz and store them as
+ * pending suggestions, topping the artist up to SUGGESTION_TARGET. Skips
+ * artists that already have a full set and never re-suggests a release that is
  * already tracked or was previously suggested (accepted or dismissed).
  */
 export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<SuggestionFetchOutcome> {
@@ -144,7 +163,9 @@ async function fetchAndStoreSuggestionLocked(
 
   try {
     const previousSuggestions = await suggestionsForArtist(item.artist_name);
-    if (previousSuggestions.some((row) => row.status === "pending")) {
+    const pendingCount = previousSuggestions.filter((row) => row.status === "pending").length;
+    const wanted = SUGGESTION_TARGET - pendingCount;
+    if (wanted <= 0) {
       return "already-pending";
     }
 
@@ -164,33 +185,44 @@ async function fetchAndStoreSuggestionLocked(
       trackedTitles.add(normalize(row.title));
     }
 
-    const suggestion = await findSuggestedRelease({
+    const suggestions = await findSuggestedReleases({
       mbArtistId: item.musicbrainz_artist_id,
       artistName: item.artist_name,
       trackedTitles,
       sourceYear: item.year,
       lengthPreference: await getReleaseLengthPreference(),
+      limit: wanted,
     });
 
-    if (!suggestion) {
+    if (suggestions.length === 0) {
       emptyLookupBackoff.set(backoffKey, Date.now() + EMPTY_LOOKUP_BACKOFF_MS);
       return "no-candidates";
     }
 
-    await db.insert(itemSuggestions).values({
-      sourceItemId: item.id,
-      title: suggestion.title,
-      artistName: item.artist_name,
-      itemType: suggestion.itemType,
-      year: suggestion.year,
-      musicbrainzReleaseId: suggestion.musicbrainzReleaseId,
-      musicbrainzReleaseGroupId: suggestion.musicbrainzReleaseGroupId,
-      status: "pending",
-    });
-    emptyLookupBackoff.delete(backoffKey);
-    console.info("[suggestions] stored suggestion", {
+    await db.insert(itemSuggestions).values(
+      suggestions.map((suggestion) => ({
+        sourceItemId: item.id,
+        title: suggestion.title,
+        artistName: item.artist_name,
+        itemType: suggestion.itemType,
+        year: suggestion.year,
+        musicbrainzReleaseId: suggestion.musicbrainzReleaseId,
+        musicbrainzReleaseGroupId: suggestion.musicbrainzReleaseGroupId,
+        status: "pending",
+      })),
+    );
+
+    // An artist with fewer suggestible releases than we asked for would
+    // otherwise be re-looked-up on every sweep for the one slot MusicBrainz
+    // can never fill; the backoff makes that a daily retry instead.
+    if (suggestions.length < wanted) {
+      emptyLookupBackoff.set(backoffKey, Date.now() + EMPTY_LOOKUP_BACKOFF_MS);
+    } else {
+      emptyLookupBackoff.delete(backoffKey);
+    }
+    console.info("[suggestions] stored suggestions", {
       artist: item.artist_name,
-      title: suggestion.title,
+      titles: suggestions.map((suggestion) => suggestion.title),
       sourceItemId: item.id,
     });
     return "stored";
@@ -218,21 +250,25 @@ export function fetchSuggestionInBackground(item: ItemSummary): void {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Resolve a suggestion for an item at state-change time, looking one up on
+ * Resolve the suggestions for an item at state-change time, looking them up on
  * the spot when nothing was prefetched — e.g. the item was marked listened
  * seconds after being added (before the background prefetch finished), or the
  * earlier prefetch failed. Bounded so the status update stays responsive: on
  * timeout the lookup keeps running in the background and its result is
  * stored for next time.
+ *
+ * Whatever was prefetched is used as-is, even if it's a single suggestion:
+ * making the user wait on a live MusicBrainz round trip to pad the prompt out
+ * to three options is a worse trade than showing the one we have.
  */
-export async function ensureSuggestionForItemNow(
+export async function ensureSuggestionsForItemNow(
   itemId: number,
   timeoutMs = 4_500,
-): Promise<StoredSuggestion | null> {
-  const prefetched = await findPendingSuggestionForItem(itemId);
-  if (prefetched) return prefetched;
+): Promise<StoredSuggestion[]> {
+  const prefetched = await findPendingSuggestionsForItem(itemId);
+  if (prefetched.length > 0) return prefetched;
 
-  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return null;
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return [];
 
   const itemRow = await db
     .select({
@@ -244,7 +280,7 @@ export async function ensureSuggestionForItemNow(
     .innerJoin(artists, eq(musicItems.artistId, artists.id))
     .where(eq(musicItems.id, itemId))
     .get();
-  if (!itemRow?.artistName) return null;
+  if (!itemRow?.artistName) return [];
 
   console.info("[suggestions] no prefetched suggestion — looking up on demand", {
     itemId,
@@ -263,10 +299,10 @@ export async function ensureSuggestionForItemNow(
     console.warn("[suggestions] on-demand lookup timed out; result will store in background", {
       itemId,
     });
-    return null;
+    return [];
   }
 
-  return findPendingSuggestionForItem(itemId);
+  return findPendingSuggestionsForItem(itemId);
 }
 
 /** MusicBrainz allows ~1 request/second; each artist lookup makes up to two. */
@@ -357,7 +393,18 @@ export async function ensureSuggestionsForToListenArtists(): Promise<void> {
     .select({ artistName: itemSuggestions.artistName })
     .from(itemSuggestions)
     .where(eq(itemSuggestions.status, "pending"));
-  const covered = new Set(pendingRows.map((row) => normalize(row.artistName)));
+  // Artists are only "covered" once they have a full set — one pending
+  // suggestion on file is no longer enough now the prompt offers a choice.
+  const pendingPerArtist = new Map<string, number>();
+  for (const row of pendingRows) {
+    const key = normalize(row.artistName);
+    pendingPerArtist.set(key, (pendingPerArtist.get(key) ?? 0) + 1);
+  }
+  const covered = new Set(
+    [...pendingPerArtist]
+      .filter(([, count]) => count >= SUGGESTION_TARGET)
+      .map(([artistKey]) => artistKey),
+  );
 
   // Most recent to-listen item per artist represents that artist in the lookup.
   const perArtist = new Map<string, (typeof candidates)[number]>();

--- a/src/lib/components/MainPage.svelte
+++ b/src/lib/components/MainPage.svelte
@@ -73,7 +73,7 @@
   let items = $state(data.items);
   let childStacks = $state<Array<{ id: number; name: string; item_count: number }>>([]);
 
-  let suggestion = $state<ItemSuggestion | null>(null);
+  let suggestions = $state<ItemSuggestion[]>([]);
   let suggestionSourceId = $state<number | null>(null);
 
   let addFormComponent: AddForm | undefined = $state();
@@ -269,8 +269,8 @@
     const result = await api.updateListenStatus(itemId, status);
     app.send({ type: "LIST_REFRESH" });
 
-    if (status === "listened" && result?.suggestion) {
-      suggestion = result.suggestion;
+    if (status === "listened" && result?.suggestions.length) {
+      suggestions = result.suggestions;
       suggestionSourceId = itemId;
     }
   }
@@ -438,11 +438,11 @@
 />
 
 <SuggestionPickerModal
-  {suggestion}
+  {suggestions}
   sourceItemId={suggestionSourceId}
   onAccepted={() => app.send({ type: "LIST_REFRESH" })}
   onClosed={() => {
-    suggestion = null;
+    suggestions = [];
     suggestionSourceId = null;
   }}
 />

--- a/src/lib/components/ReleasePage.svelte
+++ b/src/lib/components/ReleasePage.svelte
@@ -68,7 +68,7 @@
   }
 
   // ── Suggestion picker ──────────────────────────────────────────────────────
-  let suggestion = $state<ItemSuggestion | null>(null);
+  let suggestions = $state<ItemSuggestion[]>([]);
   let suggestionSourceId = $state<number | null>(null);
 
   async function onStatusChange(event: Event): Promise<void> {
@@ -86,8 +86,8 @@
     if (wasScheduled) {
       await clearReminder();
     }
-    if (newStatus === "listened" && result?.suggestion) {
-      suggestion = result.suggestion;
+    if (newStatus === "listened" && result?.suggestions.length) {
+      suggestions = result.suggestions;
       suggestionSourceId = item.id;
     }
   }
@@ -794,11 +794,11 @@
 </main>
 
 <SuggestionPickerModal
-  {suggestion}
+  {suggestions}
   sourceItemId={suggestionSourceId}
   onAccepted={() => {}}
   onClosed={() => {
-    suggestion = null;
+    suggestions = [];
     suggestionSourceId = null;
   }}
 />

--- a/src/lib/components/SuggestionArtwork.svelte
+++ b/src/lib/components/SuggestionArtwork.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { ItemSuggestion } from "../../types";
+
+  let { suggestion }: { suggestion: ItemSuggestion } = $props();
+
+  // Cover Art Archive is keyed by both release-group and release MBID, but the
+  // two are nowhere near equally covered: a suggestion is one specific pressing
+  // out of dozens, and most pressings have no scan uploaded, while the
+  // release-group nearly always does. Ask the group first and only fall back to
+  // the exact release — asking the release alone is why these prompts came up
+  // blank most of the time.
+  const artworkCandidates = $derived.by(() => {
+    const urls: string[] = [];
+    if (suggestion.musicbrainzReleaseGroupId) {
+      urls.push(
+        `https://coverartarchive.org/release-group/${encodeURIComponent(suggestion.musicbrainzReleaseGroupId)}/front-250`,
+      );
+    }
+    if (suggestion.musicbrainzReleaseId) {
+      urls.push(
+        `https://coverartarchive.org/release/${encodeURIComponent(suggestion.musicbrainzReleaseId)}/front-250`,
+      );
+    }
+    return urls;
+  });
+
+  // Index into artworkCandidates; past the end means "give up, show no image".
+  let candidateIndex = $state(0);
+  let retried = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  const artworkUrl = $derived(artworkCandidates[candidateIndex] ?? null);
+
+  $effect.pre(() => {
+    void suggestion;
+    if (retryTimer !== null) clearTimeout(retryTimer);
+    retryTimer = null;
+    candidateIndex = 0;
+    retried = false;
+  });
+
+  // CAA also serves the odd transient 5xx from its archive.org backend, which
+  // reaches an <img> as the same bare `error` event as a genuine 404. One retry
+  // pass over the whole list costs nothing and rescues those.
+  function onArtworkError(): void {
+    if (candidateIndex + 1 < artworkCandidates.length) {
+      candidateIndex += 1;
+      return;
+    }
+    // Dropping the <img> and re-adding it is what forces a fresh request; the
+    // browser won't reload a src it has already failed on.
+    candidateIndex = artworkCandidates.length;
+    if (retried) return;
+    retried = true;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      candidateIndex = 0;
+    }, 800);
+  }
+</script>
+
+{#if artworkUrl}
+  <img
+    src={artworkUrl}
+    alt={suggestion.title}
+    class="suggestion-picker__artwork"
+    onerror={onArtworkError}
+  />
+{/if}

--- a/src/lib/components/SuggestionPickerModal.svelte
+++ b/src/lib/components/SuggestionPickerModal.svelte
@@ -1,82 +1,48 @@
 <script lang="ts">
   import type { ItemSuggestion } from "../../types";
   import { api } from "../api";
+  import SuggestionArtwork from "./SuggestionArtwork.svelte";
 
   let {
-    suggestion,
+    suggestions,
     sourceItemId,
     onAccepted,
     onClosed,
   }: {
-    suggestion: ItemSuggestion | null;
+    suggestions: ItemSuggestion[];
     sourceItemId: number | null;
     onAccepted: () => void;
     onClosed: () => void;
   } = $props();
 
-  // Cover Art Archive is keyed by both release-group and release MBID, but the
-  // two are nowhere near equally covered: a suggestion is one specific pressing
-  // out of dozens, and most pressings have no scan uploaded, while the
-  // release-group nearly always does. Ask the group first and only fall back to
-  // the exact release — asking the release alone is why these prompts came up
-  // blank most of the time.
-  const artworkCandidates = $derived.by(() => {
-    if (!suggestion) return [];
-    const urls: string[] = [];
-    if (suggestion.musicbrainzReleaseGroupId) {
-      urls.push(
-        `https://coverartarchive.org/release-group/${encodeURIComponent(suggestion.musicbrainzReleaseGroupId)}/front-250`,
-      );
-    }
-    if (suggestion.musicbrainzReleaseId) {
-      urls.push(
-        `https://coverartarchive.org/release/${encodeURIComponent(suggestion.musicbrainzReleaseId)}/front-250`,
-      );
-    }
-    return urls;
-  });
+  const isOpen = $derived(suggestions.length > 0);
 
-  // Index into artworkCandidates; past the end means "give up, show no image".
-  let candidateIndex = $state(0);
-  let retried = false;
-  let retryTimer: ReturnType<typeof setTimeout> | null = null;
-  const artworkUrl = $derived(artworkCandidates[candidateIndex] ?? null);
+  // The suggestion the "Add to list" button will take. Reset whenever the
+  // prompt opens with a different set, so a stale id can't carry over.
+  let selectedId = $state<number | null>(null);
+  const suggestionsKey = $derived(suggestions.map((s) => s.id).join(","));
 
   $effect.pre(() => {
-    void suggestion;
-    if (retryTimer !== null) clearTimeout(retryTimer);
-    retryTimer = null;
-    candidateIndex = 0;
-    retried = false;
+    void suggestionsKey;
+    selectedId = suggestions[0]?.id ?? null;
   });
 
-  // CAA also serves the odd transient 5xx from its archive.org backend, which
-  // reaches an <img> as the same bare `error` event as a genuine 404. One retry
-  // pass over the whole list costs nothing and rescues those.
-  function onArtworkError(): void {
-    if (candidateIndex + 1 < artworkCandidates.length) {
-      candidateIndex += 1;
-      return;
-    }
-    // Dropping the <img> and re-adding it is what forces a fresh request; the
-    // browser won't reload a src it has already failed on.
-    candidateIndex = artworkCandidates.length;
-    if (retried) return;
-    retried = true;
-    retryTimer = setTimeout(() => {
-      retryTimer = null;
-      candidateIndex = 0;
-    }, 800);
-  }
+  const artistNames = $derived([...new Set(suggestions.map((s) => s.artistName))]);
+  const message = $derived.by(() => {
+    if (suggestions.length === 0) return "";
+    const by = artistNames.length === 1 ? `Also by ${artistNames[0]}` : "Also by artists you like";
+    return suggestions.length === 1 ? by : `${by} — pick one`;
+  });
 
   async function accept(): Promise<void> {
-    if (sourceItemId === null) return;
-    // Snapshot the id: destructured $props() reads are live, and onClosed()
-    // nulls the parent state this prop is bound to.
+    if (sourceItemId === null || selectedId === null) return;
+    // Snapshot the ids: destructured $props() reads are live, and onClosed()
+    // nulls the parent state these props are bound to.
     const itemId = sourceItemId;
+    const suggestionId = selectedId;
     onClosed();
     try {
-      await api.acceptSuggestion(itemId);
+      await api.acceptSuggestion(itemId, suggestionId);
     } catch {
       alert("Failed to add release.");
       return;
@@ -87,16 +53,18 @@
   async function dismiss(): Promise<void> {
     if (sourceItemId === null) return;
     const itemId = sourceItemId;
+    // Turning down the prompt turns down every release it offered.
+    const suggestionIds = suggestions.map((s) => s.id);
     onClosed();
     try {
-      await api.dismissSuggestion(itemId);
+      await api.dismissSuggestion(itemId, suggestionIds);
     } catch {
       alert("Failed to dismiss suggestion.");
     }
   }
 
   $effect(() => {
-    if (!suggestion) return;
+    if (!isOpen) return;
     const onEscape = (event: KeyboardEvent): void => {
       if (event.key === "Escape") void dismiss();
     };
@@ -105,7 +73,7 @@
   });
 </script>
 
-<div id="suggestion-picker-modal" class="link-picker" hidden={!suggestion}>
+<div id="suggestion-picker-modal" class="link-picker" hidden={!isOpen}>
   <div
     class="link-picker__backdrop"
     data-suggestion-picker-close="true"
@@ -120,21 +88,20 @@
   >
     <div class="link-picker__header">
       <h2 id="suggestion-picker-title">You might also like</h2>
-      <p id="suggestion-picker-message">
-        {suggestion ? `Also by ${suggestion.artistName}` : ""}
-      </p>
+      <p id="suggestion-picker-message">{message}</p>
     </div>
-    <div id="suggestion-picker-list" class="link-picker__list" style="overflow-y: visible">
-      {#if suggestion}
-        <button type="button" class="link-picker__candidate is-selected" aria-pressed="true">
-          {#if artworkUrl}
-            <img
-              src={artworkUrl}
-              alt={suggestion.title}
-              class="suggestion-picker__artwork"
-              onerror={onArtworkError}
-            />
-          {/if}
+    <div id="suggestion-picker-list" class="link-picker__list">
+      {#each suggestions as suggestion (suggestion.id)}
+        {@const isSelected = suggestion.id === selectedId}
+        <button
+          type="button"
+          class="link-picker__candidate"
+          class:is-selected={isSelected}
+          data-suggestion-id={suggestion.id}
+          aria-pressed={isSelected ? "true" : "false"}
+          onclick={() => (selectedId = suggestion.id)}
+        >
+          <SuggestionArtwork {suggestion} />
           <span class="link-picker__candidate-main">
             <span class="link-picker__candidate-title"
               >{suggestion.title}{suggestion.year ? ` (${suggestion.year})` : ""}</span
@@ -145,13 +112,19 @@
             <span class="badge badge--source">{suggestion.itemType}</span>
           </span>
         </button>
-      {/if}
+      {/each}
     </div>
     <div class="link-picker__actions">
       <button type="button" id="suggestion-picker-dismiss" class="btn btn--ghost" onclick={dismiss}
         >Dismiss</button
       >
-      <button type="button" id="suggestion-picker-accept" class="btn btn--primary" onclick={accept}>
+      <button
+        type="button"
+        id="suggestion-picker-accept"
+        class="btn btn--primary"
+        disabled={selectedId === null}
+        onclick={accept}
+      >
         Add to list
       </button>
     </div>

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -203,26 +203,41 @@ export class ApiClient {
   async updateListenStatus(
     id: number,
     status: ListenStatus,
-  ): Promise<{ item: MusicItemFull; suggestion: ItemSuggestion | null } | null> {
-    return this.requestJsonOrNull<{ item: MusicItemFull; suggestion: ItemSuggestion | null }>(
+  ): Promise<{ item: MusicItemFull; suggestions: ItemSuggestion[] } | null> {
+    const result = await this.requestJsonOrNull<{
+      item: MusicItemFull;
+      suggestion?: ItemSuggestion | null;
+      suggestions?: ItemSuggestion[];
+    }>(
       `/api/music-items/${id}`,
       "updateListenStatus",
-      this.jsonRequest("PATCH", { listenStatus: status }),
+      this.jsonRequest("PATCH", {
+        listenStatus: status,
+      }),
     );
+    if (!result) return null;
+
+    // `suggestions` is what the server sends now; `suggestion` is the single
+    // one older builds returned.
+    const suggestions =
+      result.suggestions ?? (result.suggestion ? [result.suggestion] : ([] as ItemSuggestion[]));
+    return { item: result.item, suggestions };
   }
 
-  async acceptSuggestion(sourceItemId: number): Promise<MusicItemFull> {
+  async acceptSuggestion(sourceItemId: number, suggestionId: number): Promise<MusicItemFull> {
     return this.requestJson<MusicItemFull>(
       `/api/music-items/${sourceItemId}/suggestion/accept`,
       "acceptSuggestion",
-      { method: "POST" },
+      this.jsonRequest("POST", { suggestionId }),
     );
   }
 
-  async dismissSuggestion(sourceItemId: number): Promise<void> {
-    await this.request(`/api/music-items/${sourceItemId}/suggestion/dismiss`, "dismissSuggestion", {
-      method: "POST",
-    });
+  async dismissSuggestion(sourceItemId: number, suggestionIds: number[]): Promise<void> {
+    await this.request(
+      `/api/music-items/${sourceItemId}/suggestion/dismiss`,
+      "dismissSuggestion",
+      this.jsonRequest("POST", { suggestionIds }),
+    );
   }
 
   async saveOrder(contextKey: string, itemIds: number[]): Promise<void> {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3628,6 +3628,34 @@ a:hover {
   gap: var(--space-5);
 }
 
+/* The prompt has no list-header row, so the shared four-row template would put
+   the list in an `auto` row and hand the flexible one to the buttons. With one
+   suggestion that was invisible; with three it clips the list and leaves the
+   spare space under the buttons. Three rows, list flexible. */
+#suggestion-picker-modal .link-picker__dialog {
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+/* The list scrolls when three releases won't fit — on a short landscape window
+   — rather than pushing the buttons off the bottom of the dialog. The link
+   picker hides its scrollbar because it draws its own; this list has no such
+   chrome, so it keeps the real one as its scroll affordance. */
+#suggestion-picker-list {
+  scrollbar-width: thin;
+}
+
+#suggestion-picker-list::-webkit-scrollbar {
+  width: 12px;
+}
+
+/* Smaller covers where vertical space is scarce, so all three stay in view. */
+@media (max-width: 520px), (orientation: landscape) and (max-height: 500px) {
+  .suggestion-picker__artwork {
+    width: 56px;
+    height: 56px;
+  }
+}
+
 /* Folder rows */
 .folder-row {
   display: flex;

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import {
   lookupRelease,
-  findSuggestedRelease,
+  findSuggestedReleases,
   fetchReleaseGroupIdForRelease,
   fetchArtistReleaseGroups,
   searchArtistCandidates,
   MusicBrainzHttpError,
 } from "../../server/musicbrainz";
+import type { SuggestedRelease } from "../../server/musicbrainz";
+
+/** The single top pick, which is what most of these cases are about. */
+async function findSuggestedRelease(
+  opts: Parameters<typeof findSuggestedReleases>[0],
+): Promise<SuggestedRelease | null> {
+  const [first] = await findSuggestedReleases(opts);
+  return first ?? null;
+}
 
 function makeMbArtistSearchResponse(artists: unknown[]): Response {
   return new Response(JSON.stringify({ artists }), {
@@ -32,7 +41,7 @@ beforeEach(() => {
   mock.restore();
 });
 
-describe("findSuggestedRelease", () => {
+describe("findSuggestedReleases", () => {
   afterEach(() => {
     mock.restore();
   });
@@ -335,6 +344,91 @@ describe("findSuggestedRelease", () => {
 
     expect(result?.musicbrainzReleaseGroupId).toBeNull();
     expect(result?.itemType).toBe("album");
+  });
+
+  test("returns up to `limit` releases, best first", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistReleasesResponse([
+        { id: "r1", title: "Amber", date: "1994" },
+        { id: "r2", title: "Tri Repetae", date: "1995" },
+        { id: "r3", title: "Chiastic Slide", date: "1997" },
+        { id: "r4", title: "Confield", date: "2001" },
+      ]),
+    );
+
+    const results = await findSuggestedReleases({
+      mbArtistId: "artist-uuid",
+      artistName: "Autechre",
+      trackedTitles: new Set(),
+      sourceYear: 1996,
+      limit: 3,
+    });
+
+    expect(results.map((r) => r.title)).toEqual(["Tri Repetae", "Chiastic Slide", "Amber"]);
+  });
+
+  test("returns fewer than `limit` when the artist has fewer untracked releases", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistReleasesResponse([
+        { id: "r1", title: "Amber", date: "1994" },
+        { id: "r2", title: "Tri Repetae", date: "1995" },
+      ]),
+    );
+
+    const results = await findSuggestedReleases({
+      mbArtistId: "artist-uuid",
+      artistName: "Autechre",
+      trackedTitles: new Set(["amber"]),
+      sourceYear: 1996,
+      limit: 3,
+    });
+
+    expect(results.map((r) => r.title)).toEqual(["Tri Repetae"]);
+  });
+
+  test("offers distinct records, not several pressings of one", async () => {
+    // MB lists each pressing separately — same release group, different ids.
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistReleasesResponse([
+        { id: "r1", title: "Tri Repetae", date: "1995", "release-group": { id: "rg-tri" } },
+        {
+          id: "r2",
+          title: "Tri Repetae (Japanese Edition)",
+          date: "1995",
+          "release-group": { id: "rg-tri" },
+        },
+        { id: "r3", title: "Chiastic Slide", date: "1997", "release-group": { id: "rg-chi" } },
+      ]),
+    );
+
+    const results = await findSuggestedReleases({
+      mbArtistId: "artist-uuid",
+      artistName: "Autechre",
+      trackedTitles: new Set(),
+      sourceYear: 1996,
+      limit: 3,
+    });
+
+    expect(results.map((r) => r.title)).toEqual(["Tri Repetae", "Chiastic Slide"]);
+  });
+
+  test("treats near-identical titles as the same record when there are no group ids", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      makeMbArtistReleasesResponse([
+        { id: "r1", title: "Tri Repetae", date: "1995" },
+        { id: "r2", title: "Tri Repetae [2009 Remaster]", date: "2009" },
+      ]),
+    );
+
+    const results = await findSuggestedReleases({
+      mbArtistId: "artist-uuid",
+      artistName: "Autechre",
+      trackedTitles: new Set(),
+      sourceYear: 1996,
+      limit: 3,
+    });
+
+    expect(results.map((r) => r.title)).toEqual(["Tri Repetae"]);
   });
 
   test("throws on fetch error so callers can distinguish failure from no-candidates", async () => {

--- a/tests/unit/suggestion-route.test.ts
+++ b/tests/unit/suggestion-route.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+import { db } from "../../server/db/index";
+import { artists, itemSuggestions, musicItems } from "../../server/db/schema";
+import { musicItemRoutes } from "../../server/routes/music-items";
+import { normalize } from "../../server/utils";
+
+// The prompt offers up to three releases, so the accept/dismiss endpoints have
+// to be told which one the user picked — "the artist's pending suggestion" is
+// no longer a single row.
+
+const ARTIST = "Suggestion Route Band";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/music-items", musicItemRoutes);
+  return app;
+}
+
+let sourceItemId: number;
+
+async function seedSuggestions(titles: string[]): Promise<number[]> {
+  const rows = await db
+    .insert(itemSuggestions)
+    .values(
+      titles.map((title) => ({
+        sourceItemId,
+        title,
+        artistName: ARTIST,
+        itemType: "album",
+        status: "pending",
+      })),
+    )
+    .returning({ id: itemSuggestions.id });
+  return rows.map((row) => row.id);
+}
+
+function post(path: string, body?: unknown) {
+  return makeApp().request(`http://localhost/api/music-items/${sourceItemId}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+async function statusOf(suggestionId: number): Promise<string | undefined> {
+  const row = await db
+    .select({ status: itemSuggestions.status })
+    .from(itemSuggestions)
+    .where(eq(itemSuggestions.id, suggestionId))
+    .get();
+  return row?.status;
+}
+
+beforeEach(async () => {
+  process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+  const [artist] = await db
+    .insert(artists)
+    .values({ name: ARTIST, normalizedName: normalize(ARTIST) })
+    .onConflictDoNothing()
+    .returning({ id: artists.id });
+  const artistId =
+    artist?.id ??
+    (await db
+      .select({ id: artists.id })
+      .from(artists)
+      .where(eq(artists.normalizedName, normalize(ARTIST)))
+      .get())!.id;
+
+  const [item] = await db
+    .insert(musicItems)
+    .values({ title: "Source Album", normalizedTitle: normalize("Source Album"), artistId })
+    .returning({ id: musicItems.id });
+  sourceItemId = item.id;
+});
+
+afterEach(async () => {
+  await db.delete(itemSuggestions).where(eq(itemSuggestions.sourceItemId, sourceItemId));
+  // Accepting creates a release of its own — clear the whole artist so the
+  // next case starts from an empty library.
+  const artist = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .where(eq(artists.normalizedName, normalize(ARTIST)))
+    .get();
+  if (artist) await db.delete(musicItems).where(eq(musicItems.artistId, artist.id));
+  await db.delete(musicItems).where(eq(musicItems.id, sourceItemId));
+  delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+});
+
+describe("POST /:id/suggestion/accept", () => {
+  test("adds the suggestion the user picked, not the first one offered", async () => {
+    const [, second] = await seedSuggestions(["First Offer", "Second Offer", "Third Offer"]);
+
+    const response = await post("/suggestion/accept", { suggestionId: second });
+
+    expect(response.status).toBe(201);
+    const created = (await response.json()) as { title: string };
+    expect(created.title).toBe("Second Offer");
+    expect(await statusOf(second)).toBe("accepted");
+  });
+
+  test("leaves the releases the user did not pick pending for next time", async () => {
+    const [first, second, third] = await seedSuggestions([
+      "First Offer",
+      "Second Offer",
+      "Third Offer",
+    ]);
+
+    await post("/suggestion/accept", { suggestionId: second });
+
+    expect(await statusOf(first)).toBe("pending");
+    expect(await statusOf(third)).toBe("pending");
+  });
+
+  test("falls back to the first suggestion when no id is sent", async () => {
+    const [first] = await seedSuggestions(["First Offer", "Second Offer"]);
+
+    const response = await post("/suggestion/accept");
+
+    expect(response.status).toBe(201);
+    expect(await statusOf(first)).toBe("accepted");
+  });
+
+  test("404s on an id that is not one of the item's pending suggestions", async () => {
+    await seedSuggestions(["First Offer"]);
+
+    const response = await post("/suggestion/accept", { suggestionId: -1 });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("POST /:id/suggestion/dismiss", () => {
+  test("dismisses every release the prompt offered", async () => {
+    const ids = await seedSuggestions(["First Offer", "Second Offer", "Third Offer"]);
+
+    const response = await post("/suggestion/dismiss", { suggestionIds: ids });
+
+    expect(response.status).toBe(200);
+    for (const id of ids) {
+      expect(await statusOf(id)).toBe("dismissed");
+    }
+  });
+
+  test("dismisses only the first when the client sends no ids", async () => {
+    const [first, second] = await seedSuggestions(["First Offer", "Second Offer"]);
+
+    await post("/suggestion/dismiss");
+
+    expect(await statusOf(first)).toBe("dismissed");
+    expect(await statusOf(second)).toBe("pending");
+  });
+});

--- a/tests/unit/suggestions.test.ts
+++ b/tests/unit/suggestions.test.ts
@@ -7,9 +7,10 @@ import { normalize } from "../../server/utils";
 import {
   backfillSuggestionReleaseGroups,
   fetchAndStoreSuggestion,
-  findPendingSuggestionForItem,
-  ensureSuggestionForItemNow,
+  findPendingSuggestionsForItem,
+  ensureSuggestionsForItemNow,
   ensureSuggestionsForToListenArtists,
+  SUGGESTION_TARGET,
   __clearSuggestionSweepBackoff,
 } from "../../server/suggestions";
 
@@ -67,6 +68,25 @@ const testSuggestion: musicbrainz.SuggestedRelease = {
   musicbrainzReleaseGroupId: "mb-release-group-uuid",
 };
 
+/** A full set of distinct suggestions, as a healthy lookup returns. */
+const testSuggestionSet: musicbrainz.SuggestedRelease[] = [
+  testSuggestion,
+  {
+    title: "Chiastic Slide",
+    itemType: "album",
+    year: 1997,
+    musicbrainzReleaseId: "mb-release-uuid-2",
+    musicbrainzReleaseGroupId: "mb-release-group-uuid-2",
+  },
+  {
+    title: "Confield",
+    itemType: "album",
+    year: 2001,
+    musicbrainzReleaseId: "mb-release-uuid-3",
+    musicbrainzReleaseGroupId: "mb-release-group-uuid-3",
+  },
+];
+
 describe("fetchAndStoreSuggestion", () => {
   beforeEach(() => {
     __clearSuggestionSweepBackoff();
@@ -77,7 +97,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 
   test("skips when item has no artist_name", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease");
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases");
 
     const outcome = await fetchAndStoreSuggestion({
       id: 1,
@@ -90,8 +110,8 @@ describe("fetchAndStoreSuggestion", () => {
     expect(mbSpy).not.toHaveBeenCalled();
   });
 
-  test("reports no-candidates when findSuggestedRelease returns null, then backs off", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(null);
+  test("reports no-candidates when the lookup finds nothing, then backs off", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([]);
     const { itemId } = await createArtistWithItem("Nothing Found FM", "Static");
 
     const first = await fetchAndStoreSuggestion({
@@ -113,7 +133,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 
   test("reports error without backing off when the lookup throws", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockRejectedValue(
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockRejectedValue(
       new Error("MusicBrainz artist search returned 503"),
     );
     const { itemId } = await createArtistWithItem("Rate Limited Band", "Throttled");
@@ -139,7 +159,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 
   test("stores a pending suggestion for the item's artist", async () => {
-    spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce([testSuggestion]);
     const { itemId } = await createArtistWithItem("Autechre Store Test", "Amber");
 
     const outcome = await fetchAndStoreSuggestion({
@@ -160,8 +180,55 @@ describe("fetchAndStoreSuggestion", () => {
     expect(row?.artistName).toBe("Autechre Store Test");
   });
 
-  test("skips the lookup when the artist already has a pending suggestion", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+  test("asks for and stores a full set, so the prompt can offer a choice", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce(
+      testSuggestionSet,
+    );
+    const { itemId } = await createArtistWithItem("Full Set Band", "First Album");
+
+    const outcome = await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Full Set Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+
+    expect(outcome).toBe("stored");
+    expect(mbSpy.mock.calls[0][0].limit).toBe(SUGGESTION_TARGET);
+    const rows = await db
+      .select()
+      .from(itemSuggestions)
+      .where(eq(itemSuggestions.sourceItemId, itemId));
+    expect(rows.map((row) => row.title)).toEqual(["Tri Repetae", "Chiastic Slide", "Confield"]);
+    expect(rows.every((row) => row.status === "pending")).toBe(true);
+  });
+
+  test("tops the artist up to a full set rather than re-asking for one", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue(
+      testSuggestionSet.slice(1),
+    );
+    const { itemId } = await createArtistWithItem("Top Up Band", "First Album");
+    await seedSuggestion(itemId, "Top Up Band", { releaseId: "already-here" });
+
+    const outcome = await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Top Up Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+
+    expect(outcome).toBe("stored");
+    // One already on file, so only the remaining slots are asked for.
+    expect(mbSpy.mock.calls[0][0].limit).toBe(SUGGESTION_TARGET - 1);
+    const rows = await db
+      .select()
+      .from(itemSuggestions)
+      .where(eq(itemSuggestions.sourceItemId, itemId));
+    expect(rows.length).toBe(SUGGESTION_TARGET);
+  });
+
+  test("skips the lookup when the artist already has a full set of suggestions", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue(testSuggestionSet);
     const { itemId } = await createArtistWithItem("Dedupe Test Band", "First Album");
 
     const first = await fetchAndStoreSuggestion({
@@ -182,11 +249,28 @@ describe("fetchAndStoreSuggestion", () => {
     expect(mbSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("backs off an artist whose lookup could not fill the set", async () => {
+    // Only one suggestible release exists; without a backoff every sweep would
+    // spend a MusicBrainz round trip on the two slots it can never fill.
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
+    const { itemId } = await createArtistWithItem("Short Catalogue Band", "Only Album");
+    const summary = {
+      id: itemId,
+      artist_name: "Short Catalogue Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    };
+
+    expect(await fetchAndStoreSuggestion(summary)).toBe("stored");
+    expect(await fetchAndStoreSuggestion(summary)).toBe("skipped");
+    expect(mbSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("concurrent calls for the same artist share one lookup and store one row", async () => {
     // The background prefetch fired at creation and the on-demand lookup at
     // state-change time can overlap — they must not both insert.
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockImplementation(
-      () => new Promise((resolve) => setTimeout(() => resolve(testSuggestion), 30)),
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([testSuggestion]), 30)),
     );
     const { itemId } = await createArtistWithItem("Concurrent Band", "Race Album");
     const summary = {
@@ -212,7 +296,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 
   test("excludes previously suggested (dismissed) titles from the next lookup", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue(testSuggestionSet);
     const { itemId } = await createArtistWithItem("Dismiss Exclude Band", "Debut");
 
     await fetchAndStoreSuggestion({
@@ -239,7 +323,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 
   test("excludes titles from the whole library, not just the item's artist", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
     await createArtistWithItem("Other Library Artist", "Crosslib Album", "listened");
     const { itemId } = await createArtistWithItem("Library Wide Band", "Own Album");
 
@@ -259,7 +343,7 @@ describe("fetchAndStoreSuggestion", () => {
   test("passes the stored release length preference to the lookup", async () => {
     const { setReleaseLengthPreference } = await import("../../server/settings");
     await setReleaseLengthPreference("shorter");
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
     const { itemId } = await createArtistWithItem("Length Pref Band", "Length Album");
 
     await fetchAndStoreSuggestion({
@@ -274,7 +358,7 @@ describe("fetchAndStoreSuggestion", () => {
   });
 });
 
-describe("findPendingSuggestionForItem", () => {
+describe("findPendingSuggestionsForItem", () => {
   beforeEach(() => {
     __clearSuggestionSweepBackoff();
   });
@@ -284,7 +368,7 @@ describe("findPendingSuggestionForItem", () => {
   });
 
   test("returns the suggestion keyed to the item itself", async () => {
-    spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce([testSuggestion]);
     const { itemId } = await createArtistWithItem("Own Suggestion Band", "Own Album");
     await fetchAndStoreSuggestion({
       id: itemId,
@@ -293,13 +377,13 @@ describe("findPendingSuggestionForItem", () => {
       musicbrainz_artist_id: null,
     });
 
-    const found = await findPendingSuggestionForItem(itemId);
+    const [found] = await findPendingSuggestionsForItem(itemId);
     expect(found?.title).toBe("Tri Repetae");
     expect(found?.sourceItemId).toBe(itemId);
   });
 
   test("falls back to the artist's pending suggestion for a sibling item", async () => {
-    spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce([testSuggestion]);
     const { artistId, itemId } = await createArtistWithItem("Fallback Band", "Album One");
     // A second item by the same artist with no suggestion of its own — e.g.
     // one created before the prefetch existed.
@@ -315,18 +399,54 @@ describe("findPendingSuggestionForItem", () => {
       musicbrainz_artist_id: null,
     });
 
-    const found = await findPendingSuggestionForItem(sibling.id);
+    const [found] = await findPendingSuggestionsForItem(sibling.id);
     expect(found?.title).toBe("Tri Repetae");
   });
 
-  test("returns null when the artist has no pending suggestion", async () => {
+  test("returns nothing when the artist has no pending suggestion", async () => {
     const { itemId } = await createArtistWithItem("No Suggestion Band", "Silent Album");
-    const found = await findPendingSuggestionForItem(itemId);
-    expect(found).toBeNull();
+    const found = await findPendingSuggestionsForItem(itemId);
+    expect(found).toEqual([]);
+  });
+
+  test("returns the artist's whole pending set, own-item suggestions first", async () => {
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce(testSuggestionSet);
+    const { artistId, itemId } = await createArtistWithItem("Whole Set Band", "Album One");
+    const [sibling] = await db
+      .insert(musicItems)
+      .values({ title: "Album Two", normalizedTitle: normalize("Album Two"), artistId })
+      .returning({ id: musicItems.id });
+    // Keyed to the sibling, so it must lead when the sibling is the source.
+    await seedSuggestion(sibling.id, "Whole Set Band", { releaseId: "sibling-release" });
+
+    await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Whole Set Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+
+    const found = await findPendingSuggestionsForItem(sibling.id);
+    expect(found.length).toBe(SUGGESTION_TARGET);
+    expect(found[0].sourceItemId).toBe(sibling.id);
+    expect(found.map((row) => row.title)).toContain("Tri Repetae");
+  });
+
+  test("caps the set at the requested limit", async () => {
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce(testSuggestionSet);
+    const { itemId } = await createArtistWithItem("Capped Band", "Album One");
+    await fetchAndStoreSuggestion({
+      id: itemId,
+      artist_name: "Capped Band",
+      year: null,
+      musicbrainz_artist_id: null,
+    });
+
+    expect((await findPendingSuggestionsForItem(itemId, 2)).length).toBe(2);
   });
 });
 
-describe("ensureSuggestionForItemNow", () => {
+describe("ensureSuggestionsForItemNow", () => {
   beforeEach(() => {
     __clearSuggestionSweepBackoff();
     delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
@@ -337,8 +457,10 @@ describe("ensureSuggestionForItemNow", () => {
     delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
   });
 
-  test("returns the prefetched suggestion without a live lookup", async () => {
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+  test("returns the prefetched suggestions without a live lookup", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce([
+      testSuggestion,
+    ]);
     const { itemId } = await createArtistWithItem("Prefetched Now Band", "Ready Album");
     await fetchAndStoreSuggestion({
       id: itemId,
@@ -348,53 +470,55 @@ describe("ensureSuggestionForItemNow", () => {
     });
     mbSpy.mockClear();
 
-    const found = await ensureSuggestionForItemNow(itemId);
+    const found = await ensureSuggestionsForItemNow(itemId);
 
-    expect(found?.title).toBe("Tri Repetae");
+    expect(found.map((row) => row.title)).toEqual(["Tri Repetae"]);
     expect(mbSpy).not.toHaveBeenCalled();
   });
 
-  test("looks up a suggestion on demand when nothing was prefetched", async () => {
+  test("looks up suggestions on demand when nothing was prefetched", async () => {
     // The exact race the prompt used to lose: item marked listened before the
     // background prefetch stored anything.
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValueOnce(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValueOnce([
+      testSuggestion,
+    ]);
     const { itemId } = await createArtistWithItem("On Demand Band", "Fresh Album");
 
-    const found = await ensureSuggestionForItemNow(itemId);
+    const found = await ensureSuggestionsForItemNow(itemId);
 
     expect(mbSpy).toHaveBeenCalledTimes(1);
-    expect(found?.title).toBe("Tri Repetae");
-    expect(found?.status).toBe("pending");
+    expect(found[0]?.title).toBe("Tri Repetae");
+    expect(found[0]?.status).toBe("pending");
   });
 
-  test("returns null when the lookup exceeds the timeout, but stores in background", async () => {
-    let resolveLookup: (value: musicbrainz.SuggestedRelease) => void;
-    spyOn(musicbrainz, "findSuggestedRelease").mockReturnValueOnce(
+  test("returns nothing when the lookup exceeds the timeout, but stores in background", async () => {
+    let resolveLookup: (value: musicbrainz.SuggestedRelease[]) => void;
+    spyOn(musicbrainz, "findSuggestedReleases").mockReturnValueOnce(
       new Promise((resolve) => {
         resolveLookup = resolve;
       }),
     );
     const { itemId } = await createArtistWithItem("Slow Lookup Band", "Slow Album");
 
-    const found = await ensureSuggestionForItemNow(itemId, 50);
-    expect(found).toBeNull();
+    const found = await ensureSuggestionsForItemNow(itemId, 50);
+    expect(found).toEqual([]);
 
     // The in-flight lookup completes later and stores the suggestion for
     // the next state change.
-    resolveLookup!(testSuggestion);
+    resolveLookup!([testSuggestion]);
     await new Promise((resolve) => setTimeout(resolve, 20));
-    const later = await findPendingSuggestionForItem(itemId);
+    const [later] = await findPendingSuggestionsForItem(itemId);
     expect(later?.title).toBe("Tri Repetae");
   });
 
   test("does not perform a live lookup under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
     process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease");
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases");
     const { itemId } = await createArtistWithItem("Disabled Now Band", "Quiet Album");
 
-    const found = await ensureSuggestionForItemNow(itemId);
+    const found = await ensureSuggestionsForItemNow(itemId);
 
-    expect(found).toBeNull();
+    expect(found).toEqual([]);
     expect(mbSpy).not.toHaveBeenCalled();
   });
 });
@@ -406,7 +530,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
     process.env.OTB_SUGGESTION_SWEEP_THROTTLE_MS = "0";
     // The sweep opens with the release-group backfill; stub it so rows left by
     // other tests can't send these cases to the real MusicBrainz.
-    spyOn(musicbrainz, "fetchReleaseGroupIdForRelease").mockResolvedValue(null);
+    spyOn(musicbrainz, "fetchReleaseGroupIdForRelease").mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -417,7 +541,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("prefetches a suggestion for a to-listen artist with none pending", async () => {
     const uncoveredName = `Sweep Band ${Date.now()}`;
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
     const { itemId } = await createArtistWithItem(uncoveredName, "Sweep Album");
 
     await ensureSuggestionsForToListenArtists();
@@ -434,7 +558,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("skips artists whose items are all listened", async () => {
     const listenedName = `Listened Band ${Date.now()}`;
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(testSuggestion);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
     await createArtistWithItem(listenedName, "Done Album", "listened");
 
     await ensureSuggestionsForToListenArtists();
@@ -445,7 +569,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("backs off artists whose lookup found nothing", async () => {
     const emptyName = `Empty Band ${Date.now()}`;
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(null);
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([]);
     await createArtistWithItem(emptyName, "Only Album");
 
     await ensureSuggestionsForToListenArtists();
@@ -459,7 +583,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("retries artists whose lookup errored", async () => {
     const flakyName = `Flaky Band ${Date.now()}`;
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease").mockRejectedValue(
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockRejectedValue(
       new Error("MusicBrainz artist lookup returned 503"),
     );
     await createArtistWithItem(flakyName, "Retry Album");
@@ -473,7 +597,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("no-ops under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
     process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
-    const mbSpy = spyOn(musicbrainz, "findSuggestedRelease");
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases");
     await createArtistWithItem(`Disabled Band ${Date.now()}`, "Hidden Album");
 
     await ensureSuggestionsForToListenArtists();
@@ -483,7 +607,7 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
   test("backfills release-group ids for suggestions stored without one", async () => {
     const name = `Backfill Sweep Band ${Date.now()}`;
-    spyOn(musicbrainz, "findSuggestedRelease").mockResolvedValue(null);
+    spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([]);
     const groupSpy = spyOn(musicbrainz, "fetchReleaseGroupIdForRelease").mockResolvedValue(
       "swept-rg",
     );


### PR DESCRIPTION
The prompt showed one release, take it or leave it. It now offers up to three — as many as MusicBrainz has for the artist — with the first selected and the others one click away.

## Changes

**Lookup** — `findSuggestedReleases` returns the top `limit` candidates instead of a single pick, skipping repeat pressings of a record it already picked (same release group, or a title close to one already on the list). MusicBrainz lists every edition separately, so without that the three slots would fill with three copies of one album.

**Storage** — the prefetch and the hourly sweep top each artist up to three pending suggestions rather than stopping at one. An artist MusicBrainz can't fill enters the existing 24h backoff, so a short catalogue doesn't cost a lookup on every sweep.

**API** — `PATCH /api/music-items/:id` returns `suggestions`; `suggestion` stays as its first entry for clients built before the choice existed (a bundled native build can lag the server). Accept takes the picked `suggestionId` (falls back to the first when absent), dismiss turns down every id the prompt showed. Releases the user didn't pick stay pending for next time.

**UI** — the modal renders the candidates as a selectable list, artwork per row (extracted into `SuggestionArtwork.svelte`, retaining the release-group-first Cover Art Archive fallback). The dialog gives the list the flexible grid row so all three fit on a phone, and the list scrolls rather than pushing the buttons off a short landscape window.

## Testing

- `bun run test:unit` — 792 pass, including new cases for the multi-result lookup, the top-up/backoff behaviour, and a new `tests/unit/suggestion-route.test.ts` covering accept-by-id and dismiss-all.
- `bunx playwright test playwright/suggestion-on-listened.spec.ts` — 6 pass, including new e2e coverage for picking the third option and for dismissing the whole prompt.
- Full e2e suite: 50 pass, 3 pre-existing `persistent-player.spec.ts` failures that reproduce on the base branch in this environment.
- `bun run typecheck`, `oxlint`, `oxfmt --check` clean.
- Checked the modal at desktop, mobile (390×844) and short-landscape (740×380) viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D35ZSxVsmXUjaqYprpwfwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01D35ZSxVsmXUjaqYprpwfwk)_