### PR TITLE
Pin the share sheet's list search field above the rows

### DIFF
--- a/docs/ios-native-app.md
+++ b/docs/ios-native-app.md
@@ -34,12 +34,14 @@ for free by building the same targets with **Mac Catalyst** (see [Enable macOS
   name. On **Add** it `POST`s the URL — plus `notes` and `listName` when set — to
   `POST /api/ingest/link` with a `Bearer` token. The extension talks to the server
   directly, so a share works even when the app isn't running.
-- The list picker has a **search field** above the rows, the native counterpart of the
-  web app's `StackDropdown` (same "Search or add a list…" placeholder). Typing filters
-  your lists case- and accent-insensitively; pressing Return files the item into the
-  typed name — an existing list if one matches, a new one if not — so a big collection
-  doesn't have to be scrolled. When the search matches nothing, the "New list…" row
-  reads `New list “<what you typed>”` and creates it in one tap.
+- The list picker has a **search field pinned above the rows**, the native counterpart
+  of the web app's `StackDropdown` (same "Search or add a list…" placeholder). Typing
+  filters your lists case- and accent-insensitively; pressing Return files the item into
+  the typed name — an existing list if one matches, a new one if not — so a big
+  collection doesn't have to be scrolled. When the search matches nothing, the "New
+  list…" row reads `New list “<what you typed>”` and creates it in one tap. The field sits
+  between the title bar and the rows rather than scrolling with them, so it's reachable
+  from anywhere in a long list.
 - The list picker carries **its own Add button** in the top right, doing exactly what
   the compose form's does. Picking a list is usually the last decision, so this saves
   a trip back to the first screen just to post. Whichever Add you tap, the same note,

--- a/native/ShareExtension/ShareViewController.swift
+++ b/native/ShareExtension/ShareViewController.swift
@@ -1314,10 +1314,10 @@ private extension UITableViewController {
     /// Resize `tableHeaderView` to the height its own Auto Layout asks for.
     ///
     /// Table header views are laid out by frame, not by constraints, so a header
-    /// built with Auto Layout (the list picker's search field, the release
-    /// picker's message banner) keeps whatever height it was given until it's
-    /// measured and re-set. Call from `viewDidLayoutSubviews`; the height check
-    /// stops the re-assignment from looping.
+    /// built with Auto Layout (the release picker's message banner) keeps
+    /// whatever height it was given until it's measured and re-set. Call from
+    /// `viewDidLayoutSubviews`; the height check stops the re-assignment from
+    /// looping.
     func sizeTableHeaderToFit() {
         guard let header = tableView.tableHeaderView else { return }
         let height = header.systemLayoutSizeFitting(
@@ -1340,16 +1340,18 @@ private extension UITableViewController {
 /// reported via `onSelectionChanged` after every change — the server resolves the
 /// names (creating any new), so no id round-trip is needed.
 ///
-/// A **search field** sits above the rows — the native twin of the web app's
+/// A **search field** is pinned above the rows — the native twin of the web app's
 /// `StackDropdown` box, down to the "Search or add a list…" placeholder. Typing
 /// filters the existing lists, and Return files the item into whatever was typed
 /// (matching an existing list by name, or creating one) so a long collection
-/// doesn't have to be scrolled through on a phone-sized sheet.
+/// doesn't have to be scrolled through on a phone-sized sheet. It stays put while
+/// the rows scroll, so it's still there once you're deep in the list.
 ///
 /// There's also an **Add** button in the top right, mirroring the compose form's:
 /// choosing a list is normally the last decision, so the user can post from here
 /// and close the sheet without first navigating back.
-private final class ListPickerViewController: UITableViewController, UITextFieldDelegate {
+private final class ListPickerViewController: UIViewController,
+    UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate {
     var onSelectionChanged: (([String]) -> Void)?
     var onAdd: (() -> Void)?
 
@@ -1363,6 +1365,10 @@ private final class ListPickerViewController: UITableViewController, UITextField
     // Selection order is preserved so the compose row and payload stay stable.
     private var selected: [String]
 
+    /// The rows. Owned rather than inherited from `UITableViewController`,
+    /// whose view *is* its table — there'd be nowhere to hang a field that
+    /// doesn't scroll with the rows.
+    private let tableView = UITableView(frame: .zero, style: .plain)
     private let searchField = UITextField()
     /// The trimmed search text. Empty means "show every list".
     private var query = ""
@@ -1391,7 +1397,7 @@ private final class ListPickerViewController: UITableViewController, UITextField
     init(stacks: [String], selected: [String]) {
         self.names = stacks
         self.selected = selected
-        super.init(style: .plain)
+        super.init(nibName: nil, bundle: nil)
     }
 
     @available(*, unavailable)
@@ -1403,20 +1409,36 @@ private final class ListPickerViewController: UITableViewController, UITextField
         super.viewDidLoad()
         title = "Lists"
         // The Winamp black playlist: black well, light-blue text, navy separators.
+        view.backgroundColor = OTBTheme.playlistBg
         tableView.backgroundColor = OTBTheme.playlistBg
         tableView.separatorColor = OTBTheme.navyBorder
         tableView.tintColor = OTBTheme.accent // checkmark colour
-
-        let searchHeader = makeSearchHeader()
-        searchHeader.frame = CGRect(
-            x: 0,
-            y: 0,
-            width: tableView.bounds.width,
-            height: 1 // resized to its content in viewDidLayoutSubviews
-        )
-        tableView.tableHeaderView = searchHeader
+        tableView.dataSource = self
+        tableView.delegate = self
         // Flicking through the results puts the keyboard away.
         tableView.keyboardDismissMode = .onDrag
+
+        // The search band is a sibling of the table pinned under the title bar,
+        // not the table's own `tableHeaderView`: a header scrolls off with the
+        // rows, so on the collection this screen exists for — dozens of lists —
+        // the field is gone by the time you've scrolled far enough to want it.
+        // Pinned, it's on screen whatever the rows are doing, and its height
+        // comes from Auto Layout rather than from measuring a frame-laid-out
+        // header.
+        let searchBand = makeSearchHeader()
+        searchBand.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(searchBand)
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            searchBand.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            searchBand.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            searchBand.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: searchBand.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardFrameChanged),
@@ -1434,14 +1456,9 @@ private final class ListPickerViewController: UITableViewController, UITextField
         addButton.isEnabled = canAdd
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        sizeTableHeaderToFit()
-    }
-
-    /// The search row: a sunken white field (the app's `--bevel-field` input)
-    /// on a chrome band, so it reads as window furniture above the black
-    /// playlist rather than as another list row.
+    /// The search band: a sunken white field (the app's `--bevel-field` input)
+    /// on a chrome band, so it reads as window furniture below the title bar
+    /// rather than as another list row.
     private func makeSearchHeader() -> UIView {
         let container = UIView()
         container.backgroundColor = OTBTheme.chrome
@@ -1519,6 +1536,7 @@ private final class ListPickerViewController: UITableViewController, UITextField
     func setPosting(_ posting: Bool, progress: String? = nil) {
         isPosting = posting
         tableView.isUserInteractionEnabled = !posting
+        searchField.isEnabled = !posting
         navigationItem.hidesBackButton = posting
         if posting {
             // Get the keyboard out of the way of the spinner and the toast.
@@ -1563,13 +1581,13 @@ private final class ListPickerViewController: UITableViewController, UITextField
     }
 
     // Section 0: existing lists (checkmark = selected). Section 1: "New list…".
-    override func numberOfSections(in tableView: UITableView) -> Int { 2 }
+    func numberOfSections(in tableView: UITableView) -> Int { 2 }
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         section == 0 ? visibleNames.count : 1
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell")
             ?? UITableViewCell(style: .default, reuseIdentifier: "cell")
 
@@ -1599,7 +1617,7 @@ private final class ListPickerViewController: UITableViewController, UITextField
 
     /// Zebra-stripe the existing-list rows, matching the playlist's alternating
     /// row backgrounds (--playlist-bg / --playlist-bg-alt).
-    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         guard indexPath.section == 0 else {
             cell.backgroundColor = OTBTheme.playlistBg
             return
@@ -1607,7 +1625,7 @@ private final class ListPickerViewController: UITableViewController, UITextField
         cell.backgroundColor = indexPath.row.isMultiple(of: 2) ? OTBTheme.playlistBg : OTBTheme.playlistBgAlt
     }
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
         if indexPath.section == 1 {


### PR DESCRIPTION
The share sheet's list picker already has a search field (added in 3a39bcc), but it was the table's `tableHeaderView` — so it scrolls away with the rows. On the collection this screen exists for (dozens of lists) the field is off screen by the time you've scrolled far enough to want it, and if you're looking at the middle of the list there's no sign a search exists at all. Its height also depended on measuring a frame-laid-out header in `viewDidLayoutSubviews` rather than on Auto Layout.

## Changes

- `ListPickerViewController` now owns a `UITableView` instead of subclassing `UITableViewController` (whose view *is* its table, leaving nowhere to hang something that doesn't scroll). The data source and delegate methods are conformances rather than overrides.
- The search band is pinned between the title bar and the rows with constraints — always on screen, height from its own Auto Layout rather than from `sizeTableHeaderToFit()`.
- The search field is disabled along with the rows while a post is in flight; it was still editable behind the spinner.
- Retro styling is unchanged: same sunken white `--bevel-field` well on a chrome band above the black playlist, same "Search or add a list…" placeholder, same filtering and Return-to-file behaviour.
- `sizeTableHeaderToFit()` stays for the release picker's message banner; its doc comment no longer claims the list picker uses it.
- `docs/ios-native-app.md` updated to describe the pinned field.

## Testing

- `bun test tests/unit` — 812 pass, 0 fail
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (3 pre-existing warnings)
- The Swift itself is compiled by the `ios-build` workflow, which this branch touches `native/**` to trigger.

---
_Generated by [Claude Code](https://claude.ai/code/session_012f8f9yTePw9UAvHz5HeMZ7)_