### PR TITLE
Stop the stack bar scrollbar jumping

### DIFF
--- a/src/lib/components/HorizontalScrollbar.svelte
+++ b/src/lib/components/HorizontalScrollbar.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
   /** Retro horizontal scrollbar for the stack bar. */
+  import {
+    clampThumbOffset,
+    maxThumbOffset,
+    measureThumb,
+    thumbOffsetForTrackClick,
+    thumbOffsetToScroll,
+    type ScrollMetrics,
+  } from "../../ui/domain/scrollbar";
+
   let {
     target,
     id,
@@ -15,33 +24,58 @@
   } = $props();
 
   const MIN_THUMB_WIDTH = 42;
+  /** What a click on an arrow button travels — roughly one stack tab. */
+  const STEP = 80;
+  /** Hold-to-scroll waits, like a real scrollbar, before it starts repeating. */
+  const REPEAT_DELAY_MS = 260;
+  /** Held-button scrolling glides at a steady speed instead of lurching. */
+  const REPEAT_SPEED = 700;
 
   let trackEl: HTMLElement | undefined = $state();
   let thumbWidth = $state(0);
   let thumbLeft = $state(0);
   let hasOverflow = $state(false);
 
-  let repeatTimer: ReturnType<typeof setInterval> | null = null;
+  let syncFrame: number | null = null;
   let drag: { startX: number; startLeft: number } | null = null;
 
+  function metrics(): ScrollMetrics | null {
+    if (!target || !trackEl) return null;
+    return {
+      viewport: target.clientWidth,
+      content: target.scrollWidth,
+      offset: target.scrollLeft,
+      track: trackEl.clientWidth,
+      minThumb: MIN_THUMB_WIDTH,
+    };
+  }
+
   function sync(): void {
-    if (!target || !trackEl) return;
-    const scrollRange = target.scrollWidth - target.clientWidth;
-    hasOverflow = scrollRange > 0;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics) return;
 
-    const trackWidth = trackEl.clientWidth;
-    if (!hasOverflow || trackWidth <= 0) {
-      thumbWidth = trackWidth;
-      thumbLeft = 0;
-      return;
+    const thumb = measureThumb(scrollMetrics);
+    hasOverflow = thumb.hasOverflow;
+    thumbWidth = thumb.size;
+    // While dragging, the thumb belongs to the pointer: re-deriving it from
+    // scrollLeft here would fight the drag and jitter the thumb.
+    if (!drag) thumbLeft = thumb.offset;
+  }
+
+  /** Measure once per frame rather than inside every scroll event. */
+  function scheduleSync(): void {
+    if (syncFrame !== null) return;
+    syncFrame = requestAnimationFrame(() => {
+      syncFrame = null;
+      sync();
+    });
+  }
+
+  function cancelScheduledSync(): void {
+    if (syncFrame !== null) {
+      cancelAnimationFrame(syncFrame);
+      syncFrame = null;
     }
-
-    thumbWidth = Math.max(
-      MIN_THUMB_WIDTH,
-      Math.floor((target.clientWidth / target.scrollWidth) * trackWidth),
-    );
-    const maxThumbLeft = Math.max(trackWidth - thumbWidth, 0);
-    thumbLeft = Math.round(maxThumbLeft * (target.scrollLeft / scrollRange));
   }
 
   $effect(() => {
@@ -49,18 +83,27 @@
     if (!target) return;
 
     sync();
-    requestAnimationFrame(sync);
+    scheduleSync();
 
     const el = target;
-    el.addEventListener("scroll", sync);
-    window.addEventListener("resize", sync);
-    const resizeObserver = new ResizeObserver(sync);
+    el.addEventListener("scroll", scheduleSync, { passive: true });
+    window.addEventListener("resize", scheduleSync);
+    const resizeObserver = new ResizeObserver(scheduleSync);
     resizeObserver.observe(el);
+    // The chrome is hidden until the content overflows, so the track measures
+    // zero on the first sync; re-measure as soon as it takes up space.
+    if (trackEl) resizeObserver.observe(trackEl);
+    // Tabs are added, removed and re-wrapped without the bar itself resizing;
+    // without this the thumb keeps a stale width until the next scroll.
+    const contentObserver = new MutationObserver(scheduleSync);
+    contentObserver.observe(el, { childList: true, subtree: true });
 
     return () => {
-      el.removeEventListener("scroll", sync);
-      window.removeEventListener("resize", sync);
+      el.removeEventListener("scroll", scheduleSync);
+      window.removeEventListener("resize", scheduleSync);
       resizeObserver.disconnect();
+      contentObserver.disconnect();
+      cancelScheduledSync();
     };
   });
 
@@ -68,16 +111,39 @@
     target?.scrollBy({ left: delta, behavior: "auto" });
   }
 
-  function startRepeatScroll(delta: number): void {
+  let repeatFrame: number | null = null;
+
+  /** Step once on press, then glide while the button stays held. */
+  function startRepeatScroll(direction: -1 | 1): void {
     stopRepeatScroll();
-    repeatTimer = setInterval(() => scrollByStep(delta), 60);
+    scrollByStep(direction * STEP);
+
+    const pressedAt = performance.now();
+    let previous = pressedAt;
+    const tick = (now: number): void => {
+      if (now - pressedAt >= REPEAT_DELAY_MS) {
+        scrollByStep((direction * REPEAT_SPEED * (now - previous)) / 1000);
+      }
+      previous = now;
+      repeatFrame = requestAnimationFrame(tick);
+    };
+    repeatFrame = requestAnimationFrame(tick);
   }
 
   function stopRepeatScroll(): void {
-    if (repeatTimer) {
-      clearInterval(repeatTimer);
-      repeatTimer = null;
+    if (repeatFrame !== null) {
+      cancelAnimationFrame(repeatFrame);
+      repeatFrame = null;
     }
+  }
+
+  /**
+   * Pointer presses already stepped in `startRepeatScroll`; only synthetic and
+   * keyboard activations (`detail === 0`) still need the click to scroll.
+   */
+  function onButtonClick(event: MouseEvent, direction: -1 | 1): void {
+    if (event.detail !== 0) return;
+    scrollByStep(direction * STEP);
   }
 
   $effect(() => {
@@ -94,67 +160,65 @@
     };
   });
 
+  function beginDrag(event: PointerEvent, capturedBy: HTMLElement, startLeft: number): void {
+    if (event.pointerId !== undefined && typeof capturedBy.setPointerCapture === "function") {
+      capturedBy.setPointerCapture(event.pointerId);
+    }
+    drag = { startX: event.clientX, startLeft };
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
+  }
+
   function onTrackPointerDown(event: PointerEvent): void {
     if (!target || !trackEl) return;
     if ((event.target as HTMLElement).id === thumbId) return;
 
-    const scrollRange = target.scrollWidth - target.clientWidth;
-    if (scrollRange <= 0) return;
-
-    const maxThumbLeft = Math.max(trackEl.clientWidth - thumbWidth, 0);
-    if (maxThumbLeft <= 0) return;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics || maxThumbOffset(scrollMetrics) <= 0) return;
 
     // Jump the thumb so its centre sits under the pointer, then scroll there,
     // rather than paging by a fixed step. This makes a click travel to the
     // clicked region instead of hopping around.
     event.preventDefault();
     const trackRect = trackEl.getBoundingClientRect();
-    const clickOffset = event.clientX - trackRect.left;
-    const nextLeft = Math.max(0, Math.min(maxThumbLeft, clickOffset - thumbWidth / 2));
-    target.scrollLeft = (nextLeft / maxThumbLeft) * scrollRange;
+    const nextLeft = thumbOffsetForTrackClick(event.clientX - trackRect.left, scrollMetrics);
+    thumbLeft = nextLeft;
+    target.scrollLeft = thumbOffsetToScroll(nextLeft, scrollMetrics);
 
     // Hand off to the drag logic so the thumb sticks to the pointer if the
     // user keeps dragging after the initial click.
-    if (event.pointerId !== undefined && typeof trackEl.setPointerCapture === "function") {
-      trackEl.setPointerCapture(event.pointerId);
-    }
-    drag = { startX: event.clientX, startLeft: nextLeft };
-    document.addEventListener("pointermove", onDragMove);
-    document.addEventListener("pointerup", onDragEnd, { once: true });
-    document.addEventListener("pointercancel", onDragEnd, { once: true });
+    beginDrag(event, trackEl, nextLeft);
   }
 
   function onDragMove(event: PointerEvent): void {
-    if (!drag || !target || !trackEl) return;
+    if (!drag || !target) return;
 
-    const scrollRange = target.scrollWidth - target.clientWidth;
-    if (scrollRange <= 0) return;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics || maxThumbOffset(scrollMetrics) <= 0) return;
 
-    const maxThumbLeft = Math.max(trackEl.clientWidth - thumbWidth, 0);
-    if (maxThumbLeft <= 0) return;
-
-    const nextLeft = Math.max(
-      0,
-      Math.min(maxThumbLeft, drag.startLeft + (event.clientX - drag.startX)),
+    const nextLeft = clampThumbOffset(
+      drag.startLeft + (event.clientX - drag.startX),
+      scrollMetrics,
     );
-    target.scrollLeft = (nextLeft / maxThumbLeft) * scrollRange;
+    thumbLeft = nextLeft;
+    target.scrollLeft = thumbOffsetToScroll(nextLeft, scrollMetrics);
   }
 
   function onDragEnd(): void {
     drag = null;
     document.removeEventListener("pointermove", onDragMove);
+    scheduleSync();
   }
 
   function onThumbPointerDown(event: PointerEvent): void {
     event.preventDefault();
-    const thumb = event.currentTarget as HTMLElement;
-    if (event.pointerId !== undefined && typeof thumb.setPointerCapture === "function") {
-      thumb.setPointerCapture(event.pointerId);
-    }
-    drag = { startX: event.clientX, startLeft: thumbLeft };
-    document.addEventListener("pointermove", onDragMove);
-    document.addEventListener("pointerup", onDragEnd, { once: true });
-    document.addEventListener("pointercancel", onDragEnd, { once: true });
+    beginDrag(event, event.currentTarget as HTMLElement, thumbLeft);
+  }
+
+  /** Keep the inline styles short so a fractional thumb doesn't churn the DOM. */
+  function px(value: number): string {
+    return `${Math.round(value * 100) / 100}px`;
   }
 </script>
 
@@ -164,8 +228,8 @@
     class="stack-scrollbar__button"
     data-stack-scroll-btn="left"
     tabindex="-1"
-    onclick={() => scrollByStep(-80)}
-    onpointerdown={() => startRepeatScroll(-80)}
+    onclick={(event) => onButtonClick(event, -1)}
+    onpointerdown={() => startRepeatScroll(-1)}
     onpointerup={stopRepeatScroll}
     onpointerleave={stopRepeatScroll}
     onpointercancel={stopRepeatScroll}
@@ -183,7 +247,7 @@
       id={thumbId}
       class="stack-scrollbar__thumb"
       role="presentation"
-      style="width: {thumbWidth}px; left: {thumbLeft}px"
+      style="width: {px(thumbWidth)}; transform: translateX({px(thumbLeft)})"
       onpointerdown={onThumbPointerDown}
     ></div>
   </div>
@@ -192,8 +256,8 @@
     class="stack-scrollbar__button"
     data-stack-scroll-btn="right"
     tabindex="-1"
-    onclick={() => scrollByStep(80)}
-    onpointerdown={() => startRepeatScroll(80)}
+    onclick={(event) => onButtonClick(event, 1)}
+    onpointerdown={() => startRepeatScroll(1)}
     onpointerup={stopRepeatScroll}
     onpointerleave={stopRepeatScroll}
     onpointercancel={stopRepeatScroll}

--- a/src/lib/components/StackBar.svelte
+++ b/src/lib/components/StackBar.svelte
@@ -1,3 +1,14 @@
+<script lang="ts" module>
+  /**
+   * How far the bar was scrolled, kept outside the component instance.
+   *
+   * Picking a stack is a real navigation between routes, so the bar is torn
+   * down and rebuilt; without this the tabs snap back to the left every time
+   * one is clicked, dragging the tab out from under the pointer.
+   */
+  let lastScrollLeft = 0;
+</script>
+
 <script lang="ts">
   import { tick } from "svelte";
   import type { StackWithCount } from "../../types";
@@ -40,18 +51,28 @@
   // alphabetical order along the top row before wrapping onto the second one.
   // Row-wise flow needs an explicit column count: the first column is pinned to
   // "All" (row 1) and the manage cog (row 2), and the remaining tabs — the
-  // stacks plus the delete tab while it is showing — split across both rows.
-  const flowingTabCount = $derived(visibleStacks.length + (selectedStack ? 1 : 0));
+  // stacks plus the delete tab — split across both rows. The delete tab counts
+  // even while it is hidden: letting the count change when a stack is selected
+  // re-wraps every tab and lurches the bar sideways. Its reserved column is
+  // `max-content`, so it takes no width until the tab actually shows.
+  const flowingTabCount = $derived(visibleStacks.length + 1);
   const columnCount = $derived(1 + Math.ceil(flowingTabCount / 2));
 
-  // Keep the active tab visible when the selection changes.
+  // Keep the active tab visible when the selection changes. Only when it
+  // changes: re-running this on every stack refresh would yank the bar back to
+  // the active tab under a user who had scrolled somewhere else.
+  let revealedStack: number | null | undefined = undefined;
   $effect(() => {
-    void currentStack;
+    const stack = currentStack;
     void visibleStacks;
+    if (stack === revealedStack) return;
     tick().then(() => {
       if (!barEl) return;
       const activeBtn = barEl.querySelector(".stack-tab.active");
+      // The tab for a deep-linked stack only exists once the stacks load; keep
+      // trying until it does, then remember we've revealed this selection.
       if (!(activeBtn instanceof HTMLElement)) return;
+      revealedStack = stack;
       const tabLeft = activeBtn.offsetLeft;
       const tabRight = tabLeft + activeBtn.offsetWidth;
       if (tabLeft < barEl.scrollLeft) {
@@ -61,6 +82,32 @@
       }
     });
   });
+
+  // Put the bar back where it was after the navigation that rebuilt it, once
+  // enough tabs have rendered for the offset to survive being set.
+  let restoredScroll = false;
+  $effect(() => {
+    void visibleStacks;
+    if (restoredScroll || !barEl) return;
+    if (lastScrollLeft === 0 || barEl.scrollWidth <= barEl.clientWidth) return;
+    barEl.scrollLeft = lastScrollLeft;
+    restoredScroll = true;
+  });
+
+  function rememberScroll(): void {
+    if (barEl) lastScrollLeft = barEl.scrollLeft;
+  }
+
+  /**
+   * Take focus by hand so the browser doesn't scroll the pressed tab into
+   * view: clicking a half-visible tab (or the cog, pinned to the far left)
+   * would otherwise yank the whole bar sideways mid-click. Keyboard focus
+   * still scrolls, which is how a tabbing user finds the tab they landed on.
+   */
+  function focusWithoutScrolling(event: MouseEvent): void {
+    event.preventDefault();
+    (event.currentTarget as HTMLElement).focus({ preventScroll: true });
+  }
 </script>
 
 <div class="stack-bar-shell">
@@ -69,16 +116,19 @@
     class="stack-bar"
     style="--stack-bar-columns: {columnCount}"
     bind:this={barEl}
+    onscroll={rememberScroll}
   >
     <button
       class="stack-tab{currentStack === null ? ' active' : ''}"
       data-stack="all"
+      onmousedown={focusWithoutScrolling}
       onclick={onSelectAll}>All</button
     >
     {#each visibleStacks as stack (stack.id)}
       <button
         class="stack-tab{currentStack === stack.id ? ' active' : ''}"
         data-stack-id={stack.id}
+        onmousedown={focusWithoutScrolling}
         onclick={() => onSelectStack(stack.id)}>{stack.name}</button
       >
     {/each}
@@ -86,6 +136,7 @@
       class="stack-tab stack-tab--manage"
       id="manage-stacks-btn"
       title="Manage stacks"
+      onmousedown={focusWithoutScrolling}
       onclick={onToggleManage}
     >
       <svg
@@ -109,6 +160,7 @@
       hidden={!selectedStack}
       disabled={!selectedStack}
       aria-label="Delete selected stack"
+      onmousedown={focusWithoutScrolling}
       onclick={() => {
         if (currentStack !== null) void onDeleteStack(currentStack);
       }}

--- a/src/lib/components/VerticalScrollbar.svelte
+++ b/src/lib/components/VerticalScrollbar.svelte
@@ -4,6 +4,15 @@
    * custom scrollbar behaviour of the pre-SvelteKit app shell: step buttons
    * with press-and-hold repeat, track paging, and a draggable thumb.
    */
+  import {
+    clampThumbOffset,
+    maxThumbOffset,
+    measureThumb,
+    thumbOffsetForTrackClick,
+    thumbOffsetToScroll,
+    type ScrollMetrics,
+  } from "../../ui/domain/scrollbar";
+
   let {
     target,
     id,
@@ -23,33 +32,62 @@
   } = $props();
 
   const MIN_THUMB_HEIGHT = 56;
+  /** One "line" of the list — what a click on an arrow button travels. */
+  const STEP = 40;
+  /** Hold-to-scroll waits, like a real scrollbar, before it starts repeating. */
+  const REPEAT_DELAY_MS = 260;
+  /** Held-button scrolling glides at a steady speed instead of lurching. */
+  const REPEAT_SPEED = 700;
 
   let trackEl: HTMLElement | undefined = $state();
   let thumbHeight = $state(0);
   let thumbTop = $state(0);
   let hasOverflow = $state(false);
 
-  let repeatTimer: ReturnType<typeof setInterval> | null = null;
+  let syncFrame: number | null = null;
   let drag: { startY: number; startTop: number } | null = null;
 
+  function metrics(): ScrollMetrics | null {
+    if (!target || !trackEl) return null;
+    return {
+      viewport: target.clientHeight,
+      content: target.scrollHeight,
+      offset: target.scrollTop,
+      track: trackEl.clientHeight,
+      minThumb: MIN_THUMB_HEIGHT,
+    };
+  }
+
   function sync(): void {
-    if (!target || !trackEl) return;
-    const scrollRange = target.scrollHeight - target.clientHeight;
-    hasOverflow = scrollRange > 0;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics) return;
 
-    const trackHeight = trackEl.clientHeight;
-    if (!hasOverflow || trackHeight <= 0) {
-      thumbHeight = trackHeight;
-      thumbTop = 0;
-      return;
+    const thumb = measureThumb(scrollMetrics);
+    hasOverflow = thumb.hasOverflow;
+    thumbHeight = thumb.size;
+    // While dragging, the thumb belongs to the pointer: re-deriving it from
+    // scrollTop here would fight the drag and jitter the thumb.
+    if (!drag) thumbTop = thumb.offset;
+  }
+
+  /**
+   * Measure once per frame. Reading scrollHeight inside every scroll event
+   * forces a layout of the whole list, which is what makes scrolling a long
+   * playlist stutter.
+   */
+  function scheduleSync(): void {
+    if (syncFrame !== null) return;
+    syncFrame = requestAnimationFrame(() => {
+      syncFrame = null;
+      sync();
+    });
+  }
+
+  function cancelScheduledSync(): void {
+    if (syncFrame !== null) {
+      cancelAnimationFrame(syncFrame);
+      syncFrame = null;
     }
-
-    thumbHeight = Math.max(
-      MIN_THUMB_HEIGHT,
-      Math.floor((target.clientHeight / target.scrollHeight) * trackHeight),
-    );
-    const maxThumbTop = Math.max(trackHeight - thumbHeight, 0);
-    thumbTop = Math.round(maxThumbTop * (target.scrollTop / scrollRange));
   }
 
   $effect(() => {
@@ -57,18 +95,28 @@
     if (!target) return;
 
     sync();
-    requestAnimationFrame(sync);
+    scheduleSync();
 
     const el = target;
-    el.addEventListener("scroll", sync);
-    window.addEventListener("resize", sync);
-    const resizeObserver = new ResizeObserver(sync);
+    el.addEventListener("scroll", scheduleSync, { passive: true });
+    window.addEventListener("resize", scheduleSync);
+    const resizeObserver = new ResizeObserver(scheduleSync);
     resizeObserver.observe(el);
+    // The chrome is hidden until the content overflows, so the track measures
+    // zero on the first sync; re-measure as soon as it takes up space.
+    if (trackEl) resizeObserver.observe(trackEl);
+    // Content can grow or shrink without the container resizing (rows added, a
+    // panel opened). Without this the thumb keeps a stale size until the next
+    // scroll event, which then snaps it into place.
+    const contentObserver = new MutationObserver(scheduleSync);
+    contentObserver.observe(el, { childList: true, subtree: true });
 
     return () => {
-      el.removeEventListener("scroll", sync);
-      window.removeEventListener("resize", sync);
+      el.removeEventListener("scroll", scheduleSync);
+      window.removeEventListener("resize", scheduleSync);
       resizeObserver.disconnect();
+      contentObserver.disconnect();
+      cancelScheduledSync();
     };
   });
 
@@ -76,16 +124,39 @@
     target?.scrollBy({ top: delta, behavior: "auto" });
   }
 
-  function startRepeatScroll(delta: number): void {
+  let repeatFrame: number | null = null;
+
+  /** Step once on press, then glide while the button stays held. */
+  function startRepeatScroll(direction: -1 | 1): void {
     stopRepeatScroll();
-    repeatTimer = setInterval(() => scrollByStep(delta), 60);
+    scrollByStep(direction * STEP);
+
+    const pressedAt = performance.now();
+    let previous = pressedAt;
+    const tick = (now: number): void => {
+      if (now - pressedAt >= REPEAT_DELAY_MS) {
+        scrollByStep((direction * REPEAT_SPEED * (now - previous)) / 1000);
+      }
+      previous = now;
+      repeatFrame = requestAnimationFrame(tick);
+    };
+    repeatFrame = requestAnimationFrame(tick);
   }
 
   function stopRepeatScroll(): void {
-    if (repeatTimer) {
-      clearInterval(repeatTimer);
-      repeatTimer = null;
+    if (repeatFrame !== null) {
+      cancelAnimationFrame(repeatFrame);
+      repeatFrame = null;
     }
+  }
+
+  /**
+   * Pointer presses already stepped in `startRepeatScroll`; only synthetic and
+   * keyboard activations (`detail === 0`) still need the click to scroll.
+   */
+  function onButtonClick(event: MouseEvent, direction: -1 | 1): void {
+    if (event.detail !== 0) return;
+    scrollByStep(direction * STEP);
   }
 
   $effect(() => {
@@ -98,67 +169,65 @@
     };
   });
 
+  function beginDrag(event: PointerEvent, capturedBy: HTMLElement, startTop: number): void {
+    if (event.pointerId !== undefined && typeof capturedBy.setPointerCapture === "function") {
+      capturedBy.setPointerCapture(event.pointerId);
+    }
+    drag = { startY: event.clientY, startTop };
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd, { once: true });
+    document.addEventListener("pointercancel", onDragEnd, { once: true });
+  }
+
   function onTrackPointerDown(event: PointerEvent): void {
     if (!target || !trackEl) return;
     if ((event.target as HTMLElement).id === thumbId) return;
 
-    const scrollRange = target.scrollHeight - target.clientHeight;
-    if (scrollRange <= 0) return;
-
-    const maxThumbTop = Math.max(trackEl.clientHeight - thumbHeight, 0);
-    if (maxThumbTop <= 0) return;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics || maxThumbOffset(scrollMetrics) <= 0) return;
 
     // Jump the thumb so its centre sits under the pointer, then scroll there,
     // rather than paging by a fixed step. This makes a click travel to the
     // clicked region instead of hopping around.
     event.preventDefault();
     const trackRect = trackEl.getBoundingClientRect();
-    const clickOffset = event.clientY - trackRect.top;
-    const nextTop = Math.max(0, Math.min(maxThumbTop, clickOffset - thumbHeight / 2));
-    target.scrollTop = (nextTop / maxThumbTop) * scrollRange;
+    const nextTop = thumbOffsetForTrackClick(event.clientY - trackRect.top, scrollMetrics);
+    thumbTop = nextTop;
+    target.scrollTop = thumbOffsetToScroll(nextTop, scrollMetrics);
 
     // Hand off to the drag logic so the thumb sticks to the pointer if the
     // user keeps dragging after the initial click.
-    if (event.pointerId !== undefined && typeof trackEl.setPointerCapture === "function") {
-      trackEl.setPointerCapture(event.pointerId);
-    }
-    drag = { startY: event.clientY, startTop: nextTop };
-    document.addEventListener("pointermove", onDragMove);
-    document.addEventListener("pointerup", onDragEnd, { once: true });
-    document.addEventListener("pointercancel", onDragEnd, { once: true });
+    beginDrag(event, trackEl, nextTop);
   }
 
   function onDragMove(event: PointerEvent): void {
-    if (!drag || !target || !trackEl) return;
+    if (!drag || !target) return;
 
-    const scrollRange = target.scrollHeight - target.clientHeight;
-    if (scrollRange <= 0) return;
+    const scrollMetrics = metrics();
+    if (!scrollMetrics || maxThumbOffset(scrollMetrics) <= 0) return;
 
-    const maxThumbTop = Math.max(trackEl.clientHeight - thumbHeight, 0);
-    if (maxThumbTop <= 0) return;
-
-    const nextTop = Math.max(
-      0,
-      Math.min(maxThumbTop, drag.startTop + (event.clientY - drag.startY)),
+    const nextTop = clampThumbOffset(
+      drag.startTop + (event.clientY - drag.startY),
+      scrollMetrics,
     );
-    target.scrollTop = (nextTop / maxThumbTop) * scrollRange;
+    thumbTop = nextTop;
+    target.scrollTop = thumbOffsetToScroll(nextTop, scrollMetrics);
   }
 
   function onDragEnd(): void {
     drag = null;
     document.removeEventListener("pointermove", onDragMove);
+    scheduleSync();
   }
 
   function onThumbPointerDown(event: PointerEvent): void {
     event.preventDefault();
-    const thumb = event.currentTarget as HTMLElement;
-    if (event.pointerId !== undefined && typeof thumb.setPointerCapture === "function") {
-      thumb.setPointerCapture(event.pointerId);
-    }
-    drag = { startY: event.clientY, startTop: thumbTop };
-    document.addEventListener("pointermove", onDragMove);
-    document.addEventListener("pointerup", onDragEnd, { once: true });
-    document.addEventListener("pointercancel", onDragEnd, { once: true });
+    beginDrag(event, event.currentTarget as HTMLElement, thumbTop);
+  }
+
+  /** Keep the inline styles short so a fractional thumb doesn't churn the DOM. */
+  function px(value: number): string {
+    return `${Math.round(value * 100) / 100}px`;
   }
 </script>
 
@@ -169,8 +238,8 @@
     {...{ [buttonAttr]: "up" }}
     aria-label="Scroll up"
     tabindex="-1"
-    onclick={() => scrollByStep(-40)}
-    onpointerdown={() => startRepeatScroll(-40)}
+    onclick={(event) => onButtonClick(event, -1)}
+    onpointerdown={() => startRepeatScroll(-1)}
     onpointerup={stopRepeatScroll}
     onpointercancel={stopRepeatScroll}
     onpointerleave={stopRepeatScroll}
@@ -188,7 +257,7 @@
       id={thumbId}
       class="music-scrollbar__thumb"
       role="presentation"
-      style="height: {thumbHeight}px; top: {thumbTop}px"
+      style="height: {px(thumbHeight)}; transform: translateY({px(thumbTop)})"
       onpointerdown={onThumbPointerDown}
     ></div>
   </div>
@@ -198,8 +267,8 @@
     {...{ [buttonAttr]: "down" }}
     aria-label="Scroll down"
     tabindex="-1"
-    onclick={() => scrollByStep(40)}
-    onpointerdown={() => startRepeatScroll(40)}
+    onclick={(event) => onButtonClick(event, 1)}
+    onpointerdown={() => startRepeatScroll(1)}
     onpointerup={stopRepeatScroll}
     onpointercancel={stopRepeatScroll}
     onpointerleave={stopRepeatScroll}

--- a/src/ui/domain/scrollbar.ts
+++ b/src/ui/domain/scrollbar.ts
@@ -1,0 +1,97 @@
+/**
+ * Geometry for the retro custom scrollbars (playlist, link picker, stack bar).
+ *
+ * The maths is axis-agnostic and kept free of the DOM so it can be unit
+ * tested: the components measure the elements and hand the numbers over.
+ *
+ * Everything here is deliberately fractional — rounding the thumb to whole
+ * pixels makes it sit still for several frames and then hop, which is what
+ * reads as a "jumpy" scrollbar on a long list.
+ */
+
+export type ScrollMetrics = {
+  /** Visible length of the scroll container along the axis. */
+  viewport: number;
+  /** Total scrollable length of its content along the axis. */
+  content: number;
+  /** Current scroll offset (scrollTop / scrollLeft). */
+  offset: number;
+  /** Length of the scrollbar track the thumb moves inside. */
+  track: number;
+  /** Smallest thumb the chrome stays grabbable at. */
+  minThumb: number;
+};
+
+export type ThumbGeometry = {
+  /** Thumb length along the axis, in px. */
+  size: number;
+  /** Thumb distance from the start of the track, in px. */
+  offset: number;
+  /** False when the content fits: the scrollbar renders disabled. */
+  hasOverflow: boolean;
+};
+
+/** How far the content can travel; 0 when everything fits. */
+export function scrollRange(metrics: ScrollMetrics): number {
+  return Math.max(metrics.content - metrics.viewport, 0);
+}
+
+/** How far the thumb can travel; 0 when the thumb fills the track. */
+export function maxThumbOffset(metrics: ScrollMetrics): number {
+  return Math.max(metrics.track - thumbSize(metrics), 0);
+}
+
+/**
+ * Thumb length: proportional to how much of the content is visible, floored at
+ * `minThumb` so a long list still leaves something you can grab.
+ */
+export function thumbSize(metrics: ScrollMetrics): number {
+  const { viewport, content, track, minThumb } = metrics;
+  if (track <= 0) return 0;
+  if (content <= 0 || scrollRange(metrics) <= 0) return track;
+  const proportional = (viewport / content) * track;
+  return Math.min(track, Math.max(minThumb, proportional));
+}
+
+/**
+ * The thumb position that matches the container's current scroll offset.
+ *
+ * `hasOverflow` reads the content alone, never the track: the chrome is hidden
+ * while it is false, so a track-dependent answer could never become true.
+ */
+export function measureThumb(metrics: ScrollMetrics): ThumbGeometry {
+  const range = scrollRange(metrics);
+  const size = thumbSize(metrics);
+
+  if (range <= 0) {
+    return { size, offset: 0, hasOverflow: false };
+  }
+
+  const travel = maxThumbOffset(metrics);
+  const progress = clamp(metrics.offset / range, 0, 1);
+  return { size, offset: travel * progress, hasOverflow: true };
+}
+
+/** Inverse of {@link measureThumb}: the scroll offset a thumb position means. */
+export function thumbOffsetToScroll(offset: number, metrics: ScrollMetrics): number {
+  const travel = maxThumbOffset(metrics);
+  if (travel <= 0) return 0;
+  return (clampThumbOffset(offset, metrics) / travel) * scrollRange(metrics);
+}
+
+/** Keep a thumb position inside the track. */
+export function clampThumbOffset(offset: number, metrics: ScrollMetrics): number {
+  return clamp(offset, 0, maxThumbOffset(metrics));
+}
+
+/**
+ * Where the thumb should land when the track is clicked at `pointerOffset`
+ * (measured from the start of the track): centred under the pointer.
+ */
+export function thumbOffsetForTrackClick(pointerOffset: number, metrics: ScrollMetrics): number {
+  return clampThumbOffset(pointerOffset - thumbSize(metrics) / 2, metrics);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/tests/unit/scrollbar.test.ts
+++ b/tests/unit/scrollbar.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clampThumbOffset,
+  maxThumbOffset,
+  measureThumb,
+  scrollRange,
+  thumbOffsetForTrackClick,
+  thumbOffsetToScroll,
+  thumbSize,
+  type ScrollMetrics,
+} from "../../src/ui/domain/scrollbar";
+
+/** A long playlist: 300 cards in a short window, so the thumb hits its floor. */
+const longList: ScrollMetrics = {
+  viewport: 600,
+  content: 27_600,
+  offset: 0,
+  track: 540,
+  minThumb: 56,
+};
+
+/** A short list where the thumb is comfortably bigger than the minimum. */
+const shortList: ScrollMetrics = {
+  viewport: 600,
+  content: 1200,
+  offset: 0,
+  track: 540,
+  minThumb: 56,
+};
+
+describe("thumbSize", () => {
+  test("is proportional to the visible fraction of the content", () => {
+    expect(thumbSize(shortList)).toBe(270);
+  });
+
+  test("never shrinks below the grabbable minimum", () => {
+    expect(thumbSize(longList)).toBe(56);
+  });
+
+  test("fills the track when the content fits", () => {
+    expect(thumbSize({ ...shortList, content: 600 })).toBe(540);
+  });
+
+  test("never overflows the track", () => {
+    expect(thumbSize({ ...longList, track: 40 })).toBe(40);
+  });
+});
+
+describe("measureThumb", () => {
+  test("reports no overflow when everything is visible", () => {
+    expect(measureThumb({ ...shortList, content: 600 })).toEqual({
+      size: 540,
+      offset: 0,
+      hasOverflow: false,
+    });
+  });
+
+  test("puts the thumb at the start of the track at the top of the list", () => {
+    expect(measureThumb(longList).offset).toBe(0);
+  });
+
+  test("puts the thumb at the end of the track at the bottom of the list", () => {
+    const bottom = { ...longList, offset: scrollRange(longList) };
+    expect(measureThumb(bottom).offset).toBeCloseTo(maxThumbOffset(longList), 5);
+  });
+
+  test("tracks scroll position without rounding, so the thumb glides", () => {
+    // One frame of a slow scroll: a whole-pixel thumb would not move at all.
+    const scrolled = measureThumb({ ...longList, offset: 6 });
+    expect(scrolled.offset).toBeGreaterThan(0);
+    expect(scrolled.offset).toBeLessThan(1);
+  });
+
+  test("clamps an overscrolled offset instead of running past the track", () => {
+    const overscrolled = measureThumb({ ...longList, offset: 99_999 });
+    expect(overscrolled.offset).toBe(maxThumbOffset(longList));
+    const rubberBanded = measureThumb({ ...longList, offset: -80 });
+    expect(rubberBanded.offset).toBe(0);
+  });
+});
+
+describe("thumbOffsetToScroll", () => {
+  test("is the inverse of measureThumb", () => {
+    for (const offset of [0, 137, 4021, scrollRange(longList)]) {
+      const thumb = measureThumb({ ...longList, offset });
+      expect(thumbOffsetToScroll(thumb.offset, longList)).toBeCloseTo(offset, 5);
+    }
+  });
+
+  test("stays put when the thumb cannot travel", () => {
+    const fits = { ...shortList, content: 600 };
+    expect(thumbOffsetToScroll(120, fits)).toBe(0);
+  });
+});
+
+describe("clampThumbOffset", () => {
+  test("keeps a dragged thumb inside the track", () => {
+    expect(clampThumbOffset(-40, longList)).toBe(0);
+    expect(clampThumbOffset(10_000, longList)).toBe(484);
+  });
+});
+
+describe("thumbOffsetForTrackClick", () => {
+  test("centres the thumb under the pointer", () => {
+    expect(thumbOffsetForTrackClick(300, longList)).toBe(272);
+  });
+
+  test("clamps at both ends of the track", () => {
+    expect(thumbOffsetForTrackClick(4, longList)).toBe(0);
+    expect(thumbOffsetForTrackClick(538, longList)).toBe(maxThumbOffset(longList));
+  });
+});


### PR DESCRIPTION
Picking a genre tab lurched the whole stack bar sideways, and the thumb hopped a pixel at a time instead of gliding. Reproduced in a browser with 28 tabs; every number below is measured, not estimated.

## What was jumping

**Selecting a tab re-wrapped the bar.** The 🗑 delete tab is `hidden` until a stack is selected, but the two-row grid's column count was derived from the tab count — so selecting anything added a column, re-flowed both rows, grew `scrollWidth` 1105 → 1177, and jumped the thumb from 700px wide at x=124 to 657px at x=117. Its column is now always reserved; being `max-content`, it costs nothing while the tab is hidden.

**Clicking a tab threw the bar back to the left.** Picking a stack navigates `/` → `/s/[id]/[name]`, which rebuilds the bar and dropped its scroll offset (measured 200 → 0) — the tab slides out from under the pointer mid-click. The offset now survives the navigation.

**Every stack refresh yanked the bar back to the active tab.** The reveal effect depended on the derived `visibleStacks` array, so it re-ran on each refresh rather than only when the selection changed.

**Pressing a half-visible tab yanked the bar** via the browser's focus scroll-into-view. Focus is now taken with `preventScroll` on mouse press; keyboard focus still reveals the tab it lands on, which is what a tabbing user needs.

## The thumb itself

The horizontal and vertical scrollbars are the same component written twice, so the shared defects are fixed in both:

- Fractional thumb geometry applied as a `transform`. Whole-pixel `top`/`left` with `Math.round` meant that on a 300-row list scrolling 6px a frame, the thumb sat still for 8 frames and then hopped 1px.
- One measurement per animation frame instead of reading `scrollHeight` inside every scroll event, which forced a layout of the whole list on each one.
- A re-measure on content mutations, so the thumb can't keep a stale size until the next scroll and then snap into place.
- While dragged, the thumb follows the pointer exactly rather than being re-derived from `scrollTop` underneath it.
- Arrow buttons step once per press — the old `click` handler fired an extra step after a press-and-hold — then glide, instead of lurching 40/80px sixteen times a second.

Geometry moves to `src/ui/domain/scrollbar.ts` behind unit tests.

## Testing

- `bun test tests/unit` — 806 pass, including the new `tests/unit/scrollbar.test.ts`
- `bun run typecheck` — 0 errors, 0 warnings
- `bun run lint`, `oxfmt --check` on the changed files — clean
- Visual regression, desktop + mobile — 6 pass, no diffs
- `bunx playwright test playwright --project=chromium` — 50 pass. The 3 failures in `persistent-player.spec.ts` need outbound access to Bandcamp and fail identically on `main` in this sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7MQzq1toY2P8f7aCBs1Ea)_