### PR TITLE
Support Discogs /shop/item marketplace URLs and normalize to /sell/item

### DIFF
--- a/server/discogs.ts
+++ b/server/discogs.ts
@@ -158,7 +158,8 @@ function parseItemType(formats: unknown): ItemType {
 function extractDiscogsTypeAndId(
   url: string,
 ): { type: "release" | "master" | "listing"; id: string } | null {
-  const listingMatch = url.match(/discogs\.com\/sell\/item\/(\d+)/);
+  // /sell/item/<id> is the legacy spelling of /shop/item/<id>; same listing id.
+  const listingMatch = url.match(/discogs\.com\/(?:sell|shop)\/item\/(\d+)/);
   if (listingMatch) return { type: "listing", id: listingMatch[1] };
   const match = url.match(/discogs\.com\/(release|master)\/(\d+)/);
   if (!match) return null;

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -54,8 +54,16 @@ const URL_PATTERNS: Array<{
     },
   },
   {
+    // Discogs renamed marketplace listing pages from /sell/item/<id> to
+    // /shop/item/<id>. Both paths serve the same listing id — the API's own
+    // `uri` field still answers with the /sell/ form — so accept either and
+    // normalise to /sell/, keeping a listing shared under both spellings one
+    // item rather than two.
     source: "discogs",
-    pattern: /^https?:\/\/(?:www\.)?discogs\.com\/(?:(?:release|master)\/\d+|sell\/item\/\d+)/,
+    pattern:
+      /^https?:\/\/(?:www\.)?discogs\.com\/(?:(?:release|master)\/\d+|(?:sell|shop)\/item\/\d+)/,
+    normalizer: (match) =>
+      (match.input ?? match[0]).split("?")[0].replace("/shop/item/", "/sell/item/"),
   },
   {
     source: "tidal",

--- a/tests/unit/discogs.test.ts
+++ b/tests/unit/discogs.test.ts
@@ -248,6 +248,22 @@ describe("fetchDiscogsRelease", () => {
     });
   });
 
+  test("resolves shop/item URL via marketplace listing", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(makeDiscogsResponse({ release: { id: 5678 } }))
+      .mockResolvedValueOnce(makeDiscogsResponse(RELEASE_FIXTURE));
+
+    const result = await fetchDiscogsRelease("https://www.discogs.com/shop/item/4334240712", 5000);
+
+    const [listingUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(listingUrl).toBe("https://api.discogs.com/marketplace/listings/4334240712");
+
+    const [releaseUrl] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    expect(releaseUrl).toBe("https://api.discogs.com/releases/5678");
+
+    expect(result?.potentialTitle).toBe("Some EP");
+  });
+
   test("returns null when sell/item listing cannot be resolved", async () => {
     spyOn(globalThis, "fetch").mockResolvedValueOnce(
       makeDiscogsResponse({ message: "Not Found" }, 404),

--- a/tests/unit/parse-url.test.ts
+++ b/tests/unit/parse-url.test.ts
@@ -75,6 +75,38 @@ describe("parseUrl - soundcloud", () => {
   });
 });
 
+describe("parseUrl - discogs", () => {
+  test("identifies a marketplace listing on the legacy /sell/item path", () => {
+    const result = parseUrl("https://www.discogs.com/sell/item/4334240712");
+
+    expect(result.source).toBe("discogs");
+    expect(result.normalizedUrl).toBe("https://www.discogs.com/sell/item/4334240712");
+  });
+
+  test("identifies a marketplace listing on the current /shop/item path", () => {
+    const result = parseUrl("https://www.discogs.com/shop/item/4334240712");
+
+    expect(result.source).toBe("discogs");
+  });
+
+  test("normalises /shop/item to /sell/item so both spellings dedupe together", () => {
+    const shop = parseUrl("https://www.discogs.com/shop/item/4334240712?ev=item_sug");
+    const sell = parseUrl("https://www.discogs.com/sell/item/4334240712");
+
+    expect(shop.normalizedUrl).toBe(sell.normalizedUrl);
+    expect(shop.normalizedUrl).toBe("https://www.discogs.com/sell/item/4334240712");
+  });
+
+  test("leaves a release URL and its slug untouched", () => {
+    const result = parseUrl("https://www.discogs.com/release/123456-Neil-Young-On-The-Beach?ev=x");
+
+    expect(result.source).toBe("discogs");
+    expect(result.normalizedUrl).toBe(
+      "https://www.discogs.com/release/123456-Neil-Young-On-The-Beach",
+    );
+  });
+});
+
 describe("parseUrl - generic mobile subdomain handling", () => {
   test("strips m. from mixcloud links", () => {
     const result = parseUrl("https://m.mixcloud.com/somebody/some-show/");


### PR DESCRIPTION
## Summary
This PR adds support for Discogs' newer `/shop/item/` marketplace listing URL format while maintaining backward compatibility with the legacy `/sell/item/` format. Both URL patterns are normalized to `/sell/item/` to ensure listings shared under either spelling are deduplicated as a single item.

## Key Changes
- **URL Pattern Matching**: Updated the Discogs URL pattern in `server/utils.ts` to accept both `/sell/item/` and `/shop/item/` marketplace listing paths
- **URL Normalization**: Added a normalizer function that converts `/shop/item/` URLs to `/sell/item/` format, removing query parameters in the process
- **Listing ID Extraction**: Updated `extractDiscogsTypeAndId()` in `server/discogs.ts` to recognize both marketplace URL formats when extracting listing IDs
- **Test Coverage**: Added comprehensive test cases covering:
  - Legacy `/sell/item/` path recognition
  - Current `/shop/item/` path recognition
  - URL normalization ensuring both paths deduplicate to the same normalized URL
  - Release URL handling to ensure it remains unaffected

## Implementation Details
- The Discogs API's marketplace listing endpoint accepts the same listing ID regardless of which URL format was used
- Query parameters are stripped during normalization to further improve deduplication
- Release and master URLs are left untouched by the normalization logic
- Both URL formats are now treated as equivalent sources for the same marketplace listing

https://claude.ai/code/session_01KHauAnB4WiEsitd9SbKEP8