### PR TITLE
Skip "you might also like" lookups for compilations

### DIFF
--- a/server/artist-identity.ts
+++ b/server/artist-identity.ts
@@ -28,6 +28,37 @@ export type MbidConfidence = "confirmed" | "probable" | "unresolved";
 /** MusicBrainz's Various Artists placeholder — never a real artist to track. */
 export const VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
+/**
+ * The names a compilation's "artist" goes by. Not a person or a band, so
+ * anything that reasons about an artist's discography — the watch, the
+ * "you might also like" suggestions — has to leave them alone: there is no
+ * such discography to walk.
+ */
+const VARIOUS_ARTISTS_NAMES = new Set([
+  "various",
+  "various artist",
+  "various artists",
+  "va",
+  "v/a",
+  "v.a.",
+  "compilation",
+]);
+
+/**
+ * Is this a compilation placeholder rather than a real artist? Matched on the
+ * MusicBrainz id when we have one, and on the name otherwise — most items get
+ * their artist name from a scrape or the user typing it, long before any MBID
+ * is resolved.
+ */
+export function isVariousArtists(
+  artistName: string | null | undefined,
+  mbid?: string | null,
+): boolean {
+  if (mbid === VARIOUS_ARTISTS_MBID) return true;
+  if (!artistName) return false;
+  return VARIOUS_ARTISTS_NAMES.has(artistName.toLowerCase().trim().replace(/\s+/g, " "));
+}
+
 /** A name-search hit is only accepted at or above this score. */
 const MIN_ACCEPTED_SCORE = 95;
 /** …and only when it beats the runner-up by at least this much. */

--- a/server/suggestions.ts
+++ b/server/suggestions.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, isNotNull, isNull } from "drizzle-orm";
+import { isVariousArtists } from "./artist-identity";
 import { db } from "./db/index";
 import { musicItems, artists, itemSuggestions } from "./db/schema";
 import { fetchReleaseGroupIdForRelease, findSuggestedReleases } from "./musicbrainz";
@@ -98,6 +99,8 @@ export async function findPendingSuggestionsForItem(
   const combined: StoredSuggestion[] = [];
   for (const row of [...own, ...forArtist]) {
     if (seen.has(row.id)) continue;
+    // Rows stored before compilations were excluded from the lookup.
+    if (isVariousArtists(row.artistName)) continue;
     seen.add(row.id);
     combined.push(row);
   }
@@ -114,7 +117,8 @@ export type SuggestionFetchOutcome =
   // The lookup failed (network, rate limit, blocked UA); retried on the
   // next sweep or creation — transient failures must not back off for 24h.
   | "error"
-  // No artist name, or the artist is inside its no-candidates backoff window.
+  // No artist name, a compilation rather than a real artist, or the artist is
+  // inside its no-candidates backoff window.
   | "skipped";
 
 // Artists whose last lookup found nothing suggestible — don't hammer
@@ -138,6 +142,9 @@ const inFlightByArtist = new Map<string, Promise<SuggestionFetchOutcome>>();
 export async function fetchAndStoreSuggestion(item: ItemSummary): Promise<SuggestionFetchOutcome> {
   const artistName = item.artist_name;
   if (!artistName) return "skipped";
+  // "Various Artists" is a placeholder, not an artist: its "discography" is
+  // every compilation ever pressed, so suggesting from it is noise.
+  if (isVariousArtists(artistName, item.musicbrainz_artist_id)) return "skipped";
 
   const artistKey = normalize(artistName);
   const inFlight = inFlightByArtist.get(artistKey);
@@ -281,6 +288,7 @@ export async function ensureSuggestionsForItemNow(
     .where(eq(musicItems.id, itemId))
     .get();
   if (!itemRow?.artistName) return [];
+  if (isVariousArtists(itemRow.artistName, itemRow.mbArtistId)) return [];
 
   console.info("[suggestions] no prefetched suggestion — looking up on demand", {
     itemId,
@@ -409,6 +417,7 @@ export async function ensureSuggestionsForToListenArtists(): Promise<void> {
   // Most recent to-listen item per artist represents that artist in the lookup.
   const perArtist = new Map<string, (typeof candidates)[number]>();
   for (const candidate of candidates) {
+    if (isVariousArtists(candidate.artistName, candidate.mbArtistId)) continue;
     const key = normalize(candidate.artistName);
     if (!perArtist.has(key)) perArtist.set(key, candidate);
   }

--- a/tests/unit/artist-identity.test.ts
+++ b/tests/unit/artist-identity.test.ts
@@ -6,6 +6,7 @@ import { artists, musicItems } from "../../server/db/schema";
 import { normalize } from "../../server/utils";
 import {
   backfillArtistMbidsFromItems,
+  isVariousArtists,
   mbidFromItems,
   pickArtistFromSearch,
   resolveArtistMbid,
@@ -277,5 +278,35 @@ describe("setArtistMbid", () => {
     expect(row?.mbidConfidence).toBe("confirmed");
     expect(row?.pollFailureCount).toBe(0);
     expect(row!.nextPollAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+});
+
+describe("isVariousArtists", () => {
+  test("recognises the names a compilation credit goes by", () => {
+    for (const name of [
+      "Various Artists",
+      "various artists",
+      "  Various   Artists  ",
+      "Various Artist",
+      "Various",
+      "VA",
+      "V/A",
+      "V.A.",
+      "Compilation",
+    ]) {
+      expect(isVariousArtists(name)).toBe(true);
+    }
+  });
+
+  test("recognises the MusicBrainz placeholder whatever the name says", () => {
+    expect(isVariousArtists("Diverse Interpreten", VARIOUS_ARTISTS_MBID)).toBe(true);
+  });
+
+  test("leaves real artists alone", () => {
+    for (const name of ["Autechre", "Various Production", "Va Va Voom", "The Compilations"]) {
+      expect(isVariousArtists(name)).toBe(false);
+    }
+    expect(isVariousArtists(null)).toBe(false);
+    expect(isVariousArtists("Autechre", "some-other-mbid")).toBe(false);
   });
 });

--- a/tests/unit/suggestions.test.ts
+++ b/tests/unit/suggestions.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import * as musicbrainz from "../../server/musicbrainz";
 import { db } from "../../server/db/index";
 import { artists, itemSuggestions, musicItems } from "../../server/db/schema";
+import { VARIOUS_ARTISTS_MBID } from "../../server/artist-identity";
 import { normalize } from "../../server/utils";
 import {
   backfillSuggestionReleaseGroups,
@@ -107,6 +108,33 @@ describe("fetchAndStoreSuggestion", () => {
     });
 
     expect(outcome).toBe("skipped");
+    expect(mbSpy).not.toHaveBeenCalled();
+  });
+
+  test("skips compilations, by name and by MusicBrainz id", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases");
+
+    for (const artistName of ["Various Artists", "various artists", "VA", "V/A", "Various"]) {
+      expect(
+        await fetchAndStoreSuggestion({
+          id: 1,
+          artist_name: artistName,
+          year: null,
+          musicbrainz_artist_id: null,
+        }),
+      ).toBe("skipped");
+    }
+
+    // A compilation credited to something else entirely, caught by its MBID.
+    expect(
+      await fetchAndStoreSuggestion({
+        id: 1,
+        artist_name: "Diverse Interpreten",
+        year: null,
+        musicbrainz_artist_id: VARIOUS_ARTISTS_MBID,
+      }),
+    ).toBe("skipped");
+
     expect(mbSpy).not.toHaveBeenCalled();
   });
 
@@ -511,6 +539,18 @@ describe("ensureSuggestionsForItemNow", () => {
     expect(later?.title).toBe("Tri Repetae");
   });
 
+  test("never looks up or surfaces suggestions for a compilation", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
+    const { itemId } = await createArtistWithItem("Various Artists", "Now That's What I Call 42");
+    // …even if a row was stored back when compilations were looked up.
+    await seedSuggestion(itemId, "Various Artists", { releaseId: "legacy-release" });
+
+    const found = await ensureSuggestionsForItemNow(itemId);
+
+    expect(found).toEqual([]);
+    expect(mbSpy).not.toHaveBeenCalled();
+  });
+
   test("does not perform a live lookup under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {
     process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
     const mbSpy = spyOn(musicbrainz, "findSuggestedReleases");
@@ -593,6 +633,16 @@ describe("ensureSuggestionsForToListenArtists", () => {
 
     const calls = mbSpy.mock.calls.filter((c) => c[0].artistName === flakyName).length;
     expect(calls).toBe(2);
+  });
+
+  test("skips compilations", async () => {
+    const mbSpy = spyOn(musicbrainz, "findSuggestedReleases").mockResolvedValue([testSuggestion]);
+    await createArtistWithItem("Various Artists", `Sweep Compilation ${Date.now()}`);
+
+    await ensureSuggestionsForToListenArtists();
+
+    const call = mbSpy.mock.calls.find((c) => c[0].artistName === "Various Artists");
+    expect(call).toBeUndefined();
   });
 
   test("no-ops under OTB_DISABLE_EXTERNAL_LOOKUPS", async () => {


### PR DESCRIPTION
"Various Artists" is a placeholder credit, not an artist: its "discography" is every compilation ever pressed, so looking up "other releases by this artist" for it produces noise rather than recommendations — and spends MusicBrainz round trips doing it.

## Changes

- New shared `isVariousArtists()` predicate in `server/artist-identity.ts`, next to the existing `VARIOUS_ARTISTS_MBID`. It matches on the MusicBrainz placeholder id when one is resolved, and on the usual names otherwise (`various artists`, `various`, `VA`, `V/A`, `V.A.`, `compilation`) — most items carry a scraped or typed artist name long before an MBID exists.
- `server/suggestions.ts` uses it in four places:
  - `fetchAndStoreSuggestion` returns `"skipped"` for a compilation, so neither the creation-time prefetch nor the on-demand path hits MusicBrainz.
  - `ensureSuggestionsForItemNow` returns nothing for a compilation without attempting a live lookup.
  - The hourly sweep passes over compilations entirely, so they don't consume a throttle slot on every run.
  - `findPendingSuggestionsForItem` filters out compilation-credited rows, so suggestions stored by earlier lookups no longer reach the prompt.

## Tests

Added unit coverage for the predicate (names, MBID, and real artists it must not catch — "Various Production", "Va Va Voom") and for each of the three suggestion paths. Full unit suite passes locally: 798 pass, 0 fail. Lint and format are clean on the touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JY9WGanujhZNPyU5cpUb5e)_