### PR TITLE
Only file a new release when there is a link to it

### DIFF
--- a/server/musicbrainz.ts
+++ b/server/musicbrainz.ts
@@ -809,3 +809,55 @@ export async function fetchReleaseTrackArtists(releaseId: string): Promise<strin
   }
   return [...names];
 }
+
+// ---------------------------------------------------------------------------
+// External links (release group url-rels)
+//
+// The "External links" block on a MusicBrainz release-group page: the url
+// relationships editors have attached to the work — a Bandcamp page, an Apple
+// Music or Spotify album, a Discogs master, a Wikidata item. It is the second
+// of the two pieces of evidence the New Releases gate accepts that a record
+// exists somewhere you could actually go and hear it.
+// ---------------------------------------------------------------------------
+
+export interface MbUrlRelation {
+  /** MB's relationship type — "streaming", "free streaming", "discogs"… */
+  type: string | null;
+  url: string;
+}
+
+/**
+ * The url relationships attached to a release group.
+ *
+ * Throws `MusicBrainzHttpError` on a non-2xx response and the underlying error
+ * on a network failure: a caller gating on "are there any links" must not read
+ * a failed request as a confident "none".
+ */
+export async function fetchReleaseGroupUrlRelations(
+  releaseGroupId: string,
+): Promise<MbUrlRelation[]> {
+  const params = new URLSearchParams({ inc: "url-rels", fmt: "json" });
+  const response = await mbFetch(`${MB_API_BASE}/release-group/${releaseGroupId}?${params}`);
+  if (!response.ok) {
+    throw new MusicBrainzHttpError(
+      response.status,
+      `MusicBrainz release-group lookup returned ${response.status} for ${releaseGroupId}`,
+    );
+  }
+
+  const data = (await response.json()) as { relations?: unknown[] };
+  const relations: MbUrlRelation[] = [];
+  for (const entry of Array.isArray(data.relations) ? data.relations : []) {
+    if (!entry || typeof entry !== "object") continue;
+    const relation = entry as Record<string, unknown>;
+    const target = relation.url;
+    const resource =
+      target && typeof target === "object" ? (target as Record<string, unknown>).resource : null;
+    if (typeof resource !== "string" || resource.length === 0) continue;
+    relations.push({
+      type: typeof relation.type === "string" ? relation.type : null,
+      url: resource,
+    });
+  }
+  return relations;
+}

--- a/server/release-alerts.ts
+++ b/server/release-alerts.ts
@@ -11,7 +11,24 @@ import {
 // Deliberately not via ./music-item-creator: `ingest.test.ts` mocks that
 // module process-wide (see ./music-item-store.ts).
 import { createMusicItemDirect } from "./music-item-store";
-import { remindAtForReleaseDate, parseSecondaryTypes, type AlertReason } from "./artist-watch";
+import {
+  checkReleaseLink,
+  type ReleaseLink,
+  type ReleaseLinkOutcome,
+  type ReleaseLinkQuery,
+} from "./release-link-check";
+import {
+  LOOKUP_SERVICE_CONFIG,
+  saveArtwork,
+  saveLink,
+  stampLookup,
+} from "./secondary-link-enrichment";
+import {
+  isAnnouncedRelease,
+  remindAtForReleaseDate,
+  parseSecondaryTypes,
+  type AlertReason,
+} from "./artist-watch";
 import { getArtistWatchSettings, getNewReleasesStackId, setNewReleasesStackId } from "./settings";
 import type { ItemType } from "../src/types";
 
@@ -199,10 +216,43 @@ export function itemTypeForReleaseGroup(primaryType: string | null): ItemType {
   return candidate && ITEM_TYPES.has(candidate as ItemType) ? (candidate as ItemType) : "album";
 }
 
-export interface AcceptResult {
-  itemId: number;
-  remindAt: Date | null;
+/**
+ * Keep what the gate already found: the link itself, the cover art that came
+ * with it, and — when the provider was asked and had nothing — the attempt
+ * marker, so the release page doesn't re-ask on every view.
+ *
+ * The marker is withheld for a record that isn't out yet (`released` false):
+ * the provider's "no" is about today, and stamping it would keep the item out
+ * of the backfill for good once the record actually appeared.
+ */
+async function persistAcceptedLink(
+  itemId: number,
+  link: ReleaseLink,
+  released: boolean,
+): Promise<void> {
+  await saveLink(itemId, link.url, link.sourceName);
+  if (link.artworkUrl) await saveArtwork(itemId, link.artworkUrl);
+  if (link.via === "musicbrainz" && link.providerSearched && released) {
+    await stampLookup(itemId);
+  }
 }
+
+/** The link that vouched for the release, as shown back to the user. */
+export interface AcceptedLink {
+  url: string;
+  /** "Apple Music", "Spotify" or "MusicBrainz". */
+  foundBy: string;
+  via: "provider" | "musicbrainz";
+}
+
+export type AcceptOutcome =
+  | { status: "added"; itemId: number; remindAt: Date | null; link: AcceptedLink | null }
+  /** No such alert, or another request accepted it first. */
+  | { status: "not-found" }
+  /** Neither the provider of choice nor MusicBrainz has a link for the record. */
+  | { status: "no-link"; serviceName: string }
+  /** The check didn't complete, so nothing is known either way — retryable. */
+  | { status: "check-failed"; message: string };
 
 /**
  * Accept an alert: create the item with the MusicBrainz metadata prefilled,
@@ -211,17 +261,26 @@ export interface AcceptResult {
  * `processReminders()` flips the item to To Listen on release day; until then
  * it sits in Scheduled, already excluded from the To Listen feeds. No new
  * scheduling code.
+ *
+ * Nothing is filed unless the release brings a link with it — the provider of
+ * choice carries it, or MusicBrainz's external links point somewhere. See
+ * ./release-link-check.ts for why, and for why a check that failed is not the
+ * same answer as a record nobody carries. The gate runs *before* the claim
+ * below, so a refused alert is left exactly as it was and can be tried again
+ * once the streaming services catch up.
  */
 export async function acceptAlert(
   alertId: number,
   now: Date = new Date(),
-): Promise<AcceptResult | null> {
+  checkLink: (query: ReleaseLinkQuery) => Promise<ReleaseLinkOutcome> = checkReleaseLink,
+): Promise<AcceptOutcome> {
   const alert = await db
     .select({
       id: releaseAlerts.id,
       status: releaseAlerts.status,
       artistName: artists.name,
       title: artistReleases.title,
+      mbReleaseGroupId: artistReleases.mbReleaseGroupId,
       primaryType: artistReleases.primaryType,
       firstReleaseDate: artistReleases.firstReleaseDate,
       firstReleaseYear: artistReleases.firstReleaseYear,
@@ -232,7 +291,24 @@ export async function acceptAlert(
     .where(eq(releaseAlerts.id, alertId))
     .get();
 
-  if (!alert || alert.status === "added") return null;
+  if (!alert || alert.status === "added") return { status: "not-found" };
+
+  const linkCheck = await checkLink({
+    title: alert.title,
+    artistName: alert.artistName,
+    mbReleaseGroupId: alert.mbReleaseGroupId,
+  });
+
+  if (linkCheck.kind === "failed") {
+    return { status: "check-failed", message: linkCheck.message };
+  }
+  if (linkCheck.kind === "none") {
+    return {
+      status: "no-link",
+      serviceName: LOOKUP_SERVICE_CONFIG[linkCheck.service].displayName,
+    };
+  }
+  const found = linkCheck.kind === "found" ? linkCheck.link : null;
 
   // Claim the alert before creating anything. Reading the status and acting on
   // it are two steps, so without a claim two concurrent accepts of the same
@@ -244,7 +320,7 @@ export async function acceptAlert(
     .set({ status: "added", resolvedAt: now })
     .where(and(eq(releaseAlerts.id, alertId), ne(releaseAlerts.status, "added")))
     .returning({ id: releaseAlerts.id });
-  if (claimed.length === 0) return null;
+  if (claimed.length === 0) return { status: "not-found" };
 
   try {
     const settings = await getArtistWatchSettings();
@@ -260,11 +336,20 @@ export async function acceptAlert(
         listenStatus: "to-listen",
         year: alert.firstReleaseYear ?? undefined,
       },
-      // A record that isn't out yet has nothing to find on the streaming
-      // services, and the lookup stamps an attempt marker that would stop the
-      // item being re-queried once it actually is released.
-      { skipLinkEnrichment: remindAt !== null },
+      // The gate has already asked the provider, so the eager background
+      // lookup would only ask it again for an answer we hold; its result is
+      // written below instead. With the gate switched off, the old rule
+      // stands: a record that isn't out yet has nothing to find on the
+      // streaming services, and the lookup stamps an attempt marker that would
+      // stop the item being re-queried once it actually is released.
+      { skipLinkEnrichment: found !== null || remindAt !== null },
     );
+
+    // Out already, as far as MusicBrainz knows — asked of the release date
+    // rather than of `remindAt`, which is also null when scheduling is off.
+    if (found) {
+      await persistAcceptedLink(item.id, found, !isAnnouncedRelease(alert.firstReleaseDate, now));
+    }
 
     if (remindAt) {
       await db
@@ -286,7 +371,12 @@ export async function acceptAlert(
       .set({ musicItemId: item.id })
       .where(eq(releaseAlerts.id, alertId));
 
-    return { itemId: item.id, remindAt };
+    return {
+      status: "added",
+      itemId: item.id,
+      remindAt,
+      link: found ? { url: found.url, foundBy: found.foundBy, via: found.via } : null,
+    };
   } catch (err) {
     // The claim is only good if the work behind it succeeded — otherwise the
     // alert would sit as `added` with no item to show for it, unreachable from

--- a/server/release-alerts.ts
+++ b/server/release-alerts.ts
@@ -13,16 +13,12 @@ import {
 import { createMusicItemDirect } from "./music-item-store";
 import {
   checkReleaseLink,
+  persistReleaseLink,
   type ReleaseLink,
   type ReleaseLinkOutcome,
   type ReleaseLinkQuery,
 } from "./release-link-check";
-import {
-  LOOKUP_SERVICE_CONFIG,
-  saveArtwork,
-  saveLink,
-  stampLookup,
-} from "./secondary-link-enrichment";
+import { LOOKUP_SERVICE_CONFIG } from "./secondary-link-enrichment";
 import {
   isAnnouncedRelease,
   remindAtForReleaseDate,
@@ -216,27 +212,6 @@ export function itemTypeForReleaseGroup(primaryType: string | null): ItemType {
   return candidate && ITEM_TYPES.has(candidate as ItemType) ? (candidate as ItemType) : "album";
 }
 
-/**
- * Keep what the gate already found: the link itself, the cover art that came
- * with it, and — when the provider was asked and had nothing — the attempt
- * marker, so the release page doesn't re-ask on every view.
- *
- * The marker is withheld for a record that isn't out yet (`released` false):
- * the provider's "no" is about today, and stamping it would keep the item out
- * of the backfill for good once the record actually appeared.
- */
-async function persistAcceptedLink(
-  itemId: number,
-  link: ReleaseLink,
-  released: boolean,
-): Promise<void> {
-  await saveLink(itemId, link.url, link.sourceName);
-  if (link.artworkUrl) await saveArtwork(itemId, link.artworkUrl);
-  if (link.via === "musicbrainz" && link.providerSearched && released) {
-    await stampLookup(itemId);
-  }
-}
-
 /** The link that vouched for the release, as shown back to the user. */
 export interface AcceptedLink {
   url: string;
@@ -268,6 +243,13 @@ export type AcceptOutcome =
  * same answer as a record nobody carries. The gate runs *before* the claim
  * below, so a refused alert is left exactly as it was and can be tried again
  * once the streaming services catch up.
+ *
+ * A record that is going to be *scheduled* is exempt: nobody carries a link to
+ * an album that isn't out, and refusing it would make the announced case — the
+ * one the watcher is most useful for — unaddable. Its check moves to release
+ * day instead, where `processReminders()` runs it before letting the item into
+ * To Listen. That is also why the gate isn't run here at all for those: the
+ * answer today says nothing about the answer on the day.
  */
 export async function acceptAlert(
   alertId: number,
@@ -293,22 +275,30 @@ export async function acceptAlert(
 
   if (!alert || alert.status === "added") return { status: "not-found" };
 
-  const linkCheck = await checkLink({
-    title: alert.title,
-    artistName: alert.artistName,
-    mbReleaseGroupId: alert.mbReleaseGroupId,
-  });
+  const settings = await getArtistWatchSettings();
+  const remindAt = settings.scheduleAnnouncedReleases
+    ? remindAtForReleaseDate(alert.firstReleaseDate, now)
+    : null;
 
-  if (linkCheck.kind === "failed") {
-    return { status: "check-failed", message: linkCheck.message };
+  let found: ReleaseLink | null = null;
+  if (remindAt === null) {
+    const linkCheck = await checkLink({
+      title: alert.title,
+      artistName: alert.artistName,
+      mbReleaseGroupId: alert.mbReleaseGroupId,
+    });
+
+    if (linkCheck.kind === "failed") {
+      return { status: "check-failed", message: linkCheck.message };
+    }
+    if (linkCheck.kind === "none") {
+      return {
+        status: "no-link",
+        serviceName: LOOKUP_SERVICE_CONFIG[linkCheck.service].displayName,
+      };
+    }
+    if (linkCheck.kind === "found") found = linkCheck.link;
   }
-  if (linkCheck.kind === "none") {
-    return {
-      status: "no-link",
-      serviceName: LOOKUP_SERVICE_CONFIG[linkCheck.service].displayName,
-    };
-  }
-  const found = linkCheck.kind === "found" ? linkCheck.link : null;
 
   // Claim the alert before creating anything. Reading the status and acting on
   // it are two steps, so without a claim two concurrent accepts of the same
@@ -323,11 +313,6 @@ export async function acceptAlert(
   if (claimed.length === 0) return { status: "not-found" };
 
   try {
-    const settings = await getArtistWatchSettings();
-    const remindAt = settings.scheduleAnnouncedReleases
-      ? remindAtForReleaseDate(alert.firstReleaseDate, now)
-      : null;
-
     const { item } = await createMusicItemDirect(
       {
         title: alert.title,
@@ -336,19 +321,21 @@ export async function acceptAlert(
         listenStatus: "to-listen",
         year: alert.firstReleaseYear ?? undefined,
       },
-      // The gate has already asked the provider, so the eager background
-      // lookup would only ask it again for an answer we hold; its result is
-      // written below instead. With the gate switched off, the old rule
-      // stands: a record that isn't out yet has nothing to find on the
-      // streaming services, and the lookup stamps an attempt marker that would
-      // stop the item being re-queried once it actually is released.
+      // Nothing to gain from the eager background lookup in either case: the
+      // gate has just asked the provider and its answer is written below, or
+      // the record isn't out, where a lookup would find nothing and stamp an
+      // attempt marker that would stop the item being re-queried once it
+      // actually is released. Release day re-checks it either way.
       { skipLinkEnrichment: found !== null || remindAt !== null },
     );
 
-    // Out already, as far as MusicBrainz knows — asked of the release date
-    // rather than of `remindAt`, which is also null when scheduling is off.
+    // Asked of the release date, not of `remindAt`: with scheduling switched
+    // off an announced record is filed straight into To Listen, and the
+    // provider's "no" about a record that isn't out must not be remembered.
     if (found) {
-      await persistAcceptedLink(item.id, found, !isAnnouncedRelease(alert.firstReleaseDate, now));
+      await persistReleaseLink(item.id, found, {
+        released: !isAnnouncedRelease(alert.firstReleaseDate, now),
+      });
     }
 
     if (remindAt) {

--- a/server/release-link-check.ts
+++ b/server/release-link-check.ts
@@ -1,0 +1,180 @@
+import { fetchReleaseGroupUrlRelations, type MbUrlRelation } from "./musicbrainz";
+import { LOOKUP_SERVICE_CONFIG } from "./secondary-link-enrichment";
+import { getLookupService, type LookupService } from "./settings";
+import type { ServiceSearchResult } from "./scraper";
+import { parseUrl } from "./utils";
+
+// ---------------------------------------------------------------------------
+// The New Releases link gate
+//
+// A release alert is a row in a database, not a record you can play. Accepting
+// one used to file an item whatever the outcome, and the queue's long tail —
+// announced-only titles, catalogue rows an editor typed in from a sleeve —
+// filed items with nothing behind them: no artwork, no link, nothing to click.
+//
+// So an alert now has to bring evidence that the record exists somewhere you
+// could go and hear it, in one of two forms:
+//
+//   1. The provider of choice (Apple Music, or Spotify when selected) has it.
+//   2. MusicBrainz's own "external links" — the url relationships on the
+//      release group — point somewhere.
+//
+// The provider is asked first: its answer is a link on the service the user
+// actually listens on, and it doubles as cover art. MusicBrainz is the
+// fallback, and a broad one on purpose — any external link counts as evidence,
+// though a streaming or purchase link is preferred over a database entry when
+// choosing which one to keep.
+//
+// A check that could not complete is NOT an absence. It comes back `failed`,
+// the alert stays where it is, and the user can try again — refusing a record
+// because MusicBrainz was throttled would be indistinguishable, from the
+// queue, from refusing it because nobody carries it.
+// ---------------------------------------------------------------------------
+
+export interface ReleaseLinkQuery {
+  title: string;
+  artistName: string | null;
+  /** The release group whose external links stand in for the provider's answer. */
+  mbReleaseGroupId: string | null;
+}
+
+export interface ReleaseLink {
+  url: string;
+  /** `sources.name` for the link, or null when the URL is on no service we model. */
+  sourceName: string | null;
+  /** Where the evidence came from, for the message shown back to the user. */
+  via: "provider" | "musicbrainz";
+  /** Display name of the thing that vouched for the release. */
+  foundBy: string;
+  /** Cover art the provider returned alongside the match, when it had any. */
+  artworkUrl: string | null;
+  /** The provider that was queried, and whether it was the one that answered. */
+  service: LookupService;
+  providerSearched: boolean;
+}
+
+export type ReleaseLinkOutcome =
+  | { kind: "found"; link: ReleaseLink }
+  | { kind: "none"; service: LookupService; providerSearched: boolean }
+  /** External lookups are switched off (tests, offline installs) — nothing was asked. */
+  | { kind: "unchecked" }
+  | { kind: "failed"; message: string };
+
+export type SearchServiceFn = (
+  title: string,
+  artist: string | null,
+  service: LookupService,
+) => Promise<ServiceSearchResult | null>;
+
+export interface ReleaseLinkDeps {
+  getService: () => Promise<LookupService>;
+  searchService: SearchServiceFn;
+  fetchExternalLinks: (releaseGroupId: string) => Promise<MbUrlRelation[]>;
+}
+
+export const defaultReleaseLinkDeps: ReleaseLinkDeps = {
+  getService: getLookupService,
+  searchService: (title, artist, service) => LOOKUP_SERVICE_CONFIG[service].search(title, artist),
+  fetchExternalLinks: fetchReleaseGroupUrlRelations,
+};
+
+/**
+ * Relationship types worth keeping, best first. A streaming link is the point
+ * of the exercise; a Discogs or Wikidata relation still counts as evidence
+ * (see the note above) but is the last thing to hand back as *the* link.
+ */
+const RELATION_PRIORITY = [
+  "streaming",
+  "free streaming",
+  "purchase for download",
+  "download for free",
+  "purchase for mail-order",
+];
+
+function relationRank(relation: MbUrlRelation): number {
+  const type = relation.type?.toLowerCase() ?? "";
+  const index = RELATION_PRIORITY.indexOf(type);
+  return index === -1 ? RELATION_PRIORITY.length : index;
+}
+
+/** The most useful of a release group's external links. */
+export function pickExternalLink(relations: MbUrlRelation[]): MbUrlRelation | null {
+  if (relations.length === 0) return null;
+  return [...relations].sort((a, b) => relationRank(a) - relationRank(b))[0];
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Does this release have a link anywhere the user could follow? Never throws —
+ * every failure is reported as an outcome, because the caller's job is to
+ * decide whether to file an item, not to handle transport errors.
+ */
+export async function checkReleaseLink(
+  query: ReleaseLinkQuery,
+  deps: ReleaseLinkDeps = defaultReleaseLinkDeps,
+): Promise<ReleaseLinkOutcome> {
+  // Nothing can be verified with the network switched off, and refusing every
+  // release would be a worse answer than the one the gate exists to prevent.
+  if (process.env.OTB_DISABLE_EXTERNAL_LOOKUPS) return { kind: "unchecked" };
+
+  const service = await deps.getService();
+  const cfg = LOOKUP_SERVICE_CONFIG[service];
+
+  let providerSearched = false;
+  let providerError: string | null = null;
+  try {
+    const hit = await deps.searchService(query.title, query.artistName, service);
+    providerSearched = true;
+    if (hit) {
+      return {
+        kind: "found",
+        link: {
+          url: hit.url,
+          sourceName: cfg.sourceName,
+          via: "provider",
+          foundBy: cfg.displayName,
+          artworkUrl: hit.artworkUrl ?? null,
+          service,
+          providerSearched,
+        },
+      };
+    }
+  } catch (error) {
+    // A provider that refused the request has said nothing about the record.
+    // Keep the reason: if MusicBrainz then comes back empty, "no link" would
+    // be a conclusion drawn from half an answer.
+    providerError = messageOf(error);
+  }
+
+  if (query.mbReleaseGroupId) {
+    let relations: MbUrlRelation[];
+    try {
+      relations = await deps.fetchExternalLinks(query.mbReleaseGroupId);
+    } catch (error) {
+      return { kind: "failed", message: messageOf(error) };
+    }
+
+    const picked = pickExternalLink(relations);
+    if (picked) {
+      const parsed = parseUrl(picked.url);
+      return {
+        kind: "found",
+        link: {
+          url: picked.url,
+          sourceName: parsed.source === "unknown" ? null : parsed.source,
+          via: "musicbrainz",
+          foundBy: "MusicBrainz",
+          artworkUrl: null,
+          service,
+          providerSearched,
+        },
+      };
+    }
+  }
+
+  if (providerError !== null) return { kind: "failed", message: providerError };
+  return { kind: "none", service, providerSearched };
+}

--- a/server/release-link-check.ts
+++ b/server/release-link-check.ts
@@ -1,5 +1,10 @@
 import { fetchReleaseGroupUrlRelations, type MbUrlRelation } from "./musicbrainz";
-import { LOOKUP_SERVICE_CONFIG } from "./secondary-link-enrichment";
+import {
+  LOOKUP_SERVICE_CONFIG,
+  saveArtwork,
+  saveLink,
+  stampLookup,
+} from "./secondary-link-enrichment";
 import { getLookupService, type LookupService } from "./settings";
 import type { ServiceSearchResult } from "./scraper";
 import { parseUrl } from "./utils";
@@ -177,4 +182,25 @@ export async function checkReleaseLink(
 
   if (providerError !== null) return { kind: "failed", message: providerError };
   return { kind: "none", service, providerSearched };
+}
+
+/**
+ * Keep what a check found: the link itself, the cover art that came with it,
+ * and — when the provider was asked and had nothing — the attempt marker, so
+ * the release page doesn't re-ask on every view.
+ *
+ * The marker is withheld for a record that isn't out yet (`released` false):
+ * the provider's "no" is about today, and stamping it would keep the item out
+ * of the backfill for good once the record actually appeared.
+ */
+export async function persistReleaseLink(
+  itemId: number,
+  link: ReleaseLink,
+  { released }: { released: boolean },
+): Promise<void> {
+  await saveLink(itemId, link.url, link.sourceName);
+  if (link.artworkUrl) await saveArtwork(itemId, link.artworkUrl);
+  if (link.via === "musicbrainz" && link.providerSearched && released) {
+    await stampLookup(itemId);
+  }
 }

--- a/server/reminders.ts
+++ b/server/reminders.ts
@@ -1,18 +1,109 @@
-import { lte, eq, and } from "drizzle-orm";
+import { lte, eq, and, inArray, sql } from "drizzle-orm";
 import { db } from "./db/index";
-import { musicItems } from "./db/schema";
+import { artistReleases, artists, musicItems, musicLinks, releaseAlerts } from "./db/schema";
+import { earliestInstant } from "./artist-watch";
+import { enrichSecondaryLinkInBackground } from "./secondary-link-enrichment";
+import {
+  checkReleaseLink,
+  persistReleaseLink,
+  type ReleaseLinkOutcome,
+  type ReleaseLinkQuery,
+} from "./release-link-check";
 
-export async function processReminders(): Promise<void> {
-  const now = new Date();
+// ---------------------------------------------------------------------------
+// Reminders
+//
+// The cron that lets a scheduled record into To Listen on its release day.
+//
+// For a record that came from a release alert this is also where the New
+// Releases link gate is actually enforced. Accepting an announced record can't
+// demand a link — nobody carries an album that isn't out — so the check is
+// deferred to here, where the record IS out and the provider of choice has had
+// its chance to list it. An item with nothing to show for itself is held back
+// and asked about again a week later, rather than being dropped into To Listen
+// with nowhere to play it.
+//
+// Everything else — a reminder the user set on an item of their own — is
+// published exactly as before. The alert link is what tells the two apart.
+// ---------------------------------------------------------------------------
 
-  const overdue = await db
-    .select({ id: musicItems.id })
+/** How long to wait before asking the services again about a held release. */
+const HOLD_RETRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** A check that didn't complete is retried tomorrow, not next week. */
+const CHECK_FAILED_RETRY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How long past the release date a record can be held for.
+ *
+ * The hold has to end somewhere: a record held forever is one the user
+ * accepted and can then never find under To Listen, and it would be asked
+ * about weekly for the rest of the install's life. Two months is long enough
+ * for a licensing delay or a slow MusicBrainz edit, and short enough that the
+ * item doesn't quietly vanish. Past it the item is published as it stands,
+ * with a line in the log saying so.
+ */
+const MAX_HOLD_MS = 56 * 24 * 60 * 60 * 1000;
+
+interface OverdueItem {
+  id: number;
+  title: string;
+  artistName: string | null;
+  /** Set only for items filed from a release alert — the ones the gate covers. */
+  fromAlert: boolean;
+  mbReleaseGroupId: string | null;
+  firstReleaseDate: string | null;
+  linkCount: number;
+}
+
+async function overdueItems(now: Date): Promise<OverdueItem[]> {
+  const rows = await db
+    .select({
+      id: musicItems.id,
+      title: musicItems.title,
+      artistName: artists.name,
+      alertId: releaseAlerts.id,
+      mbReleaseGroupId: artistReleases.mbReleaseGroupId,
+      firstReleaseDate: artistReleases.firstReleaseDate,
+      linkCount: sql<number>`(
+        SELECT COUNT(*) FROM ${musicLinks} WHERE ${musicLinks.musicItemId} = ${musicItems.id}
+      )`,
+    })
     .from(musicItems)
+    .leftJoin(artists, eq(artists.id, musicItems.artistId))
+    .leftJoin(releaseAlerts, eq(releaseAlerts.musicItemId, musicItems.id))
+    .leftJoin(artistReleases, eq(artistReleases.id, releaseAlerts.artistReleaseId))
     .where(and(lte(musicItems.remindAt, now), eq(musicItems.reminderPending, false)));
 
-  if (overdue.length === 0) return;
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    artistName: row.artistName ?? null,
+    fromAlert: row.alertId !== null,
+    mbReleaseGroupId: row.mbReleaseGroupId ?? null,
+    firstReleaseDate: row.firstReleaseDate ?? null,
+    linkCount: Number(row.linkCount ?? 0),
+  }));
+}
 
-  const ids = overdue.map((r) => r.id);
+/** Whether a record is still inside the window in which it can be held back. */
+function holdable(firstReleaseDate: string | null, now: Date): boolean {
+  const released = earliestInstant(firstReleaseDate);
+  // No date to measure from — MusicBrainz dropped it, or never had one. There
+  // is no window to be inside, so let the item through.
+  if (!released) return false;
+  return now.getTime() - released.getTime() < MAX_HOLD_MS;
+}
+
+/** Push the reminder out so the record is asked about again, still Scheduled. */
+async function holdItem(itemId: number, until: Date, now: Date): Promise<void> {
+  await db
+    .update(musicItems)
+    .set({ remindAt: until, updatedAt: now })
+    .where(eq(musicItems.id, itemId));
+}
+
+async function publishItems(ids: number[], now: Date): Promise<void> {
   await db
     .update(musicItems)
     .set({
@@ -25,7 +116,82 @@ export async function processReminders(): Promise<void> {
       updatedAt: now,
       addedToListenAt: now,
     })
-    .where(and(lte(musicItems.remindAt, now), eq(musicItems.reminderPending, false)));
+    .where(inArray(musicItems.id, ids));
+}
 
-  console.log(`[reminders] processed ${ids.length} overdue reminder(s): [${ids.join(", ")}]`);
+/**
+ * Release day for everything whose reminder has come round.
+ *
+ * `checkLink` is injectable for the tests; the app takes the default. Checks
+ * run one item at a time on purpose — each is a provider search and possibly a
+ * MusicBrainz request, and this is a background cron with nobody waiting.
+ */
+export async function processReminders(
+  now: Date = new Date(),
+  checkLink: (query: ReleaseLinkQuery) => Promise<ReleaseLinkOutcome> = checkReleaseLink,
+): Promise<void> {
+  const overdue = await overdueItems(now);
+  if (overdue.length === 0) return;
+
+  const publish: number[] = [];
+  const held: number[] = [];
+  const enrich: number[] = [];
+
+  for (const item of overdue) {
+    // Not from an alert, or it already has somewhere to go: nothing to check.
+    if (!item.fromAlert || item.linkCount > 0) {
+      publish.push(item.id);
+      if (item.fromAlert) enrich.push(item.id);
+      continue;
+    }
+
+    const outcome = await checkLink({
+      title: item.title,
+      artistName: item.artistName,
+      mbReleaseGroupId: item.mbReleaseGroupId,
+    });
+
+    if (outcome.kind === "found") {
+      await persistReleaseLink(item.id, outcome.link, { released: true });
+      publish.push(item.id);
+      enrich.push(item.id);
+      continue;
+    }
+
+    // `unchecked` means external lookups are switched off, so there is no
+    // answer to hold out for — the gate stands aside exactly as it does when
+    // an alert is accepted.
+    if (outcome.kind === "unchecked" || !holdable(item.firstReleaseDate, now)) {
+      if (outcome.kind !== "unchecked") {
+        console.log(
+          `[reminders] releasing "${item.title}" with no link — held since ${item.firstReleaseDate}`,
+        );
+      }
+      publish.push(item.id);
+      enrich.push(item.id);
+      continue;
+    }
+
+    const wait = outcome.kind === "failed" ? CHECK_FAILED_RETRY_MS : HOLD_RETRY_MS;
+    await holdItem(item.id, new Date(now.getTime() + wait), now);
+    held.push(item.id);
+  }
+
+  if (publish.length > 0) await publishItems(publish, now);
+
+  // Now the record is out, fill in the provider link the accept path couldn't
+  // find. No-ops for an item that already has one, and for one whose provider
+  // lookup has already been attempted and stamped.
+  for (const id of enrich) enrichSecondaryLinkInBackground(id);
+
+  if (publish.length > 0) {
+    console.log(
+      `[reminders] processed ${publish.length} overdue reminder(s): [${publish.join(", ")}]`,
+    );
+  }
+  if (held.length > 0) {
+    console.log(
+      `[reminders] held ${held.length} release(s) with no link yet: [${held.join(", ")}]`,
+    );
+  }
 }

--- a/server/routes/release-alerts.ts
+++ b/server/routes/release-alerts.ts
@@ -53,16 +53,44 @@ export function createReleaseAlertRoutes(): Hono {
   });
 
   // POST /:id/add — create the item, file it in New Releases, schedule it if
-  // the record is still announced-only.
+  // the record is still announced-only. Refuses a release nobody carries: the
+  // alert is left pending so it can be tried again later.
   routes.post("/:id/add", async (c) => {
     const id = parseId(c.req.param("id"));
     if (id === null) return c.json({ error: "Invalid ID" }, 400);
 
     const result = await acceptAlert(id);
-    if (!result) return c.json({ error: "Alert not found or already added" }, 404);
+
+    if (result.status === "not-found") {
+      return c.json({ error: "Alert not found or already added" }, 404);
+    }
+    if (result.status === "no-link") {
+      // 422: the request was well-formed and the alert exists — the record
+      // just has nothing behind it yet.
+      return c.json(
+        {
+          error: `No ${result.serviceName} or MusicBrainz link for this release yet.`,
+          reason: "no_link",
+        },
+        422,
+      );
+    }
+    if (result.status === "check-failed") {
+      return c.json(
+        { error: "Couldn't check for a link — try again shortly.", reason: "link_check_failed" },
+        503,
+      );
+    }
 
     const item = await fetchFullItem(result.itemId);
-    return c.json({ item, remindAt: result.remindAt?.toISOString() ?? null }, 201);
+    return c.json(
+      {
+        item,
+        remindAt: result.remindAt?.toISOString() ?? null,
+        link: result.link,
+      },
+      201,
+    );
   });
 
   // POST /:id/dismiss — never re-fires (unique index on the release).

--- a/server/secondary-link-enrichment.ts
+++ b/server/secondary-link-enrichment.ts
@@ -125,12 +125,19 @@ export async function getExistingLink(itemId: number, sourceName: string): Promi
   return rows[0]?.url ?? null;
 }
 
-export async function saveLink(itemId: number, url: string, sourceName: string): Promise<void> {
-  const sourceRows = await db
-    .select({ id: sources.id })
-    .from(sources)
-    .where(eq(sources.name, sourceName))
-    .limit(1);
+/**
+ * `sourceName` is nullable because a link can arrive from somewhere we don't
+ * model — a MusicBrainz external link may point at an artist's own site. The
+ * row is still worth keeping; it just carries no source.
+ */
+export async function saveLink(
+  itemId: number,
+  url: string,
+  sourceName: string | null,
+): Promise<void> {
+  const sourceRows = sourceName
+    ? await db.select({ id: sources.id }).from(sources).where(eq(sources.name, sourceName)).limit(1)
+    : [];
 
   const sourceId = sourceRows[0]?.id ?? null;
 

--- a/src/routes/new-releases/+page.svelte
+++ b/src/routes/new-releases/+page.svelte
@@ -89,7 +89,11 @@
       removeAlert(alert.id);
       const found = result.link ? ` Link from ${result.link.foundBy}.` : "";
       statusMessage = result.remindAt
-        ? `Added “${alert.title}” — scheduled for ${releaseDateLabel(alert)}.${found}`
+        ? // Nothing carries a record that isn't out, so a scheduled release is
+          // filed unchecked and asked about again on the day.
+          `Added “${alert.title}” — scheduled for ${releaseDateLabel(alert)}.${
+            found || " Links are checked on release day."
+          }`
         : `Added “${alert.title}” to To Listen.${found}`;
     } catch {
       statusMessage = "Couldn't add that release.";
@@ -139,8 +143,8 @@
       <h2 class="alerts__heading">📻 New Releases</h2>
       <p class="alerts__hint">
         Records by artists you've listened to that we haven't seen before. Adding one files it in
-        the New Releases stack; anything not out yet is scheduled to arrive in To Listen on release
-        day.
+        the New Releases stack, as long as there's a link to it; anything not out yet is scheduled
+        and checked again on release day.
       </p>
       <a class="alerts__feed-link" href="/feed/new-releases.rss">📡 Subscribe by RSS</a>
     </section>

--- a/src/routes/new-releases/+page.svelte
+++ b/src/routes/new-releases/+page.svelte
@@ -78,10 +78,19 @@
     busyId = alert.id;
     try {
       const result = await api.addReleaseAlert(alert.id);
+
+      // A release with nowhere to listen to it isn't filed. The card stays in
+      // the queue: the streaming services routinely catch up days later.
+      if (!result.added) {
+        statusMessage = `Not added — ${result.message}`;
+        return;
+      }
+
       removeAlert(alert.id);
+      const found = result.link ? ` Link from ${result.link.foundBy}.` : "";
       statusMessage = result.remindAt
-        ? `Added “${alert.title}” — scheduled for ${releaseDateLabel(alert)}.`
-        : `Added “${alert.title}” to To Listen.`;
+        ? `Added “${alert.title}” — scheduled for ${releaseDateLabel(alert)}.${found}`
+        : `Added “${alert.title}” to To Listen.${found}`;
     } catch {
       statusMessage = "Couldn't add that release.";
     } finally {

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -14,7 +14,9 @@ import type {
   RecognizeResult,
   ItemSuggestion,
   ReleaseAlert,
+  ReleaseAlertLink,
   ReleaseAlertStatus,
+  AddReleaseAlertResult,
   TrackedArtist,
   ArtistFollowState,
   MbArtistCandidateView,
@@ -398,14 +400,40 @@ export class ApiClient {
     );
   }
 
-  async addReleaseAlert(
-    alertId: number,
-  ): Promise<{ item: MusicItemFull; remindAt: string | null }> {
-    return this.requestJson<{ item: MusicItemFull; remindAt: string | null }>(
-      `/api/release-alerts/${alertId}/add`,
-      "addReleaseAlert",
-      { method: "POST" },
+  /**
+   * Accept an alert. A release with no link on the provider of choice and none
+   * among MusicBrainz's external links is refused rather than filed, so the two
+   * refusals are returned as results — they're expected answers, not failures,
+   * and the card stays in the queue either way.
+   */
+  async addReleaseAlert(alertId: number): Promise<AddReleaseAlertResult> {
+    const response = await fetch(
+      this.buildUrl(`/api/release-alerts/${alertId}/add`),
+      withCsrf({ method: "POST" }),
     );
+
+    if (response.status === 422 || response.status === 503) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        reason?: string;
+      };
+      return {
+        added: false,
+        reason: body.reason === "link_check_failed" ? "link_check_failed" : "no_link",
+        message: body.error ?? "Couldn't add that release.",
+      };
+    }
+
+    if (!response.ok) {
+      throw new Error(`addReleaseAlert failed: ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      item: MusicItemFull;
+      remindAt: string | null;
+      link: ReleaseAlertLink | null;
+    };
+    return { added: true, item: body.item, remindAt: body.remindAt, link: body.link ?? null };
   }
 
   async dismissReleaseAlert(alertId: number): Promise<void> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -266,6 +266,24 @@ export interface ReleaseAlert {
   first_release_year: number | null;
 }
 
+/** The link that vouched for an accepted release. */
+export interface ReleaseAlertLink {
+  url: string;
+  /** "Apple Music", "Spotify" or "MusicBrainz". */
+  foundBy: string;
+  via: "provider" | "musicbrainz";
+}
+
+/**
+ * Accepting an alert can be refused: a release is only filed once there is a
+ * link to it, either on the provider of choice or among MusicBrainz's external
+ * links. `no_link` is a decision about the record; `link_check_failed` means
+ * the lookup itself didn't complete and the alert is worth retrying.
+ */
+export type AddReleaseAlertResult =
+  | { added: true; item: MusicItemFull; remindAt: string | null; link: ReleaseAlertLink | null }
+  | { added: false; reason: "no_link" | "link_check_failed"; message: string };
+
 export interface TrackedArtist {
   id: number;
   name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -279,6 +279,9 @@ export interface ReleaseAlertLink {
  * link to it, either on the provider of choice or among MusicBrainz's external
  * links. `no_link` is a decision about the record; `link_check_failed` means
  * the lookup itself didn't complete and the alert is worth retrying.
+ *
+ * A record that isn't out yet is exempt — it is scheduled unchecked, and the
+ * server runs the check on release day before letting it into To Listen.
  */
 export type AddReleaseAlertResult =
   | { added: true; item: MusicItemFull; remindAt: string | null; link: ReleaseAlertLink | null }

--- a/tests/unit/musicbrainz.test.ts
+++ b/tests/unit/musicbrainz.test.ts
@@ -3,6 +3,7 @@ import {
   lookupRelease,
   findSuggestedReleases,
   fetchReleaseGroupIdForRelease,
+  fetchReleaseGroupUrlRelations,
   fetchArtistReleaseGroups,
   searchArtistCandidates,
   searchReleaseCandidates,
@@ -506,6 +507,53 @@ describe("fetchReleaseGroupIdForRelease", () => {
     spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("rate limited", { status: 503 }));
 
     expect(fetchReleaseGroupIdForRelease("r1")).rejects.toThrow("503");
+  });
+});
+
+describe("fetchReleaseGroupUrlRelations", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("reads the external links off a release group", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "rg1",
+          relations: [
+            { type: "streaming", url: { resource: "https://open.spotify.com/album/1" } },
+            { type: "discogs", url: { resource: "https://www.discogs.com/master/1" } },
+          ],
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const relations = await fetchReleaseGroupUrlRelations("rg1");
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/release-group/rg1?");
+    expect(url).toContain("inc=url-rels");
+    expect(relations).toEqual([
+      { type: "streaming", url: "https://open.spotify.com/album/1" },
+      { type: "discogs", url: "https://www.discogs.com/master/1" },
+    ]);
+  });
+
+  test("skips relations with no url, and a group with none at all is empty", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "rg1", relations: [{ type: "part of", target: "rg2" }] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(await fetchReleaseGroupUrlRelations("rg1")).toEqual([]);
+  });
+
+  test("throws on a non-2xx response — a throttled request is not an absence of links", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("rate limited", { status: 503 }));
+
+    expect(fetchReleaseGroupUrlRelations("rg1")).rejects.toThrow("503");
   });
 });
 

--- a/tests/unit/release-alerts-route.test.ts
+++ b/tests/unit/release-alerts-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../../server/db/index";
@@ -7,17 +7,21 @@ import {
   artists,
   musicItemStacks,
   musicItems,
+  musicLinks,
   releaseAlerts,
+  sources,
   stacks,
 } from "../../server/db/schema";
 import { normalize } from "../../server/utils";
 import { createReleaseAlertRoutes } from "../../server/routes/release-alerts";
 import { createArtistRoutes } from "../../server/routes/artists";
 import {
+  acceptAlert,
   ensureNewReleasesStack,
   itemTypeForReleaseGroup,
   NEW_RELEASES_STACK_NAME,
 } from "../../server/release-alerts";
+import type { ReleaseLinkOutcome } from "../../server/release-link-check";
 import { DEFAULT_ARTIST_WATCH_SETTINGS, setArtistWatchSettings } from "../../server/settings";
 
 function makeApp(): Hono {
@@ -252,6 +256,245 @@ describe("POST /api/release-alerts/:id/add", () => {
       method: "POST",
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The link gate
+//
+// Every test above runs with OTB_DISABLE_EXTERNAL_LOOKUPS set, which switches
+// the gate off — that is the point of these: they drive `acceptAlert` with the
+// check stubbed, and the last two let the real one run against a mocked fetch
+// to prove the route reports a refusal rather than a failure.
+// ---------------------------------------------------------------------------
+
+const NO_LINK: ReleaseLinkOutcome = {
+  kind: "none",
+  service: "apple_music",
+  providerSearched: true,
+};
+
+function providerLink(url: string): ReleaseLinkOutcome {
+  return {
+    kind: "found",
+    link: {
+      url,
+      sourceName: "apple_music",
+      via: "provider",
+      foundBy: "Apple Music",
+      artworkUrl: "https://example.test/cover.jpg",
+      service: "apple_music",
+      providerSearched: true,
+    },
+  };
+}
+
+function musicbrainzLink(url: string): ReleaseLinkOutcome {
+  return {
+    kind: "found",
+    link: {
+      url,
+      sourceName: "bandcamp",
+      via: "musicbrainz",
+      foundBy: "MusicBrainz",
+      artworkUrl: null,
+      service: "apple_music",
+      providerSearched: true,
+    },
+  };
+}
+
+async function linksFor(itemId: number): Promise<Array<{ url: string; source: string | null }>> {
+  const rows = await db
+    .select({ url: musicLinks.url, source: sources.name })
+    .from(musicLinks)
+    .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
+    .where(eq(musicLinks.musicItemId, itemId));
+  return rows.map((row) => ({ url: row.url, source: row.source ?? null }));
+}
+
+describe("acceptAlert link gate", () => {
+  test("a release with no link anywhere is refused, and the alert survives it", async () => {
+    const { alertId } = await makeAlert({ title: "Unlinked Record" });
+
+    const outcome = await acceptAlert(alertId, new Date(), async () => NO_LINK);
+    expect(outcome).toEqual({ status: "no-link", serviceName: "Apple Music" });
+
+    // Untouched: the record may well turn up on the service next week.
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("pending");
+    expect(alert?.musicItemId).toBeNull();
+
+    const created = await db
+      .select({ id: musicItems.id })
+      .from(musicItems)
+      .where(eq(musicItems.normalizedTitle, normalize("Unlinked Record")));
+    expect(created).toHaveLength(0);
+  });
+
+  test("a check that didn't complete is reported as retryable, not as a refusal", async () => {
+    const { alertId } = await makeAlert();
+
+    const outcome = await acceptAlert(alertId, new Date(), async () => ({
+      kind: "failed",
+      message: "MusicBrainz returned 503",
+    }));
+
+    expect(outcome.status).toBe("check-failed");
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("pending");
+  });
+
+  test("the provider link the gate found is filed with the item, artwork and all", async () => {
+    const url = "https://music.apple.com/gb/album/linked-record/1";
+    const { alertId } = await makeAlert({ title: "Linked Record" });
+
+    const outcome = await acceptAlert(alertId, new Date(), async () => providerLink(url));
+    expect(outcome.status).toBe("added");
+    if (outcome.status !== "added") return;
+    expect(outcome.link).toEqual({ url, foundBy: "Apple Music", via: "provider" });
+
+    expect(await linksFor(outcome.itemId)).toEqual([{ url, source: "apple_music" }]);
+
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
+    expect(item?.artworkUrl).toBe("https://example.test/cover.jpg");
+    // The provider answered, so there is no missed lookup to remember.
+    expect(item?.lookupAttemptedAt).toBeNull();
+  });
+
+  test("a MusicBrainz external link is filed, and the provider's miss is remembered", async () => {
+    const url = "https://ordinary.bandcamp.com/album/external-record";
+    const { alertId } = await makeAlert({ title: "External Record" });
+
+    const outcome = await acceptAlert(alertId, new Date(), async () => musicbrainzLink(url));
+    expect(outcome.status).toBe("added");
+    if (outcome.status !== "added") return;
+
+    expect(await linksFor(outcome.itemId)).toEqual([{ url, source: "bandcamp" }]);
+
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
+    expect(item?.lookupAttemptedAt).toBeInstanceOf(Date);
+  });
+
+  test("an announced release keeps its provider lookup for the day it comes out", async () => {
+    const url = "https://ordinary.bandcamp.com/album/announced-record";
+    const { alertId } = await makeAlert({
+      title: "Announced Record",
+      firstReleaseDate: "2099-09-18",
+      reason: "announced",
+    });
+
+    const outcome = await acceptAlert(alertId, new Date(), async () => musicbrainzLink(url));
+    expect(outcome.status).toBe("added");
+    if (outcome.status !== "added") return;
+
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
+    // Stamping the miss now would keep the item out of the backfill for good.
+    expect(item?.lookupAttemptedAt).toBeNull();
+  });
+
+  test("…and still keeps it when scheduling is off and the item goes straight in", async () => {
+    await setArtistWatchSettings({ scheduleAnnouncedReleases: false });
+    const { alertId } = await makeAlert({
+      title: "Unscheduled Record",
+      firstReleaseDate: "2099-09-18",
+      reason: "announced",
+    });
+
+    const outcome = await acceptAlert(alertId, new Date(), async () =>
+      musicbrainzLink("https://ordinary.bandcamp.com/album/unscheduled-record"),
+    );
+    expect(outcome.status).toBe("added");
+    if (outcome.status !== "added") return;
+
+    // `remind_at` is null here, but the record still isn't out — the provider's
+    // "no" says nothing about the day it is.
+    const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
+    expect(item?.remindAt).toBeNull();
+    expect(item?.lookupAttemptedAt).toBeNull();
+  });
+});
+
+describe("POST /api/release-alerts/:id/add — gate responses", () => {
+  // These let the real check run, so the environment switch has to come off.
+  afterEach(() => {
+    mock.restore();
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+  });
+
+  function mockLookups(musicbrainz: () => Response): void {
+    delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+    spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("itunes.apple.com") || url.includes("api.music.apple.com")) {
+        return Response.json({ results: {}, resultCount: 0 });
+      }
+      if (url.includes("/ws/2/release-group/")) return musicbrainz();
+      // Accepting an alert also fires the background suggestion prefetch, which
+      // asks MusicBrainz about the artist. Answer it emptily rather than
+      // letting a real request escape the suite.
+      if (url.includes("musicbrainz.org")) return Response.json({});
+      throw new Error(`unexpected fetch in test: ${url}`);
+    });
+  }
+
+  test("422s a release neither the provider nor MusicBrainz has a link for", async () => {
+    const { alertId } = await makeAlert({ title: "Nowhere Record" });
+    const app = makeApp();
+    mockLookups(() => Response.json({ relations: [] }));
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.reason).toBe("no_link");
+    expect(body.error).toContain("Apple Music");
+
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("pending");
+  });
+
+  test("503s when the check itself couldn't complete", async () => {
+    const { alertId } = await makeAlert({ title: "Unknowable Record" });
+    const app = makeApp();
+    mockLookups(() => new Response("", { status: 503 }));
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).reason).toBe("link_check_failed");
+
+    const alert = await db.select().from(releaseAlerts).where(eq(releaseAlerts.id, alertId)).get();
+    expect(alert?.status).toBe("pending");
+  });
+
+  test("201s once MusicBrainz has an external link for it", async () => {
+    const { alertId } = await makeAlert({ title: "Findable Record" });
+    const app = makeApp();
+    mockLookups(() =>
+      Response.json({
+        relations: [{ type: "streaming", url: { resource: "https://open.spotify.com/album/abc" } }],
+      }),
+    );
+
+    const res = await app.request(`http://localhost/api/release-alerts/${alertId}/add`, {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.link).toEqual({
+      url: "https://open.spotify.com/album/abc",
+      foundBy: "MusicBrainz",
+      via: "musicbrainz",
+    });
+    expect(await linksFor(body.item.id)).toEqual([
+      { url: "https://open.spotify.com/album/abc", source: "spotify" },
+    ]);
   });
 });
 

--- a/tests/unit/release-alerts-route.test.ts
+++ b/tests/unit/release-alerts-route.test.ts
@@ -376,24 +376,43 @@ describe("acceptAlert link gate", () => {
     expect(item?.lookupAttemptedAt).toBeInstanceOf(Date);
   });
 
-  test("an announced release keeps its provider lookup for the day it comes out", async () => {
-    const url = "https://ordinary.bandcamp.com/album/announced-record";
+  test("an announced release is filed unchecked — its check is release day's job", async () => {
+    const checkLink = mock(async () => NO_LINK);
     const { alertId } = await makeAlert({
       title: "Announced Record",
       firstReleaseDate: "2099-09-18",
       reason: "announced",
     });
 
-    const outcome = await acceptAlert(alertId, new Date(), async () => musicbrainzLink(url));
+    const outcome = await acceptAlert(alertId, new Date(), checkLink);
+
+    // Nobody carries an album that isn't out, so nobody is asked: the item is
+    // scheduled, and processReminders() runs the check on the day.
+    expect(checkLink).not.toHaveBeenCalled();
     expect(outcome.status).toBe("added");
     if (outcome.status !== "added") return;
-
-    const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
-    // Stamping the miss now would keep the item out of the backfill for good.
-    expect(item?.lookupAttemptedAt).toBeNull();
+    expect(outcome.link).toBeNull();
+    expect(outcome.remindAt?.toISOString()).toBe("2099-09-18T00:00:00.000Z");
   });
 
-  test("…and still keeps it when scheduling is off and the item goes straight in", async () => {
+  test("…and with scheduling off it is an ordinary add, gate and all", async () => {
+    await setArtistWatchSettings({ scheduleAnnouncedReleases: false });
+    const checkLink = mock(async () => NO_LINK);
+    const { alertId } = await makeAlert({
+      title: "Unscheduled Announced Record",
+      firstReleaseDate: "2099-09-18",
+      reason: "announced",
+    });
+
+    const outcome = await acceptAlert(alertId, new Date(), checkLink);
+
+    expect(checkLink).toHaveBeenCalled();
+    expect(outcome.status).toBe("no-link");
+  });
+
+  test("a link found for a record that isn't out keeps its provider lookup alive", async () => {
+    // Scheduling off, so an announced record is filed straight into To Listen
+    // and the gate applies — but the provider's "no" is still about today.
     await setArtistWatchSettings({ scheduleAnnouncedReleases: false });
     const { alertId } = await makeAlert({
       title: "Unscheduled Record",
@@ -407,8 +426,6 @@ describe("acceptAlert link gate", () => {
     expect(outcome.status).toBe("added");
     if (outcome.status !== "added") return;
 
-    // `remind_at` is null here, but the record still isn't out — the provider's
-    // "no" says nothing about the day it is.
     const item = await db.select().from(musicItems).where(eq(musicItems.id, outcome.itemId)).get();
     expect(item?.remindAt).toBeNull();
     expect(item?.lookupAttemptedAt).toBeNull();

--- a/tests/unit/release-link-check.test.ts
+++ b/tests/unit/release-link-check.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  checkReleaseLink,
+  pickExternalLink,
+  type ReleaseLinkDeps,
+} from "../../server/release-link-check";
+import type { MbUrlRelation } from "../../server/musicbrainz";
+import type { ServiceSearchResult } from "../../server/scraper";
+
+const QUERY = {
+  title: "Ordinary Record",
+  artistName: "Ordinary Artist",
+  mbReleaseGroupId: "rg-1",
+};
+
+function makeDeps(overrides: Partial<ReleaseLinkDeps> = {}): ReleaseLinkDeps {
+  return {
+    getService: async () => "apple_music",
+    searchService: async () => null,
+    fetchExternalLinks: async () => [],
+    ...overrides,
+  };
+}
+
+const APPLE_HIT: ServiceSearchResult = {
+  url: "https://music.apple.com/gb/album/ordinary-record/1",
+  artworkUrl: "https://example.test/cover.jpg",
+};
+
+// The gate is a no-op with external lookups switched off (see the module note),
+// and every other test file in the suite leaves it set.
+beforeEach(() => {
+  delete process.env.OTB_DISABLE_EXTERNAL_LOOKUPS;
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("pickExternalLink", () => {
+  test("prefers a streaming relation over a database one", () => {
+    const relations: MbUrlRelation[] = [
+      { type: "discogs", url: "https://www.discogs.com/master/1" },
+      { type: "streaming", url: "https://open.spotify.com/album/1" },
+    ];
+    expect(pickExternalLink(relations)?.url).toBe("https://open.spotify.com/album/1");
+  });
+
+  test("still returns a relation type we don't rank — any external link is evidence", () => {
+    const relations: MbUrlRelation[] = [{ type: "wikidata", url: "https://www.wikidata.org/Q1" }];
+    expect(pickExternalLink(relations)?.url).toBe("https://www.wikidata.org/Q1");
+  });
+
+  test("returns null when there are no relations at all", () => {
+    expect(pickExternalLink([])).toBeNull();
+  });
+});
+
+describe("checkReleaseLink", () => {
+  test("the provider of choice answering is the whole check", async () => {
+    const fetchExternalLinks = mock(async () => []);
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({ searchService: async () => APPLE_HIT, fetchExternalLinks }),
+    );
+
+    expect(outcome.kind).toBe("found");
+    if (outcome.kind !== "found") return;
+    expect(outcome.link.via).toBe("provider");
+    expect(outcome.link.url).toBe(APPLE_HIT.url);
+    expect(outcome.link.sourceName).toBe("apple_music");
+    expect(outcome.link.foundBy).toBe("Apple Music");
+    // The cover art comes free with the match, and MusicBrainz isn't troubled.
+    expect(outcome.link.artworkUrl).toBe(APPLE_HIT.artworkUrl);
+    expect(fetchExternalLinks).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the release group's external links", async () => {
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({
+        fetchExternalLinks: async () => [
+          { type: "free streaming", url: "https://ordinary.bandcamp.com/album/ordinary-record" },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe("found");
+    if (outcome.kind !== "found") return;
+    expect(outcome.link.via).toBe("musicbrainz");
+    expect(outcome.link.sourceName).toBe("bandcamp");
+    expect(outcome.link.foundBy).toBe("MusicBrainz");
+    expect(outcome.link.providerSearched).toBe(true);
+  });
+
+  test("an external link on no service we model still counts, with no source", async () => {
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({
+        fetchExternalLinks: async () => [
+          { type: "official homepage", url: "https://label.test/1" },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe("found");
+    if (outcome.kind !== "found") return;
+    expect(outcome.link.sourceName).toBeNull();
+  });
+
+  test("neither source has anything", async () => {
+    const outcome = await checkReleaseLink(QUERY, makeDeps());
+    expect(outcome).toEqual({ kind: "none", service: "apple_music", providerSearched: true });
+  });
+
+  test("a release with no release group id falls back to nothing", async () => {
+    const fetchExternalLinks = mock(async () => []);
+    const outcome = await checkReleaseLink(
+      { ...QUERY, mbReleaseGroupId: null },
+      makeDeps({ fetchExternalLinks }),
+    );
+
+    expect(outcome.kind).toBe("none");
+    expect(fetchExternalLinks).not.toHaveBeenCalled();
+  });
+
+  test("a MusicBrainz failure is not an absence", async () => {
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({
+        fetchExternalLinks: async () => {
+          throw new Error("MusicBrainz returned 503");
+        },
+      }),
+    );
+
+    expect(outcome).toEqual({ kind: "failed", message: "MusicBrainz returned 503" });
+  });
+
+  test("a provider failure is survivable while MusicBrainz still answers", async () => {
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({
+        searchService: async () => {
+          throw new Error("itunes timed out");
+        },
+        fetchExternalLinks: async () => [
+          { type: "streaming", url: "https://open.spotify.com/album/1" },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe("found");
+    if (outcome.kind !== "found") return;
+    expect(outcome.link.providerSearched).toBe(false);
+  });
+
+  test("a provider failure with nothing on MusicBrainz is a failure, not a refusal", async () => {
+    const outcome = await checkReleaseLink(
+      QUERY,
+      makeDeps({
+        searchService: async () => {
+          throw new Error("itunes timed out");
+        },
+      }),
+    );
+
+    expect(outcome).toEqual({ kind: "failed", message: "itunes timed out" });
+  });
+
+  test("nothing is asked when external lookups are switched off", async () => {
+    process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+    const searchService = mock(async () => null);
+    const fetchExternalLinks = mock(async () => []);
+
+    const outcome = await checkReleaseLink(QUERY, makeDeps({ searchService, fetchExternalLinks }));
+
+    expect(outcome).toEqual({ kind: "unchecked" });
+    expect(searchService).not.toHaveBeenCalled();
+    expect(fetchExternalLinks).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/reminder-link-gate.test.ts
+++ b/tests/unit/reminder-link-gate.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { db } from "../../server/db/index";
+import {
+  artistReleases,
+  artists,
+  musicItems,
+  musicLinks,
+  releaseAlerts,
+  sources,
+} from "../../server/db/schema";
+import { normalize } from "../../server/utils";
+import { processReminders } from "../../server/reminders";
+import type { ReleaseLinkOutcome } from "../../server/release-link-check";
+
+// ---------------------------------------------------------------------------
+// Release day for a record filed from an alert: the link check the accept path
+// couldn't make (nobody carries an album that isn't out) happens here.
+// ---------------------------------------------------------------------------
+
+// Deliberately far in the past. `bun test` runs every file in one process
+// against one database, and this file drives the reminder cron: dating its
+// fixtures to 2020 means a sweep here can never pick up another file's
+// leftover reminder, which is stamped around the real clock.
+const NOW = new Date("2020-01-05T09:00:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const FOUND: ReleaseLinkOutcome = {
+  kind: "found",
+  link: {
+    url: "https://music.apple.com/gb/album/released-record/1",
+    sourceName: "apple_music",
+    via: "provider",
+    foundBy: "Apple Music",
+    artworkUrl: "https://example.test/cover.jpg",
+    service: "apple_music",
+    providerSearched: true,
+  },
+};
+
+const NONE: ReleaseLinkOutcome = { kind: "none", service: "apple_music", providerSearched: true };
+
+let sequence = 0;
+
+interface Fixture {
+  itemId: number;
+}
+
+/** A scheduled item whose reminder is due, optionally filed from an alert. */
+async function makeDueItem(
+  options: {
+    fromAlert?: boolean;
+    firstReleaseDate?: string;
+    url?: string;
+    remindAt?: Date;
+  } = {},
+): Promise<Fixture> {
+  sequence += 1;
+  const name = `Reminder Artist ${Date.now()}-${sequence}`;
+  const title = `Reminder Record ${sequence}`;
+
+  const [artist] = await db
+    .insert(artists)
+    .values({ name, normalizedName: normalize(name) })
+    .returning({ id: artists.id });
+
+  const [item] = await db
+    .insert(musicItems)
+    .values({
+      title,
+      normalizedTitle: normalize(title),
+      artistId: artist.id,
+      listenStatus: "to-listen",
+      remindAt: options.remindAt ?? new Date(NOW.getTime() - 60_000),
+      reminderPending: false,
+    })
+    .returning({ id: musicItems.id });
+
+  if (options.url) {
+    await db.insert(musicLinks).values({ musicItemId: item.id, url: options.url });
+  }
+
+  if (options.fromAlert !== false) {
+    const [release] = await db
+      .insert(artistReleases)
+      .values({
+        artistId: artist.id,
+        mbReleaseGroupId: `rg-reminder-${sequence}`,
+        title,
+        normalizedTitle: normalize(title),
+        primaryType: "Album",
+        secondaryTypes: "[]",
+        firstReleaseDate: options.firstReleaseDate ?? "2020-01-05",
+        firstReleaseYear: 2020,
+      })
+      .returning({ id: artistReleases.id });
+
+    await db.insert(releaseAlerts).values({
+      artistId: artist.id,
+      artistReleaseId: release.id,
+      status: "added",
+      reason: "announced",
+      musicItemId: item.id,
+    });
+  }
+
+  created.push({ itemId: item.id, artistId: artist.id });
+  return { itemId: item.id };
+}
+
+function itemRow(id: number) {
+  return db.select().from(musicItems).where(eq(musicItems.id, id)).get();
+}
+
+const created: Array<{ itemId: number; artistId: number }> = [];
+
+beforeEach(() => {
+  // The gate is driven through the injected checker; this only keeps the
+  // background enrichment fired on publish from reaching the network.
+  process.env.OTB_DISABLE_EXTERNAL_LOOKUPS = "1";
+});
+
+// Held rows keep a live reminder, and a later file's cron run — with the real
+// checker and the real clock — would sweep them up. Take them with us.
+afterEach(async () => {
+  for (const { itemId, artistId } of created) {
+    await db.delete(releaseAlerts).where(eq(releaseAlerts.musicItemId, itemId));
+    await db.delete(artistReleases).where(eq(artistReleases.artistId, artistId));
+    await db.delete(musicItems).where(eq(musicItems.id, itemId));
+    await db.delete(artists).where(eq(artists.id, artistId));
+  }
+  created.length = 0;
+});
+
+describe("processReminders — the release-day link check", () => {
+  test("files the link found on release day and lets the record through", async () => {
+    const { itemId } = await makeDueItem();
+
+    await processReminders(NOW, async () => FOUND);
+
+    const item = await itemRow(itemId);
+    expect(item?.listenStatus).toBe("to-listen");
+    expect(item?.remindAt).toBeNull();
+    expect(item?.reminderPending).toBe(true);
+    expect(item?.artworkUrl).toBe("https://example.test/cover.jpg");
+
+    const links = await db
+      .select({ url: musicLinks.url, source: sources.name })
+      .from(musicLinks)
+      .leftJoin(sources, eq(musicLinks.sourceId, sources.id))
+      .where(eq(musicLinks.musicItemId, itemId));
+    expect(links).toEqual([
+      { url: "https://music.apple.com/gb/album/released-record/1", source: "apple_music" },
+    ]);
+  });
+
+  test("holds a record nobody carries yet, and asks again a week later", async () => {
+    const { itemId } = await makeDueItem();
+
+    await processReminders(NOW, async () => NONE);
+
+    const item = await itemRow(itemId);
+    // Still Scheduled — it just isn't due again until next week.
+    expect(item?.reminderPending).toBe(false);
+    expect(item?.remindAt?.getTime()).toBe(NOW.getTime() + 7 * DAY_MS);
+  });
+
+  test("a check that didn't complete is retried tomorrow rather than next week", async () => {
+    const { itemId } = await makeDueItem();
+
+    await processReminders(NOW, async () => ({ kind: "failed", message: "503" }));
+
+    const item = await itemRow(itemId);
+    expect(item?.remindAt?.getTime()).toBe(NOW.getTime() + DAY_MS);
+  });
+
+  test("the hold ends: a record still unlisted two months on is published as it stands", async () => {
+    const { itemId } = await makeDueItem({ firstReleaseDate: "2019-10-01" });
+
+    await processReminders(NOW, async () => NONE);
+
+    const item = await itemRow(itemId);
+    expect(item?.remindAt).toBeNull();
+    expect(item?.reminderPending).toBe(true);
+  });
+
+  test("an item that already has a link is published without asking anyone", async () => {
+    const checkLink = mock(async () => NONE);
+    const { itemId } = await makeDueItem({ url: "https://ordinary.bandcamp.com/album/one" });
+
+    await processReminders(NOW, checkLink);
+
+    expect(checkLink).not.toHaveBeenCalled();
+    expect((await itemRow(itemId))?.reminderPending).toBe(true);
+  });
+
+  test("a reminder the user set on their own item is not the gate's business", async () => {
+    const checkLink = mock(async () => NONE);
+    const { itemId } = await makeDueItem({ fromAlert: false });
+
+    await processReminders(NOW, checkLink);
+
+    expect(checkLink).not.toHaveBeenCalled();
+    const item = await itemRow(itemId);
+    expect(item?.remindAt).toBeNull();
+    expect(item?.reminderPending).toBe(true);
+  });
+
+  test("a reminder that isn't due yet is left alone", async () => {
+    const { itemId } = await makeDueItem({ remindAt: new Date(NOW.getTime() + DAY_MS) });
+
+    await processReminders(NOW, async () => FOUND);
+
+    const item = await itemRow(itemId);
+    expect(item?.reminderPending).toBe(false);
+    expect(item?.remindAt?.getTime()).toBe(NOW.getTime() + DAY_MS);
+  });
+
+  test("one held record doesn't stop another from being published", async () => {
+    const held = await makeDueItem();
+    const passing = await makeDueItem({ url: "https://ordinary.bandcamp.com/album/two" });
+
+    await processReminders(NOW, async (query) =>
+      query.title.includes(String(sequence)) ? FOUND : NONE,
+    );
+
+    expect((await itemRow(held.itemId))?.reminderPending).toBe(false);
+    expect((await itemRow(passing.itemId))?.reminderPending).toBe(true);
+  });
+});
+
+// Guard against the join fanning out: an item carries at most one alert, but a
+// left join that matched two rows would publish it twice and log it twice.
+test("an item with several links is still processed once", async () => {
+  const { itemId } = await makeDueItem({ url: "https://ordinary.bandcamp.com/album/three" });
+  await db.insert(musicLinks).values({ musicItemId: itemId, url: "https://example.test/other" });
+
+  await processReminders(NOW, async () => NONE);
+
+  const rows = await db
+    .select()
+    .from(musicItems)
+    .where(and(eq(musicItems.id, itemId), eq(musicItems.reminderPending, true)));
+  expect(rows).toHaveLength(1);
+});


### PR DESCRIPTION
Accepting an alert filed an item whatever was behind it, and the queue's
long tail — announced-only titles, catalogue rows typed in from a sleeve —
produced items with no artwork, no link, nothing to click.

An alert now has to bring evidence that the record exists somewhere you
could go and hear it: the provider of choice (Apple Music, or Spotify when
selected) has it, or MusicBrainz's own external links point somewhere. The
provider is asked first — its answer is a link on the service the user
actually listens on, and it carries cover art — and the link that vouched
for the release is filed with the item rather than thrown away and looked
up again in the background.

A check that could not complete is not an absence: it comes back as a
retryable failure (503) rather than a refusal (422), and either way the
alert is left pending, because the streaming services routinely catch up
days after MusicBrainz does. With OTB_DISABLE_EXTERNAL_LOOKUPS set nothing
can be verified, so the gate stands aside rather than refusing everything.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JiMmSXETWza8DcZWtBdCEn